### PR TITLE
Add numpy utilities for matrix multiplication and normalization

### DIFF
--- a/numpy_functions/__init__.py
+++ b/numpy_functions/__init__.py
@@ -1,4 +1,11 @@
 from .array_mean import array_mean
 from .dot_product import dot_product
+from .matrix_multiply import matrix_multiply
+from .normalize_array import normalize_array
 
-__all__ = ["array_mean", "dot_product"]
+__all__ = [
+    "array_mean",
+    "dot_product",
+    "matrix_multiply",
+    "normalize_array",
+]

--- a/numpy_functions/matrix_multiply.py
+++ b/numpy_functions/matrix_multiply.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+
+def matrix_multiply(mat1: np.ndarray, mat2: np.ndarray) -> np.ndarray:
+    """
+    Multiply two 2-D NumPy arrays using matrix multiplication.
+
+    Parameters
+    ----------
+    mat1 : np.ndarray
+        First matrix with shape (m, n).
+    mat2 : np.ndarray
+        Second matrix with shape (n, p).
+
+    Returns
+    -------
+    np.ndarray
+        The matrix product of ``mat1`` and ``mat2``.
+
+    Raises
+    ------
+    TypeError
+        If either input is not a NumPy ndarray.
+    ValueError
+        If inputs are not two-dimensional or shapes are incompatible.
+
+    Examples
+    --------
+    >>> matrix_multiply(np.array([[1, 2], [3, 4]]), np.array([[5], [6]]))
+    array([[17],
+           [39]])
+    """
+    if not isinstance(mat1, np.ndarray) or not isinstance(mat2, np.ndarray):
+        raise TypeError("Both inputs must be numpy.ndarray.")
+    if mat1.ndim != 2 or mat2.ndim != 2:
+        raise ValueError("Both arrays must be two-dimensional.")
+    if mat1.shape[1] != mat2.shape[0]:
+        raise ValueError("Shapes are not aligned for matrix multiplication.")
+    return np.matmul(mat1, mat2)
+
+
+__all__ = ["matrix_multiply"]

--- a/numpy_functions/normalize_array.py
+++ b/numpy_functions/normalize_array.py
@@ -1,0 +1,38 @@
+import numpy as np
+
+
+def normalize_array(arr: np.ndarray) -> np.ndarray:
+    """
+    Normalize a NumPy array so that its Euclidean norm is 1.
+
+    Parameters
+    ----------
+    arr : np.ndarray
+        Input array to normalize.
+
+    Returns
+    -------
+    np.ndarray
+        The normalized array with unit Euclidean norm.
+
+    Raises
+    ------
+    TypeError
+        If ``arr`` is not a NumPy ndarray.
+    ValueError
+        If the norm of ``arr`` is zero.
+
+    Examples
+    --------
+    >>> normalize_array(np.array([3, 4]))
+    array([0.6, 0.8])
+    """
+    if not isinstance(arr, np.ndarray):
+        raise TypeError("arr must be a numpy.ndarray.")
+    norm = np.linalg.norm(arr)
+    if norm == 0:
+        raise ValueError("Cannot normalize an array with zero norm.")
+    return arr / norm
+
+
+__all__ = ["normalize_array"]

--- a/pytest/unit/numpy_functions/test_matrix_multiply.py
+++ b/pytest/unit/numpy_functions/test_matrix_multiply.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+from numpy_functions.matrix_multiply import matrix_multiply
+
+
+def test_matrix_multiply_basic() -> None:
+    """
+    Test matrix_multiply with compatible 2-D arrays.
+    """
+    result = matrix_multiply(np.array([[1, 2], [3, 4]]), np.array([[5], [6]]))
+    expected = np.array([[17], [39]])
+    assert np.array_equal(result, expected), "Failed on basic matrix multiplication"
+
+
+def test_matrix_multiply_mismatched_shapes() -> None:
+    """
+    Test matrix_multiply with arrays that have incompatible shapes.
+    """
+    with pytest.raises(ValueError):
+        matrix_multiply(np.array([[1, 2], [3, 4]]), np.array([[1, 2, 3]]))
+
+
+def test_matrix_multiply_invalid_type() -> None:
+    """
+    Test matrix_multiply with invalid input types.
+    """
+    with pytest.raises(TypeError):
+        matrix_multiply([[1, 2]], np.array([[1], [2]]))

--- a/pytest/unit/numpy_functions/test_normalize_array.py
+++ b/pytest/unit/numpy_functions/test_normalize_array.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+from numpy_functions.normalize_array import normalize_array
+
+
+def test_normalize_array_basic() -> None:
+    """
+    Test normalize_array with a basic 1-D array.
+    """
+    result = normalize_array(np.array([3.0, 4.0]))
+    expected = np.array([0.6, 0.8])
+    assert np.allclose(result, expected), "Failed to normalize array correctly"
+
+
+def test_normalize_array_zero_norm() -> None:
+    """
+    Test normalize_array with an array of zeros which has zero norm.
+    """
+    with pytest.raises(ValueError):
+        normalize_array(np.array([0.0, 0.0]))
+
+
+def test_normalize_array_invalid_type() -> None:
+    """
+    Test normalize_array with an invalid input type.
+    """
+    with pytest.raises(TypeError):
+        normalize_array([1, 2, 3])


### PR DESCRIPTION
## Summary
- add `matrix_multiply` for validating and multiplying two 2‑D arrays
- add `normalize_array` to scale an array to unit Euclidean norm
- include comprehensive unit tests for the new utilities

## Testing
- `pytest pytest/unit/numpy_functions/test_matrix_multiply.py pytest/unit/numpy_functions/test_normalize_array.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a74c2532bc8325abe498a6bf965ca0