### PR TITLE
Add percentile and modulus NumPy utilities with tests

### DIFF
--- a/numpy_functions/__init__.py
+++ b/numpy_functions/__init__.py
@@ -18,10 +18,12 @@ from .array_sqrt import array_sqrt
 from .array_exp import array_exp
 from .array_log import array_log
 from .array_floor import array_floor
+from .array_percentile import array_percentile
 from .dot_product import dot_product
 from .elementwise_sum import elementwise_sum
 from .elementwise_product import elementwise_product
 from .elementwise_divide import elementwise_divide
+from .elementwise_mod import elementwise_mod
 from .elementwise_subtract import elementwise_subtract
 from .elementwise_power import elementwise_power
 from .elementwise_min import elementwise_min
@@ -50,10 +52,12 @@ __all__ = [
     "array_exp",
     "array_log",
     "array_floor",
+    "array_percentile",
     "dot_product",
     "elementwise_sum",
     "elementwise_product",
     "elementwise_divide",
+    "elementwise_mod",
     "elementwise_subtract",
     "elementwise_power",
     "elementwise_min",

--- a/numpy_functions/array_percentile.py
+++ b/numpy_functions/array_percentile.py
@@ -1,0 +1,41 @@
+import numpy as np
+
+
+def array_percentile(arr: np.ndarray, q: float) -> float:
+    """
+    Compute the ``q``th percentile of elements in a NumPy array.
+
+    Parameters
+    ----------
+    arr : np.ndarray
+        Array containing numerical values.
+    q : float
+        Percentile to compute, between 0 and 100 inclusive.
+
+    Returns
+    -------
+    float
+        The ``q``th percentile of the array.
+
+    Raises
+    ------
+    TypeError
+        If ``arr`` is not a NumPy ndarray or ``q`` is not a numeric type.
+    ValueError
+        If ``q`` is outside the range [0, 100].
+
+    Examples
+    --------
+    >>> array_percentile(np.array([1, 2, 3, 4]), 50)
+    2.5
+    """
+    if not isinstance(arr, np.ndarray):
+        raise TypeError("arr must be a numpy.ndarray.")
+    if not isinstance(q, (int, float)):
+        raise TypeError("q must be a float or int.")
+    if q < 0 or q > 100:
+        raise ValueError("q must be between 0 and 100.")
+    return float(np.percentile(arr, q))
+
+
+__all__ = ["array_percentile"]

--- a/numpy_functions/elementwise_mod.py
+++ b/numpy_functions/elementwise_mod.py
@@ -1,0 +1,39 @@
+import numpy as np
+
+
+def elementwise_mod(arr1: np.ndarray, arr2: np.ndarray) -> np.ndarray:
+    """
+    Compute the element-wise modulus of two NumPy arrays.
+
+    Parameters
+    ----------
+    arr1 : np.ndarray
+        The dividend array.
+    arr2 : np.ndarray
+        The divisor array.
+
+    Returns
+    -------
+    np.ndarray
+        Array containing the element-wise modulus of ``arr1`` and ``arr2``.
+
+    Raises
+    ------
+    TypeError
+        If either input is not a NumPy ndarray.
+    ValueError
+        If the arrays do not have the same shape.
+
+    Examples
+    --------
+    >>> elementwise_mod(np.array([5, 7]), np.array([2, 3]))
+    array([1, 1])
+    """
+    if not isinstance(arr1, np.ndarray) or not isinstance(arr2, np.ndarray):
+        raise TypeError("Both inputs must be numpy.ndarray.")
+    if arr1.shape != arr2.shape:
+        raise ValueError("Arrays must have the same shape.")
+    return np.mod(arr1, arr2)
+
+
+__all__ = ["elementwise_mod"]

--- a/pytest/unit/numpy_functions/test_array_percentile.py
+++ b/pytest/unit/numpy_functions/test_array_percentile.py
@@ -1,0 +1,33 @@
+import numpy as np
+import pytest
+from numpy_functions.array_percentile import array_percentile
+
+
+
+def test_array_percentile_basic() -> None:
+    """
+    Test array_percentile with a simple array.
+    """
+    assert (
+        array_percentile(np.array([1, 2, 3, 4]), 50) == 2.5
+    ), "Failed on basic percentile"
+
+
+
+def test_array_percentile_invalid_q_value() -> None:
+    """
+    Test array_percentile with an invalid percentile value.
+    """
+    with pytest.raises(ValueError):
+        array_percentile(np.array([1, 2, 3]), 150)
+
+
+
+def test_array_percentile_invalid_type() -> None:
+    """
+    Test array_percentile with invalid input types.
+    """
+    with pytest.raises(TypeError):
+        array_percentile([1, 2, 3], 50)
+    with pytest.raises(TypeError):
+        array_percentile(np.array([1, 2, 3]), "50")

--- a/pytest/unit/numpy_functions/test_elementwise_mod.py
+++ b/pytest/unit/numpy_functions/test_elementwise_mod.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pytest
+from numpy_functions.elementwise_mod import elementwise_mod
+
+
+
+def test_elementwise_mod_basic() -> None:
+    """
+    Test elementwise_mod with arrays of the same shape.
+    """
+    result = elementwise_mod(np.array([5, 7]), np.array([2, 3]))
+    expected = np.array([1, 1])
+    assert np.array_equal(result, expected), "Failed on basic element-wise modulus"
+
+
+
+def test_elementwise_mod_mismatched_shapes() -> None:
+    """
+    Test elementwise_mod with arrays of different shapes.
+    """
+    with pytest.raises(ValueError):
+        elementwise_mod(np.array([1, 2]), np.array([1, 2, 3]))
+
+
+
+def test_elementwise_mod_invalid_type() -> None:
+    """
+    Test elementwise_mod with invalid input types.
+    """
+    with pytest.raises(TypeError):
+        elementwise_mod([1, 2], np.array([1, 2]))


### PR DESCRIPTION
## Summary
- add `array_percentile` to compute q-th percentile of arrays
- add `elementwise_mod` for element-wise modulus operations
- cover new functions with unit tests and expose them in package

## Testing
- `pytest pytest/unit/numpy_functions/test_array_percentile.py pytest/unit/numpy_functions/test_elementwise_mod.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa17ecf3cc8325bc16b70dc5b0927b