### PR TITLE
Refine logger handling in decorators

### DIFF
--- a/decorators/log_function_calls.py
+++ b/decorators/log_function_calls.py
@@ -6,15 +6,15 @@ from logger_functions.logger import validate_logger
 
 
 def log_function_calls(
-    logger: logging.Logger,
+    logger: logging.Logger | None,
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """
     A decorator to log function calls, including arguments passed and the result returned.
 
     Parameters
     ----------
-    logger : logging.Logger
-        The logger instance to use for logging.
+    logger : logging.Logger | None
+        The logger instance to use for logging. Must not be None.
 
     Returns
     -------
@@ -24,9 +24,10 @@ def log_function_calls(
     Raises
     ------
     TypeError
-        If the logger is not an instance of logging.Logger.
+        If the logger is not an instance of logging.Logger or is None.
     """
     validate_logger(logger, allow_none=False)
+    assert logger is not None
 
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         @wraps(func)

--- a/decorators/redirect_output.py
+++ b/decorators/redirect_output.py
@@ -7,7 +7,7 @@ from logger_functions.logger import validate_logger
 
 
 def redirect_output(
-    file_path: str, logger: logging.Logger = None
+    file_path: str, logger: logging.Logger | None = None
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """
     A decorator to redirect the standard output of a function to a specified file.
@@ -16,7 +16,7 @@ def redirect_output(
     ----------
     file_path : str
         The path to the file where the output should be redirected.
-    logger : logging.Logger, optional
+    logger : Optional[logging.Logger], optional
         The logger to use for logging errors (default is None).
 
     Returns

--- a/decorators/requires_permission.py
+++ b/decorators/requires_permission.py
@@ -7,7 +7,7 @@ from logger_functions.logger import validate_logger
 
 
 def requires_permission(
-    permission: str, logger: logging.Logger = None
+    permission: str, logger: logging.Logger | None = None
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """
     A decorator to enforce that a user has a specific permission before executing a function.
@@ -16,7 +16,7 @@ def requires_permission(
     ----------
     permission : str
         The required permission that the user must have.
-    logger : logging.Logger, optional
+    logger : Optional[logging.Logger], optional
         The logger to use for logging errors (default is None).
 
     Returns

--- a/decorators/retry.py
+++ b/decorators/retry.py
@@ -7,7 +7,7 @@ from logger_functions.logger import validate_logger
 
 
 def retry(
-    max_retries: int, delay: int | float = 1.0, logger: logging.Logger = None
+    max_retries: int, delay: int | float = 1.0, logger: logging.Logger | None = None
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """
     A decorator to retry a function call a specified number of times with a delay between attempts.
@@ -18,7 +18,7 @@ def retry(
         The maximum number of retry attempts.
     delay : Union[int, float], optional
         The delay between retry attempts in seconds (default is 1.0).
-    logger : logging.Logger, optional
+    logger : Optional[logging.Logger], optional
         The logger to use for logging errors (default is None).
 
     Returns

--- a/decorators/serialize_output.py
+++ b/decorators/serialize_output.py
@@ -7,7 +7,7 @@ from logger_functions.logger import validate_logger
 
 
 def serialize_output(
-    format: str, logger: logging.Logger = None
+    format: str, logger: logging.Logger | None = None
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """
     A decorator to serialize the output of a function into a specified format.
@@ -16,7 +16,7 @@ def serialize_output(
     ----------
     format : str
         The format to serialize the output into. Currently supports 'json'.
-    logger : logging.Logger, optional
+    logger : Optional[logging.Logger], optional
         The logger to use for logging errors (default is None).
 
     Returns
@@ -86,8 +86,7 @@ def serialize_output(
             """
             try:
                 result = func(*args, **kwargs)
-                if format == "json":
-                    return json.dumps(result)
+                return json.dumps(result)
             except Exception as e:
                 if logger:
                     logger.error(

--- a/decorators/throttle.py
+++ b/decorators/throttle.py
@@ -7,7 +7,7 @@ from logger_functions.logger import validate_logger
 
 
 def throttle(
-    rate_limit: int | float, logger: logging.Logger = None
+    rate_limit: int | float, logger: logging.Logger | None = None
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """
     A decorator to enforce a rate limit on a function, ensuring it is not called more often than the specified rate.
@@ -16,7 +16,7 @@ def throttle(
     ----------
     rate_limit : float
         The minimum time interval (in seconds) between consecutive calls to the function.
-    logger : logging.Logger, optional
+    logger : Optional[logging.Logger], optional
         The logger to use for logging errors (default is None).
 
     Returns


### PR DESCRIPTION
## Summary
- allow `None` for logger parameters across decorators
- document updated logger expectations and enforce non-null requirements where needed
- ensure `serialize_output` always returns serialized data

## Testing
- `pyright decorators/throttle.py decorators/redirect_output.py decorators/requires_permission.py decorators/retry.py decorators/serialize_output.py decorators/log_function_calls.py`
- `pytest pytest/unit/decorators/test_throttle.py pytest/unit/decorators/test_redirect_output.py pytest/unit/decorators/test_requires_permission.py pytest/unit/decorators/test_retry.py pytest/unit/decorators/test_serialize_output.py pytest/unit/decorators/test_log_function_calls.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa170f32f4832593889ef1845046b0