### PR TITLE
Fix clone path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ A collection of reusable Python functions covering a wide range of tasks. The pr
 
 ```bash
 # clone the repository
-git clone https://github.com/MForofontov/Python-functions
-cd Python-functions
+git clone https://github.com/MForofontov/python-utils
+cd python-utils
 
 # create and activate a virtual environment
 python -m venv venv


### PR DESCRIPTION
## Summary
- update clone instructions to use the correct repository path

## Testing
- `bash pytest.sh` *(fails: allure not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870ff79f8d48325846613ff3ca38587