### PR TITLE
Add array product function with tests

### DIFF
--- a/numpy_functions/__init__.py
+++ b/numpy_functions/__init__.py
@@ -5,6 +5,7 @@ from .array_median import array_median
 from .array_max import array_max
 from .array_min import array_min
 from .array_sum import array_sum
+from .array_prod import array_prod
 from .dot_product import dot_product
 from .elementwise_sum import elementwise_sum
 from .elementwise_product import elementwise_product
@@ -22,6 +23,7 @@ __all__ = [
     "array_max",
     "array_min",
     "array_sum",
+    "array_prod",
     "dot_product",
     "elementwise_sum",
     "elementwise_product",

--- a/numpy_functions/array_prod.py
+++ b/numpy_functions/array_prod.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+
+def array_prod(arr: np.ndarray) -> float:
+    """
+    Compute the product of all elements in a NumPy array.
+
+    Parameters
+    ----------
+    arr : np.ndarray
+        Array containing numerical values.
+
+    Returns
+    -------
+    float
+        The product of all elements in the array.
+
+    Raises
+    ------
+    TypeError
+        If `arr` is not a NumPy ndarray.
+
+    Examples
+    --------
+    >>> array_prod(np.array([1, 2, 3]))
+    6.0
+    """
+    if not isinstance(arr, np.ndarray):
+        raise TypeError("arr must be a numpy.ndarray.")
+    return float(np.prod(arr))
+
+
+__all__ = ["array_prod"]

--- a/pytest/unit/numpy_functions/test_array_prod.py
+++ b/pytest/unit/numpy_functions/test_array_prod.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+from numpy_functions.array_prod import array_prod
+
+
+
+def test_array_prod_basic() -> None:
+    """
+    Test the array_prod function with positive integers.
+    """
+    assert array_prod(np.array([1, 2, 3])) == 6.0, "Failed on positive integers"
+
+
+
+def test_array_prod_negative() -> None:
+    """
+    Test the array_prod function with negative numbers.
+    """
+    assert array_prod(np.array([-1, -2, -3])) == -6.0, "Failed on negative numbers"
+
+
+
+def test_array_prod_invalid_type() -> None:
+    """
+    Test the array_prod function with an invalid input type.
+    """
+    with pytest.raises(TypeError):
+        array_prod([1, 2, 3])


### PR DESCRIPTION
## Summary
- add `array_prod` utility to compute product of array elements
- expose `array_prod` in numpy_functions package
- test product calculations and type validation

## Testing
- `pytest pytest/unit/numpy_functions/test_array_prod.py`


------
https://chatgpt.com/codex/tasks/task_e_68a88f823dec832591916415104a3ce0