### PR TITLE
Add NumPy exponential and logarithm utilities

### DIFF
--- a/numpy_functions/__init__.py
+++ b/numpy_functions/__init__.py
@@ -13,6 +13,8 @@ from .array_unique import array_unique
 from .array_clip import array_clip
 from .array_abs import array_abs
 from .array_sqrt import array_sqrt
+from .array_exp import array_exp
+from .array_log import array_log
 from .dot_product import dot_product
 from .elementwise_sum import elementwise_sum
 from .elementwise_product import elementwise_product
@@ -39,6 +41,8 @@ __all__ = [
     "array_clip",
     "array_abs",
     "array_sqrt",
+    "array_exp",
+    "array_log",
     "dot_product",
     "elementwise_sum",
     "elementwise_product",

--- a/numpy_functions/array_exp.py
+++ b/numpy_functions/array_exp.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+
+def array_exp(arr: np.ndarray) -> np.ndarray:
+    """
+    Compute the element-wise exponential of a NumPy array.
+
+    Parameters
+    ----------
+    arr : np.ndarray
+        Array containing numerical values.
+
+    Returns
+    -------
+    np.ndarray
+        Array containing the exponentials of the elements in ``arr``.
+
+    Raises
+    ------
+    TypeError
+        If ``arr`` is not a NumPy ndarray.
+
+    Examples
+    --------
+    >>> array_exp(np.array([0, 1]))
+    array([1.        , 2.71828183])
+    """
+    if not isinstance(arr, np.ndarray):
+        raise TypeError("arr must be a numpy.ndarray.")
+    return np.exp(arr)
+
+
+__all__ = ["array_exp"]

--- a/numpy_functions/array_log.py
+++ b/numpy_functions/array_log.py
@@ -1,0 +1,37 @@
+import numpy as np
+
+
+def array_log(arr: np.ndarray) -> np.ndarray:
+    """
+    Compute the element-wise natural logarithm of a NumPy array.
+
+    Parameters
+    ----------
+    arr : np.ndarray
+        Array containing positive numbers.
+
+    Returns
+    -------
+    np.ndarray
+        Array containing the natural logarithm of the elements in ``arr``.
+
+    Raises
+    ------
+    TypeError
+        If ``arr`` is not a NumPy ndarray.
+    ValueError
+        If ``arr`` contains non-positive values.
+
+    Examples
+    --------
+    >>> array_log(np.array([1, np.e]))
+    array([0., 1.])
+    """
+    if not isinstance(arr, np.ndarray):
+        raise TypeError("arr must be a numpy.ndarray.")
+    if np.any(arr <= 0):
+        raise ValueError("arr must contain only positive values.")
+    return np.log(arr)
+
+
+__all__ = ["array_log"]

--- a/pytest/unit/numpy_functions/test_array_exp.py
+++ b/pytest/unit/numpy_functions/test_array_exp.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pytest
+from numpy_functions.array_exp import array_exp
+
+
+def test_array_exp_basic() -> None:
+    """
+    Test the array_exp function with simple values.
+    """
+    result = array_exp(np.array([0, 1]))
+    expected = np.array([1.0, np.e])
+    assert np.allclose(result, expected), "Failed on basic exponential"
+
+
+def test_array_exp_invalid_type() -> None:
+    """
+    Test the array_exp function with an invalid input type.
+    """
+    with pytest.raises(TypeError):
+        array_exp([0, 1])  # type: ignore[arg-type]

--- a/pytest/unit/numpy_functions/test_array_log.py
+++ b/pytest/unit/numpy_functions/test_array_log.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+from numpy_functions.array_log import array_log
+
+
+def test_array_log_basic() -> None:
+    """
+    Test the array_log function with positive numbers.
+    """
+    result = array_log(np.array([1.0, np.e]))
+    expected = np.array([0.0, 1.0])
+    assert np.allclose(result, expected), "Failed on basic logarithm"
+
+
+def test_array_log_non_positive() -> None:
+    """
+    Test the array_log function when the array contains non-positive values.
+    """
+    with pytest.raises(ValueError):
+        array_log(np.array([0.0, -1.0]))
+
+
+def test_array_log_invalid_type() -> None:
+    """
+    Test the array_log function with an invalid input type.
+    """
+    with pytest.raises(TypeError):
+        array_log([1.0, np.e])  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- add `array_exp` for element-wise exponentials
- add `array_log` for element-wise natural logarithms with input validation
- expose new utilities and tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa103046cc83259c6fcfcac247bd1b