### PR TITLE
Add cache_clear helper and update cache tests

### DIFF
--- a/decorators/cache.py
+++ b/decorators/cache.py
@@ -59,10 +59,9 @@ def cache(func: Callable[..., Any]) -> Callable[..., Any]:
         # Return the cached result
         return cached_results[key]
 
-    def cache_clear():
-        """
-        Clear the cache.
-        """
+    def cache_clear() -> None:
+        """Public method to clear the cached results for ``func``."""
+
         cached_results.clear()
 
     wrapper.cache_clear = cache_clear

--- a/pytest/unit/decorators/test_cache.py
+++ b/pytest/unit/decorators/test_cache.py
@@ -24,6 +24,7 @@ def test_cache_basic():
     call_counts["add"] = 0
     assert add(1, 2) == 3
     assert add(1, 2) == 3  # Should return cached result
+    add.cache_clear()
     assert call_counts["add"] == 1  # Function should be called only once
     call_counts["add"] = 0
 
@@ -36,7 +37,8 @@ def test_cache_different_args():
     call_counts["add"] = 0
     assert add(1, 2) == 3
     assert add(2, 3) == 5  # Different arguments, should not use cache
-    assert call_counts["add"] == 1  # Function should be called twice
+    add.cache_clear()
+    assert call_counts["add"] == 2  # Function should be called twice
     call_counts["add"] = 0
 
 
@@ -48,6 +50,7 @@ def test_cache_with_kwargs():
     call_counts["add"] = 0
     assert add(a=1, b=2) == 3
     assert add(a=1, b=2) == 3  # Should return cached result
+    add.cache_clear()
     assert call_counts["add"] == 1  # Function should be called only once
     call_counts["add"] = 0
 


### PR DESCRIPTION
## Summary
- expose cache_clear() in decorators.cache
- clear the `add` cache in unit tests before counting calls

## Testing
- `pytest pytest/unit/decorators/test_cache.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688ba65858288325a43ade775d22b96e