### PR TITLE
Add array clipping and square root utilities with tests

### DIFF
--- a/numpy_functions/__init__.py
+++ b/numpy_functions/__init__.py
@@ -10,6 +10,8 @@ from .array_cumsum import array_cumsum
 from .array_diff import array_diff
 from .array_sort import array_sort
 from .array_unique import array_unique
+from .array_clip import array_clip
+from .array_sqrt import array_sqrt
 from .dot_product import dot_product
 from .elementwise_sum import elementwise_sum
 from .elementwise_product import elementwise_product
@@ -32,6 +34,8 @@ __all__ = [
     "array_diff",
     "array_sort",
     "array_unique",
+    "array_clip",
+    "array_sqrt",
     "dot_product",
     "elementwise_sum",
     "elementwise_product",

--- a/numpy_functions/array_clip.py
+++ b/numpy_functions/array_clip.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+
+def array_clip(arr: np.ndarray, a_min: float, a_max: float) -> np.ndarray:
+    """
+    Clip the values in a NumPy array to a specified range.
+
+    Parameters
+    ----------
+    arr : np.ndarray
+        Array containing numerical values to be clipped.
+    a_min : float
+        Minimum allowed value.
+    a_max : float
+        Maximum allowed value.
+
+    Returns
+    -------
+    np.ndarray
+        Array with values clipped between ``a_min`` and ``a_max``.
+
+    Raises
+    ------
+    TypeError
+        If ``arr`` is not a NumPy ndarray.
+    ValueError
+        If ``a_min`` is greater than ``a_max``.
+
+    Examples
+    --------
+    >>> array_clip(np.array([-1, 0, 5]), 0, 4)
+    array([0, 0, 4])
+    """
+    if not isinstance(arr, np.ndarray):
+        raise TypeError("arr must be a numpy.ndarray.")
+    if a_min > a_max:
+        raise ValueError("a_min must be less than or equal to a_max.")
+    return np.clip(arr, a_min, a_max)
+
+
+__all__ = ["array_clip"]
+

--- a/numpy_functions/array_sqrt.py
+++ b/numpy_functions/array_sqrt.py
@@ -1,0 +1,38 @@
+import numpy as np
+
+
+def array_sqrt(arr: np.ndarray) -> np.ndarray:
+    """
+    Compute the element-wise square root of a NumPy array.
+
+    Parameters
+    ----------
+    arr : np.ndarray
+        Array containing non-negative numbers.
+
+    Returns
+    -------
+    np.ndarray
+        Array containing the square roots of the elements in ``arr``.
+
+    Raises
+    ------
+    TypeError
+        If ``arr`` is not a NumPy ndarray.
+    ValueError
+        If ``arr`` contains negative values.
+
+    Examples
+    --------
+    >>> array_sqrt(np.array([0, 1, 4]))
+    array([0., 1., 2.])
+    """
+    if not isinstance(arr, np.ndarray):
+        raise TypeError("arr must be a numpy.ndarray.")
+    if np.any(arr < 0):
+        raise ValueError("arr must not contain negative values.")
+    return np.sqrt(arr)
+
+
+__all__ = ["array_sqrt"]
+

--- a/pytest/unit/numpy_functions/test_array_clip.py
+++ b/pytest/unit/numpy_functions/test_array_clip.py
@@ -1,0 +1,29 @@
+import numpy as np
+import pytest
+from numpy_functions.array_clip import array_clip
+
+
+def test_array_clip_basic() -> None:
+    """
+    Test array_clip with values outside the specified range.
+    """
+    result = array_clip(np.array([-1, 2, 5]), 0, 4)
+    expected = np.array([0, 2, 4])
+    assert np.array_equal(result, expected), "Failed to clip array values"
+
+
+def test_array_clip_invalid_type() -> None:
+    """
+    Test array_clip with an invalid input type.
+    """
+    with pytest.raises(TypeError):
+        array_clip([-1, 2, 5], 0, 4)  # type: ignore[arg-type]
+
+
+def test_array_clip_invalid_range() -> None:
+    """
+    Test array_clip when a_min is greater than a_max.
+    """
+    with pytest.raises(ValueError):
+        array_clip(np.array([1, 2, 3]), 5, 1)
+

--- a/pytest/unit/numpy_functions/test_array_sqrt.py
+++ b/pytest/unit/numpy_functions/test_array_sqrt.py
@@ -1,0 +1,29 @@
+import numpy as np
+import pytest
+from numpy_functions.array_sqrt import array_sqrt
+
+
+def test_array_sqrt_basic() -> None:
+    """
+    Test array_sqrt with non-negative numbers.
+    """
+    result = array_sqrt(np.array([0, 1, 4]))
+    expected = np.array([0.0, 1.0, 2.0])
+    assert np.array_equal(result, expected), "Failed on basic square root"
+
+
+def test_array_sqrt_negative_values() -> None:
+    """
+    Test array_sqrt when the array contains negative values.
+    """
+    with pytest.raises(ValueError):
+        array_sqrt(np.array([-1, 0]))
+
+
+def test_array_sqrt_invalid_type() -> None:
+    """
+    Test array_sqrt with an invalid input type.
+    """
+    with pytest.raises(TypeError):
+        array_sqrt([0, 1, 4])  # type: ignore[arg-type]
+


### PR DESCRIPTION
## Summary
- add `array_clip` to limit array values within a range
- add `array_sqrt` to compute element-wise square roots
- expose new utilities in numpy_functions package and provide tests

## Testing
- `python -m pytest pytest/unit/numpy_functions/test_array_clip.py pytest/unit/numpy_functions/test_array_sqrt.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa0c9977688325ad85d154a7d62b27