### PR TITLE
Add stop conditions to async_periodic loop

### DIFF
--- a/asyncio_functions/async_periodic.py
+++ b/asyncio_functions/async_periodic.py
@@ -1,12 +1,15 @@
-from collections.abc import Callable
-from collections.abc import Awaitable
+from collections.abc import Callable, Awaitable
 import asyncio
 
 
 # Define an asynchronous function to run another function periodically
-async def async_periodic(func: Callable[[], Awaitable[None]], interval: float) -> None:
-    """
-    Run an asynchronous function periodically with a fixed time interval.
+async def async_periodic(
+    func: Callable[[], Awaitable[None]],
+    interval: float,
+    stop_event: asyncio.Event | None = None,
+    stop_after: float | None = None,
+) -> None:
+    """Run an asynchronous function periodically with a fixed time interval.
 
     Parameters
     ----------
@@ -14,6 +17,10 @@ async def async_periodic(func: Callable[[], Awaitable[None]], interval: float) -
         The asynchronous function to run periodically.
     interval : float
         The time interval in seconds between executions.
+    stop_event : asyncio.Event, optional
+        Event used to signal that the periodic loop should stop.
+    stop_after : float, optional
+        Maximum time in seconds to run before stopping.
 
     Returns
     -------
@@ -22,15 +29,48 @@ async def async_periodic(func: Callable[[], Awaitable[None]], interval: float) -
     Examples
     --------
     >>> async def say_hello() -> None:
-    >>>     print("Hello!")
-    >>> asyncio.run(async_periodic(say_hello, interval=2))
-    (prints "Hello!" every 2 seconds)
+    ...     print("Hello!")
+    >>> asyncio.run(async_periodic(say_hello, interval=2, stop_after=5))
+    (prints "Hello!" every 2 seconds for roughly 5 seconds)
+
+    The periodic task can also be cancelled using an ``asyncio.Event``:
+
+    >>> async def main() -> None:
+    ...     stop = asyncio.Event()
+    ...     async def tick() -> None:
+    ...         print("tick")
+    ...     task = asyncio.create_task(async_periodic(tick, 1, stop_event=stop))
+    ...     await asyncio.sleep(3)
+    ...     stop.set()  # cancel the periodic loop
+    ...     await task
+    >>> asyncio.run(main())
+    tick
+    tick
+    tick
     """
-    # Infinite loop to run the function periodically
+    loop = asyncio.get_running_loop()
+    end_time = loop.time() + stop_after if stop_after is not None else None
+
     while True:
-        # Await the execution of the provided asynchronous function
         await func()
-        # Await for the specified interval before the next execution
-        await asyncio.sleep(interval)
+
+        if stop_event is not None and stop_event.is_set():
+            break
+
+        if end_time is not None and loop.time() >= end_time:
+            break
+
+        timeout = interval
+        if end_time is not None:
+            timeout = min(timeout, max(0, end_time - loop.time()))
+
+        if stop_event is not None:
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=timeout)
+                break
+            except asyncio.TimeoutError:
+                pass
+        else:
+            await asyncio.sleep(timeout)
 
 __all__ = ['async_periodic']


### PR DESCRIPTION
## Summary
- Allow async_periodic to stop via asyncio.Event or duration
- Document cancellation usage in async_periodic

## Testing
- `pytest -q asyncio_functions/async_periodic.py`

------
https://chatgpt.com/codex/tasks/task_e_68938e0776788325b7823ffe55313b5f