### PR TITLE
Add comprehensive tests for dictionary and file import utilities

### DIFF
--- a/pytest/unit/pandas_functions/test_dict_to_df.py
+++ b/pytest/unit/pandas_functions/test_dict_to_df.py
@@ -1,0 +1,35 @@
+import pandas as pd
+import pytest
+
+from pandas_functions.dict_to_df import dict_to_df
+
+
+def test_dict_to_df_basic() -> None:
+    """Convert a dictionary with list values to a DataFrame."""
+    # Test case 1: Dictionary with list values
+    data: dict[str, list[int]] = {"A": [1, 2], "B": [3, 4]}
+    expected: pd.DataFrame = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
+    result: pd.DataFrame = dict_to_df(data)
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_dict_to_df_nested() -> None:
+    """Convert a nested dictionary to a DataFrame."""
+    # Test case 2: Nested dictionary input
+    data: dict[str, dict[str, int]] = {
+        "col1": {"row1": 1, "row2": 2},
+        "col2": {"row1": 3},
+    }
+    expected: pd.DataFrame = pd.DataFrame({
+        "col1": {"row1": 1, "row2": 2},
+        "col2": {"row1": 3},
+    })
+    result: pd.DataFrame = dict_to_df(data)
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_dict_to_df_invalid_input() -> None:
+    """Passing a non-dictionary should raise ``ValueError``."""
+    # Test case 3: Invalid dictionary input
+    with pytest.raises(ValueError):
+        dict_to_df("not a dict")  # type: ignore[arg-type]

--- a/pytest/unit/pandas_functions/test_import_df_from_file.py
+++ b/pytest/unit/pandas_functions/test_import_df_from_file.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from pandas_functions.import_df_from_file import import_df_from_file
+
+
+def test_import_df_from_file_basic(tmp_path: Path) -> None:
+    """Import a CSV file into a DataFrame."""
+    # Test case 1: Basic CSV import
+    df: pd.DataFrame = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    file_path: Path = tmp_path / "data.csv"
+    df.to_csv(file_path, index=False)
+    result: pd.DataFrame = import_df_from_file(file_path)
+    pd.testing.assert_frame_equal(result, df)
+
+
+def test_import_df_from_file_custom_sep(tmp_path: Path) -> None:
+    """Import a file using a custom separator."""
+    # Test case 2: Custom separator
+    df: pd.DataFrame = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    file_path: Path = tmp_path / "data.tsv"
+    df.to_csv(file_path, index=False, sep="\t")
+    result: pd.DataFrame = import_df_from_file(file_path, sep="\t")
+    pd.testing.assert_frame_equal(result, df)
+
+
+def test_import_df_from_file_errors(tmp_path: Path) -> None:
+    """Missing file or invalid content should raise appropriate errors."""
+    # Test case 3: Missing file
+    missing_file: Path = tmp_path / "missing.csv"
+    with pytest.raises(FileNotFoundError):
+        import_df_from_file(missing_file)
+
+    # Test case 4: Invalid content
+    invalid_file: Path = tmp_path / "invalid.csv"
+    invalid_file.write_text("")
+    with pytest.raises(ValueError):
+        import_df_from_file(invalid_file)


### PR DESCRIPTION
## Summary
- add tests for `dict_to_df` covering nested dictionaries and invalid input
- test `import_df_from_file` for basic loading, custom separators, and error conditions

## Testing
- `pytest pytest/unit/pandas_functions/test_dict_to_df.py pytest/unit/pandas_functions/test_import_df_from_file.py`

------
https://chatgpt.com/codex/tasks/task_e_68a88efa9d5483258cf1d5b0e30268cd