### PR TITLE
Add missing type annotations

### DIFF
--- a/asyncio_functions/async_connection_pool.py
+++ b/asyncio_functions/async_connection_pool.py
@@ -19,7 +19,7 @@ class AsyncConnectionPool:
         The internal queue to manage connections.
     """
 
-    def __init__(self, max_connections: int):
+    def __init__(self, max_connections: int) -> None:
         """
         Initialize the connection pool with a maximum number of connections.
 

--- a/data_types/linked_list.py
+++ b/data_types/linked_list.py
@@ -1,4 +1,5 @@
 from typing import Generic, TypeVar
+from collections.abc import Iterator
 
 # Define a generic type variable
 T = TypeVar("T")
@@ -152,7 +153,7 @@ class LinkedList(Generic[T]):
             current = current.next
         return count
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Node[T]]:
         current = self.head
         while current:
             yield current

--- a/decorators/cache_with_expiration.py
+++ b/decorators/cache_with_expiration.py
@@ -87,7 +87,7 @@ def cache_with_expiration(
 
             return result
 
-        def cache_clear():
+        def cache_clear() -> None:
             """
             Clear the cache.
             """

--- a/decorators/event_trigger.py
+++ b/decorators/event_trigger.py
@@ -25,7 +25,7 @@ class EventManager:
         using the provided arguments.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """
         Initializes the EventManager with an empty events dictionary.
         """

--- a/decorators/time_and_resource_function.py
+++ b/decorators/time_and_resource_function.py
@@ -244,7 +244,7 @@ def time_and_resource_function(
             )
 
             # Print or log results
-            def log_or_print(message: str):
+            def log_or_print(message: str) -> None:
                 if logger:
                     logger.debug(message)
                 else:

--- a/print_functions/print_message.py
+++ b/print_functions/print_message.py
@@ -1,5 +1,5 @@
-import logging
 from datetime import datetime
+import logging
 from logger_functions.logger import get_logger
 
 # Module level logger used when no logger is provided by the caller

--- a/print_functions/print_system_info_in_terminal.py
+++ b/print_functions/print_system_info_in_terminal.py
@@ -32,7 +32,7 @@ def print_system_info_in_terminal() -> None:
     None
     """
 
-    def get_processor_name():
+    def get_processor_name() -> str:
         """
         Get the processor name.
 


### PR DESCRIPTION
## Summary
- annotate missing __init__ return types and helper functions across modules
- type LinkedList iteration and cache clear helpers
- improve logging support and processor info helper signatures

## Testing
- `python -m py_compile asyncio_functions/async_connection_pool.py data_types/linked_list.py decorators/cache_with_expiration.py decorators/event_trigger.py decorators/time_and_resource_function.py print_functions/print_message.py print_functions/print_system_info_in_terminal.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa1015b3488325bc347985d5bcc692