### PR TITLE
Handle chain with missing args

### DIFF
--- a/decorators/chain.py
+++ b/decorators/chain.py
@@ -1,6 +1,7 @@
 from typing import Any, TypeVar
 from collections.abc import Callable
 from functools import wraps
+from inspect import Parameter, signature
 
 T = TypeVar("T")
 
@@ -44,8 +45,22 @@ def chain(func: Callable[..., T]) -> Callable[..., T | Any]:
         """
         result = func(*args, **kwargs)
         if hasattr(result, "chain") and callable(getattr(result, "chain")):
+            chain_method = getattr(result, "chain")
             try:
-                return result.chain(*args, **kwargs)
+                if not args and not kwargs:
+                    sig = signature(chain_method)
+                    required = [
+                        p
+                        for name, p in sig.parameters.items()
+                        if name != "self"
+                        and p.default is Parameter.empty
+                        and p.kind
+                        in (Parameter.POSITIONAL_ONLY, Parameter.POSITIONAL_OR_KEYWORD)
+                    ]
+                    if not required:
+                        return chain_method()
+                else:
+                    return chain_method(*args, **kwargs)
             except Exception as e:
                 raise RuntimeError(
                     f"Error calling 'chain' method on result of {func.__name__}: {e}"

--- a/pytest/unit/decorators/test_chain.py
+++ b/pytest/unit/decorators/test_chain.py
@@ -105,7 +105,8 @@ def test_chain_method_with_args():
         return ChainableWithArgs(5)
 
     result = return_chainable_with_args()
-    assert result == 10  # Multiplier is passed as positional argument
+    assert isinstance(result, ChainableWithArgs)
+    assert result.value == 5  # chain is not called because required args are missing
 
 
 def test_chain_method_with_args_and_kwargs():
@@ -126,9 +127,8 @@ def test_chain_method_with_args_and_kwargs():
         return ChainableWithArgsAndKwargs(5)
 
     result = return_chainable_with_args_and_kwargs()
-    assert (
-        result == 10
-    )  # Multiplier is passed as positional argument, addend is default 0
+    assert isinstance(result, ChainableWithArgsAndKwargs)
+    assert result.value == 5  # chain is not called when required args are missing
 
 
 def test_chain_method_with_no_args():


### PR DESCRIPTION
## Summary
- add parameter inspection to `chain` decorator
- adjust wrapper logic to safely call `chain`
- update tests expecting `chain` to be skipped when required args are missing

## Testing
- `pytest pytest/unit/decorators/test_chain.py -q`
- `pytest -q` *(fails: test_AVLNode, test_cache_clear, test_cache_clear, test_deprecated_without_logger)*

------
https://chatgpt.com/codex/tasks/task_e_688ba6597648832598b8fd63a6cccc40