### PR TITLE
Add helper to export DataFrame to file

### DIFF
--- a/pandas_functions/__init__.py
+++ b/pandas_functions/__init__.py
@@ -1,7 +1,9 @@
 from .dict_to_df import dict_to_df
 from .import_df_from_file import import_df_from_file
+from .export_df_to_file import export_df_to_file
 
 __all__ = [
     "dict_to_df",
     "import_df_from_file",
+    "export_df_to_file",
 ]

--- a/pandas_functions/export_df_to_file.py
+++ b/pandas_functions/export_df_to_file.py
@@ -1,0 +1,42 @@
+from os import PathLike, fspath
+from typing import Any
+
+import pandas as pd
+
+
+def export_df_to_file(
+    df: pd.DataFrame,
+    file_path: str | PathLike[str],
+    sep: str = ",",
+    index: bool = False,
+    **kwargs: Any,
+) -> None:
+    """Export a pandas DataFrame to a delimited text file.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        The DataFrame to export.
+    file_path : str | PathLike[str]
+        Destination file path.
+    sep : str, optional
+        Field delimiter to use, by default ",".
+    index : bool, optional
+        Write row names (index), by default ``False``.
+    **kwargs : Any
+        Additional keyword arguments passed to :func:`pandas.DataFrame.to_csv`.
+
+    Raises
+    ------
+    OSError
+        If the file cannot be written.
+    """
+    try:
+        df.to_csv(file_path, sep=sep, index=index, **kwargs)
+    except OSError as exc:
+        raise OSError(
+            f"Could not write DataFrame to file: {fspath(file_path)}"
+        ) from exc
+
+
+__all__ = ["export_df_to_file"]

--- a/pytest/unit/pandas_functions/test_export_df_to_file.py
+++ b/pytest/unit/pandas_functions/test_export_df_to_file.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from pandas_functions.export_df_to_file import export_df_to_file
+
+
+def test_export_and_read_back(tmp_path: Path) -> None:
+    """Export a DataFrame and read it back to verify contents."""
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    file_path = tmp_path / "data.csv"
+    export_df_to_file(df, file_path)
+    result = pd.read_csv(file_path)
+    pd.testing.assert_frame_equal(df, result)
+
+
+def test_unwritable_destination(tmp_path: Path) -> None:
+    """Writing to an unwritable destination raises an error."""
+    df = pd.DataFrame({"a": [1]})
+    directory = tmp_path / "dir"
+    directory.mkdir()
+    with pytest.raises(OSError):
+        export_df_to_file(df, directory)


### PR DESCRIPTION
## Summary
- add `export_df_to_file` to save DataFrames with error handling
- expose `export_df_to_file` in `pandas_functions`
- test exporting DataFrames and handling unwritable destinations

## Testing
- `pytest pytest/unit/pandas_functions/test_export_df_to_file.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5f6abe5908325afbb6c4396623c24