### PR TITLE
Add numpy floor and elementwise min utilities

### DIFF
--- a/numpy_functions/__init__.py
+++ b/numpy_functions/__init__.py
@@ -17,12 +17,14 @@ from .array_abs import array_abs
 from .array_sqrt import array_sqrt
 from .array_exp import array_exp
 from .array_log import array_log
+from .array_floor import array_floor
 from .dot_product import dot_product
 from .elementwise_sum import elementwise_sum
 from .elementwise_product import elementwise_product
 from .elementwise_divide import elementwise_divide
 from .elementwise_subtract import elementwise_subtract
 from .elementwise_power import elementwise_power
+from .elementwise_min import elementwise_min
 from .elementwise_max import elementwise_max
 from .matrix_multiply import matrix_multiply
 from .normalize_array import normalize_array
@@ -47,12 +49,14 @@ __all__ = [
     "array_sqrt",
     "array_exp",
     "array_log",
+    "array_floor",
     "dot_product",
     "elementwise_sum",
     "elementwise_product",
     "elementwise_divide",
     "elementwise_subtract",
     "elementwise_power",
+    "elementwise_min",
     "elementwise_max",
     "matrix_multiply",
     "normalize_array",

--- a/numpy_functions/array_floor.py
+++ b/numpy_functions/array_floor.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+
+def array_floor(arr: np.ndarray) -> np.ndarray:
+    """
+    Compute the floor of each element in a NumPy array.
+
+    Parameters
+    ----------
+    arr : np.ndarray
+        Array containing numerical values.
+
+    Returns
+    -------
+    np.ndarray
+        Array containing the floor of each element in ``arr``.
+
+    Raises
+    ------
+    TypeError
+        If ``arr`` is not a NumPy ndarray.
+
+    Examples
+    --------
+    >>> array_floor(np.array([1.5, -2.3]))
+    array([ 1., -3.])
+    """
+    if not isinstance(arr, np.ndarray):
+        raise TypeError("arr must be a numpy.ndarray.")
+    return np.floor(arr)
+
+
+__all__ = ["array_floor"]

--- a/numpy_functions/elementwise_min.py
+++ b/numpy_functions/elementwise_min.py
@@ -1,0 +1,39 @@
+import numpy as np
+
+
+def elementwise_min(arr1: np.ndarray, arr2: np.ndarray) -> np.ndarray:
+    """
+    Compute the element-wise minimum of two NumPy arrays.
+
+    Parameters
+    ----------
+    arr1 : np.ndarray
+        The first input array.
+    arr2 : np.ndarray
+        The second input array.
+
+    Returns
+    -------
+    np.ndarray
+        Array containing the element-wise minimum of ``arr1`` and ``arr2``.
+
+    Raises
+    ------
+    TypeError
+        If either input is not a NumPy ndarray.
+    ValueError
+        If the arrays do not have the same shape.
+
+    Examples
+    --------
+    >>> elementwise_min(np.array([1, 3]), np.array([2, 2]))
+    array([1, 2])
+    """
+    if not isinstance(arr1, np.ndarray) or not isinstance(arr2, np.ndarray):
+        raise TypeError("Both inputs must be numpy.ndarray.")
+    if arr1.shape != arr2.shape:
+        raise ValueError("Arrays must have the same shape.")
+    return np.minimum(arr1, arr2)
+
+
+__all__ = ["elementwise_min"]

--- a/pytest/unit/numpy_functions/test_array_floor.py
+++ b/pytest/unit/numpy_functions/test_array_floor.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pytest
+from numpy_functions.array_floor import array_floor
+
+
+def test_array_floor_basic() -> None:
+    """
+    Test array_floor with positive and negative decimal numbers.
+    """
+    result = array_floor(np.array([1.7, -2.3, 0.0]))
+    expected = np.array([1.0, -3.0, 0.0])
+    assert np.array_equal(result, expected), "Failed on basic floor operation"
+
+
+def test_array_floor_invalid_type() -> None:
+    """
+    Test array_floor with an invalid input type.
+    """
+    with pytest.raises(TypeError):
+        array_floor([1.7, -2.3])  # type: ignore[arg-type]

--- a/pytest/unit/numpy_functions/test_elementwise_min.py
+++ b/pytest/unit/numpy_functions/test_elementwise_min.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+from numpy_functions.elementwise_min import elementwise_min
+
+
+def test_elementwise_min_basic() -> None:
+    """
+    Test elementwise_min with arrays of the same shape.
+    """
+    result = elementwise_min(np.array([1, 3]), np.array([2, 2]))
+    expected = np.array([1, 2])
+    assert np.array_equal(result, expected), "Failed on basic element-wise minimum"
+
+
+def test_elementwise_min_mismatched_shapes() -> None:
+    """
+    Test elementwise_min with arrays of different shapes.
+    """
+    with pytest.raises(ValueError):
+        elementwise_min(np.array([1, 2]), np.array([1, 2, 3]))
+
+
+def test_elementwise_min_invalid_type() -> None:
+    """
+    Test elementwise_min with invalid input types.
+    """
+    with pytest.raises(TypeError):
+        elementwise_min([1, 2], np.array([1, 2]))


### PR DESCRIPTION
## Summary
- add `array_floor` to compute the floor of every element
- add `elementwise_min` for element-wise minimum between arrays
- cover new utilities with unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa14bba8808325b879868ffa86e383