### PR TITLE
refactor: improve decorator typing with ParamSpec

### DIFF
--- a/decorators/async_handle_error.py
+++ b/decorators/async_handle_error.py
@@ -1,14 +1,17 @@
-from typing import Any
+from typing import ParamSpec, TypeVar
 from collections.abc import Callable
 from functools import wraps
 import inspect
 import logging
 from logger_functions.logger import validate_logger
 
+P = ParamSpec("P")
+R = TypeVar("R")
+
 
 def async_handle_error(
     logger: logging.Logger | None = None,
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+) -> Callable[[Callable[P, R]], Callable[P, R | None]]:
     """Decorator for handling errors in asynchronous functions.
 
     Parameters
@@ -29,7 +32,7 @@ def async_handle_error(
     """
     validate_logger(logger)
 
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R | None]:
         """
         Decorator function.
 
@@ -59,7 +62,7 @@ def async_handle_error(
                 raise TypeError(error_message)
 
         @wraps(func)
-        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R | None:
             """
             Wrapper function to handle errors in the asynchronous function.
 

--- a/decorators/async_wrapper.py
+++ b/decorators/async_wrapper.py
@@ -3,13 +3,16 @@ import inspect
 import logging
 from functools import wraps, partial
 from logger_functions.logger import validate_logger
-from typing import Any
+from typing import ParamSpec, TypeVar
 from collections.abc import Callable
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 def async_wrapper(
     logger: logging.Logger | None = None,
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
     Wraps a synchronous function to be executed asynchronously.
 
@@ -33,7 +36,7 @@ def async_wrapper(
         message="The logger must be an instance of logging.Logger",
     )
 
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         """
         Decorator function.
 
@@ -62,7 +65,7 @@ def async_wrapper(
             raise TypeError(error_message)
 
         @wraps(func)
-        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             """
             Asynchronous wrapper function.
 

--- a/decorators/cache.py
+++ b/decorators/cache.py
@@ -1,9 +1,12 @@
-from typing import Any
+from typing import Any, ParamSpec, TypeVar
 from collections.abc import Callable
 from functools import wraps
 
+P = ParamSpec("P")
+R = TypeVar("R")
 
-def cache(func: Callable[..., Any]) -> Callable[..., Any]:
+
+def cache(func: Callable[P, R]) -> Callable[P, R]:
     """
     Decorator to cache the results of a function call.
 
@@ -21,7 +24,7 @@ def cache(func: Callable[..., Any]) -> Callable[..., Any]:
     cached_results: dict[tuple[tuple[Any, ...], frozenset[tuple[str, Any]]], Any] = {}
 
     @wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> Any:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         """
         Wrapper function to cache the results of the input function.
 

--- a/decorators/cache_with_expiration.py
+++ b/decorators/cache_with_expiration.py
@@ -1,12 +1,15 @@
-from typing import Any
+from typing import Any, ParamSpec, TypeVar
 from collections.abc import Callable
 from functools import wraps
 import time
 
+P = ParamSpec("P")
+R = TypeVar("R")
+
 
 def cache_with_expiration(
     expiration_time: int,
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
     A decorator to cache the results of a function call for a specified amount of time.
 
@@ -28,7 +31,7 @@ def cache_with_expiration(
     if not isinstance(expiration_time, int) or expiration_time < 0:
         raise ValueError("expiration_time must be a positive integer")
 
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         """
         The actual decorator function.
 
@@ -43,11 +46,11 @@ def cache_with_expiration(
             The wrapped function.
         """
         cached_results: dict[
-            tuple[tuple[Any, ...], frozenset[tuple[str, Any]]], tuple[float, Any]
+            tuple[tuple[Any, ...], frozenset[tuple[str, Any]]], tuple[float, R]
         ] = {}
 
         @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             """
             The wrapper function that caches the result of the decorated function.
 

--- a/decorators/chain.py
+++ b/decorators/chain.py
@@ -1,12 +1,13 @@
-from typing import Any, TypeVar
+from typing import Any, ParamSpec, TypeVar
 from collections.abc import Callable
 from functools import wraps
 from inspect import Parameter, signature
 
+P = ParamSpec("P")
 T = TypeVar("T")
 
 
-def chain(func: Callable[..., T]) -> Callable[..., T | Any]:
+def chain(func: Callable[P, T]) -> Callable[P, T | Any]:
     """
     Decorator to call the 'chain' method on the result of a function if it exists.
 
@@ -22,7 +23,7 @@ def chain(func: Callable[..., T]) -> Callable[..., T | Any]:
     """
 
     @wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> T | Any:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> T | Any:
         """
         Wrapper function to call the 'chain' method on the result of the input function if it exists.
 

--- a/decorators/conditional_execute.py
+++ b/decorators/conditional_execute.py
@@ -1,13 +1,14 @@
-from typing import Any, TypeVar
+from typing import ParamSpec, TypeVar
 from collections.abc import Callable
 from functools import wraps
 
+P = ParamSpec("P")
 T = TypeVar("T")
 
 
 def conditional_execute(
     predicate: Callable[[], bool],
-) -> Callable[[Callable[..., T]], Callable[..., T | None]]:
+) -> Callable[[Callable[P, T]], Callable[P, T | None]]:
     """
     Decorator to conditionally execute a function based on a predicate.
 
@@ -29,7 +30,7 @@ def conditional_execute(
     if not callable(predicate):
         raise TypeError("Predicate must be callable")
 
-    def decorator(func: Callable[..., T]) -> Callable[..., T | None]:
+    def decorator(func: Callable[P, T]) -> Callable[P, T | None]:
         """
         Decorator function.
 
@@ -45,7 +46,7 @@ def conditional_execute(
         """
 
         @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> T | None:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T | None:
             """
             Wrapper function to conditionally execute the input function.
 

--- a/decorators/conditional_return.py
+++ b/decorators/conditional_return.py
@@ -1,13 +1,14 @@
-from typing import Any, TypeVar
+from typing import ParamSpec, TypeVar
 from collections.abc import Callable
 from functools import wraps
 
+P = ParamSpec("P")
 T = TypeVar("T")
 
 
 def conditional_return(
-    condition: Callable[..., bool], return_value: T
-) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    condition: Callable[P, bool], return_value: T
+) -> Callable[[Callable[P, T]], Callable[P, T]]:
     """
     Decorator to conditionally return a specified value based on a condition.
 
@@ -31,7 +32,7 @@ def conditional_return(
     if not callable(condition):
         raise TypeError("Condition must be callable")
 
-    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+    def decorator(func: Callable[P, T]) -> Callable[P, T]:
         """
         Decorator function.
 
@@ -47,7 +48,7 @@ def conditional_return(
         """
 
         @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> T:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             """
             Wrapper function to conditionally return a specified value.
 

--- a/decorators/deprecated.py
+++ b/decorators/deprecated.py
@@ -1,14 +1,17 @@
-from typing import Any
+from typing import Any, ParamSpec, TypeVar
 from collections.abc import Callable
 from functools import wraps
 import warnings
 import logging
 from logger_functions.logger import validate_logger
 
+P = ParamSpec("P")
+R = TypeVar("R")
+
 
 def deprecated(
     logger: logging.Logger | None = None,
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
     Decorator to mark functions as deprecated. It will result in a warning being emitted when the function is used.
 
@@ -29,7 +32,7 @@ def deprecated(
     """
     validate_logger(logger)
 
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         """
         Decorator function to wrap the input function.
 
@@ -45,7 +48,7 @@ def deprecated(
         """
 
         @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             """
             Wrapper function to emit a deprecation warning and log a message.
 

--- a/decorators/enforce_types.py
+++ b/decorators/enforce_types.py
@@ -1,14 +1,17 @@
 import logging
 from functools import wraps
-from typing import Any, get_type_hints, get_origin, get_args
+from typing import Any, ParamSpec, TypeVar, get_type_hints, get_origin, get_args
 import inspect
 from collections.abc import Callable
 from logger_functions.logger import validate_logger
 
+P = ParamSpec("P")
+R = TypeVar("R")
+
 
 def enforce_types(
     logger: logging.Logger | None = None,
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
     A decorator to enforce type checking on the arguments and return value of a function.
 
@@ -29,7 +32,7 @@ def enforce_types(
     """
     validate_logger(logger)
 
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         """
         The actual decorator function.
 
@@ -45,7 +48,7 @@ def enforce_types(
         """
 
         @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             """
             The wrapper function that checks the types of the arguments and return value.
 

--- a/decorators/env_config.py
+++ b/decorators/env_config.py
@@ -1,9 +1,12 @@
-from typing import Any
+from typing import ParamSpec, TypeVar
 from collections.abc import Callable
 from functools import wraps
 import os
 import logging
 from logger_functions.logger import validate_logger
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 def env_config(
@@ -12,7 +15,7 @@ def env_config(
     var_type: type = str,
     custom_message: str | None = None,
     logger: logging.Logger | None = None,
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
     A decorator to inject environment variables into a function.
 
@@ -67,7 +70,7 @@ def env_config(
     if not isinstance(custom_message, str) and custom_message is not None:
         log_or_raise_error("custom_message must be a string or None")
 
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         """
         The actual decorator function.
 
@@ -83,7 +86,7 @@ def env_config(
         """
 
         @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             """
             The wrapper function that injects the environment variable.
 

--- a/decorators/event_trigger.py
+++ b/decorators/event_trigger.py
@@ -2,7 +2,11 @@ from typing import Any
 from collections.abc import Callable
 from functools import wraps
 import logging
+from typing import ParamSpec, TypeVar
 from logger_functions.logger import validate_logger
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 class EventManager:
@@ -11,7 +15,7 @@ class EventManager:
 
     Attributes
     ----------
-    events : Dict[str, List[Callable[..., Any]]]
+    events : Dict[str, List[Callable[P, R]]]
         A dictionary where the keys are event names and the values are lists of callback functions.
 
     Methods
@@ -29,9 +33,9 @@ class EventManager:
         """
         Initializes the EventManager with an empty events dictionary.
         """
-        self.events: dict[str, list[Callable[..., Any]]] = {}
+        self.events: dict[str, list[Callable[P, R]]] = {}
 
-    def subscribe(self, event_name: str, callback: Callable[..., Any]) -> None:
+    def subscribe(self, event_name: str, callback: Callable[P, R]) -> None:
         """
         Adds a callback function to the list of callbacks for a given event name.
 
@@ -46,7 +50,7 @@ class EventManager:
             self.events[event_name] = []
         self.events[event_name].append(callback)
 
-    def trigger(self, event_name: str, *args: Any, **kwargs: Any) -> None:
+    def trigger(self, event_name: str, *args: P.args, **kwargs: P.kwargs) -> None:
         """
         Executes all callback functions associated with the given event name.
 
@@ -66,7 +70,7 @@ class EventManager:
 
 def event_trigger(
     event_manager: EventManager, event_name: str, logger: logging.Logger | None = None
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
     A decorator to trigger an event before executing the decorated function.
 
@@ -111,7 +115,7 @@ def event_trigger(
     if not isinstance(event_name, str) or not event_name:
         log_or_raise_error("event_name must be a non-empty string")
 
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         """
         The actual decorator function.
 
@@ -127,7 +131,7 @@ def event_trigger(
         """
 
         @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             """
             The wrapper function that triggers the event and then calls the original function.
 

--- a/decorators/format_output.py
+++ b/decorators/format_output.py
@@ -1,11 +1,14 @@
-from typing import Any
+from typing import ParamSpec, TypeVar
 from collections.abc import Callable
 from functools import wraps
+
+P = ParamSpec("P")
+R = TypeVar("R", bound=str)
 
 
 def format_output(
     format_string: str,
-) -> Callable[[Callable[..., Any]], Callable[..., str]]:
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
     A decorator to format the output of a function using a specified format string.
 
@@ -27,7 +30,7 @@ def format_output(
     if not isinstance(format_string, str):
         raise TypeError("format_string must be a string")
 
-    def decorator(func: Callable[..., Any]) -> Callable[..., str]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         """
         The actual decorator function.
 
@@ -43,7 +46,7 @@ def format_output(
         """
 
         @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> str:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             """
             The wrapper function that formats the output of the decorated function.
 

--- a/decorators/handle_error.py
+++ b/decorators/handle_error.py
@@ -1,13 +1,16 @@
-from typing import Any
+from typing import ParamSpec, TypeVar
 from collections.abc import Callable
 from functools import wraps
 import logging
 from logger_functions.logger import validate_logger
 
+P = ParamSpec("P")
+R = TypeVar("R")
+
 
 def handle_error(
     error_message: str, logger: logging.Logger | None = None
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+) -> Callable[[Callable[P, R]], Callable[P, R | None]]:
     """
     A decorator to handle exceptions in the decorated function. If an exception occurs,
     it logs a specified error message and returns None.
@@ -31,7 +34,7 @@ def handle_error(
     """
     validate_logger(logger)
 
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R | None]:
         """
         The actual decorator function.
 
@@ -47,7 +50,7 @@ def handle_error(
         """
 
         @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R | None:
             """
             The wrapper function that handles exceptions.
 

--- a/decorators/log_function_calls.py
+++ b/decorators/log_function_calls.py
@@ -1,13 +1,16 @@
 import logging
 from functools import wraps
-from typing import Any
+from typing import Any, ParamSpec, TypeVar
 from collections.abc import Callable
 from logger_functions.logger import validate_logger
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 def log_function_calls(
     logger: logging.Logger,
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
     A decorator to log function calls, including arguments passed and the result returned.
 
@@ -28,9 +31,9 @@ def log_function_calls(
     """
     validate_logger(logger, allow_none=False)
 
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             """
             The wrapper function that logs function calls.
 

--- a/decorators/log_signature.py
+++ b/decorators/log_signature.py
@@ -1,14 +1,17 @@
-from typing import Any
+from typing import Any, ParamSpec, TypeVar
 from collections.abc import Callable
 from functools import wraps
 import inspect
 import logging
 from logger_functions.logger import validate_logger
 
+P = ParamSpec("P")
+R = TypeVar("R")
+
 
 def log_signature(
     logger: logging.Logger | None,
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
     A decorator to log the function signature and the arguments passed to it.
 
@@ -31,7 +34,7 @@ def log_signature(
         logger = logging.getLogger(__name__)
     validate_logger(logger, allow_none=False)
 
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         """
         The actual decorator function.
 
@@ -47,7 +50,7 @@ def log_signature(
         """
 
         @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             """
             The wrapper function that logs the function signature and arguments.
 

--- a/decorators/manipulate_output.py
+++ b/decorators/manipulate_output.py
@@ -1,13 +1,16 @@
-from typing import Any
+from typing import ParamSpec, TypeVar
 from collections.abc import Callable
 from functools import wraps
 import logging
 from logger_functions.logger import validate_logger
 
+P = ParamSpec("P")
+R = TypeVar("R")
+
 
 def manipulate_output(
-    manipulation_func: Callable[[Any], Any], logger: logging.Logger | None = None
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    manipulation_func: Callable[[R], R], logger: logging.Logger | None = None
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
     A decorator to manipulate the output of a function using a specified manipulation function.
 
@@ -35,7 +38,7 @@ def manipulate_output(
             logger.error("manipulation_func must be a callable function.")
         raise TypeError("manipulation_func must be a callable function.")
 
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         """
         The actual decorator function.
 
@@ -51,7 +54,7 @@ def manipulate_output(
         """
 
         @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             """
             The wrapper function that manipulates the output.
 

--- a/decorators/multi_decorator.py
+++ b/decorators/multi_decorator.py
@@ -1,13 +1,16 @@
-from typing import Any
+from typing import ParamSpec, TypeVar
 from collections.abc import Callable
 import logging
 from logger_functions.logger import validate_logger
 
+P = ParamSpec("P")
+R = TypeVar("R")
+
 
 def multi_decorator(
-    decorators: list[Callable[[Callable[..., Any]], Callable[..., Any]]],
+    decorators: list[Callable[[Callable[P, R]], Callable[P, R]]],
     logger: logging.Logger | None = None,
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
     A function to apply multiple decorators to a target function.
 
@@ -37,7 +40,7 @@ def multi_decorator(
 
     validate_logger(logger)
 
-    def combine(func: Callable[..., Any]) -> Callable[..., Any]:
+    def combine(func: Callable[P, R]) -> Callable[P, R]:
         """
         The function that applies all the decorators to the target function.
 

--- a/decorators/normalize_input.py
+++ b/decorators/normalize_input.py
@@ -1,13 +1,16 @@
-from typing import Any
+from typing import Any, ParamSpec, TypeVar
 from collections.abc import Callable
 from functools import wraps
 import logging
 from logger_functions.logger import validate_logger
 
+P = ParamSpec("P")
+R = TypeVar("R")
+
 
 def normalize_input(
     normalization_func: Callable[[Any], Any], logger: logging.Logger | None = None
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
     A decorator to normalize the input arguments of a function using a specified normalization function.
 
@@ -36,7 +39,7 @@ def normalize_input(
             )
         raise TypeError(f"Normalizer {normalization_func} is not callable")
 
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         """
         The actual decorator function.
 
@@ -52,7 +55,7 @@ def normalize_input(
         """
 
         @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             """
             The wrapper function that normalizes the input arguments.
 

--- a/decorators/rate_limit.py
+++ b/decorators/rate_limit.py
@@ -4,7 +4,11 @@ from collections import deque
 from functools import wraps
 import time
 import logging
+from typing import ParamSpec, TypeVar
 from logger_functions.logger import validate_logger
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 class RateLimitExceededException(Exception):
@@ -16,7 +20,7 @@ def rate_limit(
     period: int,
     logger: logging.Logger | None = None,
     exception_message: str | None = None,
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
     A decorator to limit the number of times a function can be called within a specific period.
 
@@ -57,7 +61,7 @@ def rate_limit(
             logger.error("exception_message must be a string or None", exc_info=True)
         raise TypeError("exception_message must be a string or None")
 
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         """
         The actual decorator function.
 
@@ -75,7 +79,7 @@ def rate_limit(
         calls: deque[float] = deque(maxlen=max_calls)
 
         @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             """
             The wrapper function that enforces the rate limit.
 

--- a/decorators/redirect_output.py
+++ b/decorators/redirect_output.py
@@ -1,14 +1,17 @@
-from typing import Any
+from typing import ParamSpec, TypeVar
 from collections.abc import Callable
 from contextlib import redirect_stdout
 from functools import wraps
 import logging
 from logger_functions.logger import validate_logger
 
+P = ParamSpec("P")
+R = TypeVar("R")
+
 
 def redirect_output(
-    file_path: str, logger: logging.Logger = None
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    file_path: str, logger: logging.Logger | None = None
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
     A decorator to redirect the standard output of a function to a specified file.
 
@@ -35,7 +38,7 @@ def redirect_output(
             logger.error("file_path must be a string", exc_info=True)
         raise TypeError("file_path must be a string")
 
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         """
         The actual decorator function.
 
@@ -51,7 +54,7 @@ def redirect_output(
         """
 
         @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             """
             The wrapper function that redirects the output.
 

--- a/decorators/requires_permission.py
+++ b/decorators/requires_permission.py
@@ -1,14 +1,17 @@
-from typing import Any
+from typing import ParamSpec, TypeVar, Concatenate
 from collections.abc import Callable
 from functools import wraps
 import logging
 import inspect
 from logger_functions.logger import validate_logger
 
+P = ParamSpec("P")
+R = TypeVar("R")
+
 
 def requires_permission(
-    permission: str, logger: logging.Logger = None
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    permission: str, logger: logging.Logger | None = None
+) -> Callable[[Callable[Concatenate[list[str], P], R]], Callable[Concatenate[list[str], P], R]]:
     """
     A decorator to enforce that a user has a specific permission before executing a function.
 
@@ -38,7 +41,7 @@ def requires_permission(
             )
         raise TypeError("permission must be a string")
 
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+    def decorator(func: Callable[Concatenate[list[str], P], R]) -> Callable[Concatenate[list[str], P], R]:
         """
         The actual decorator function.
 
@@ -54,7 +57,7 @@ def requires_permission(
         """
 
         @wraps(func)
-        def wrapper(user_permissions: list[str], *args: Any, **kwargs: Any) -> Any:
+        def wrapper(user_permissions: list[str], *args: P.args, **kwargs: P.kwargs) -> R:
             """
             The wrapper function that checks for the required permission.
 
@@ -103,7 +106,7 @@ def requires_permission(
             # Call the original function with the provided arguments and keyword arguments
             if inspect.signature(func).parameters:
                 return func(user_permissions, *args, **kwargs)
-            return func(*args, **kwargs)
+            return func(*args, **kwargs)  # type: ignore[misc]
 
         return wrapper
 

--- a/decorators/retry.py
+++ b/decorators/retry.py
@@ -1,14 +1,17 @@
-from typing import Any
+from typing import ParamSpec, TypeVar
 from collections.abc import Callable
 from functools import wraps
 import logging
 import time
 from logger_functions.logger import validate_logger
 
+P = ParamSpec("P")
+R = TypeVar("R")
+
 
 def retry(
-    max_retries: int, delay: int | float = 1.0, logger: logging.Logger = None
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    max_retries: int, delay: int | float = 1.0, logger: logging.Logger | None = None
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
     A decorator to retry a function call a specified number of times with a delay between attempts.
 
@@ -44,7 +47,7 @@ def retry(
             )
         raise TypeError("delay must be a positive float or an positive integer or 0")
 
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         """
         The actual decorator function.
 
@@ -60,7 +63,7 @@ def retry(
         """
 
         @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             """
             The wrapper function that retries the function call.
 

--- a/decorators/serialize_output.py
+++ b/decorators/serialize_output.py
@@ -1,14 +1,17 @@
-from typing import Any
+from typing import ParamSpec, TypeVar
 from collections.abc import Callable
 from functools import wraps
 import json
 import logging
 from logger_functions.logger import validate_logger
 
+P = ParamSpec("P")
+R = TypeVar("R", bound=str)
+
 
 def serialize_output(
-    format: str, logger: logging.Logger = None
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    format: str, logger: logging.Logger | None = None
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
     A decorator to serialize the output of a function into a specified format.
 
@@ -52,7 +55,7 @@ def serialize_output(
             )
         raise ValueError("Unsupported format. Currently, only 'json' is supported.")
 
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         """
         The actual decorator function.
 
@@ -68,7 +71,7 @@ def serialize_output(
         """
 
         @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> str:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             """
             The wrapper function that serializes the output.
 

--- a/decorators/throttle.py
+++ b/decorators/throttle.py
@@ -1,14 +1,17 @@
-from typing import Any
+from typing import ParamSpec, TypeVar
 from collections.abc import Callable
 from functools import wraps
 import time
 import logging
 from logger_functions.logger import validate_logger
 
+P = ParamSpec("P")
+R = TypeVar("R")
+
 
 def throttle(
-    rate_limit: int | float, logger: logging.Logger = None
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    rate_limit: int | float, logger: logging.Logger | None = None
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
     A decorator to enforce a rate limit on a function, ensuring it is not called more often than the specified rate.
 
@@ -39,7 +42,7 @@ def throttle(
             )
         raise TypeError("rate_limit must be a positive float or an integer")
 
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         """
         The actual decorator function.
 
@@ -56,7 +59,7 @@ def throttle(
         last_called = 0.0
 
         @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             """
             The wrapper function that enforces the rate limit.
 

--- a/decorators/time_and_resource_function.py
+++ b/decorators/time_and_resource_function.py
@@ -5,9 +5,12 @@ import threading
 import gc
 from types import SimpleNamespace
 from logger_functions.logger import validate_logger
-from typing import Any
+from typing import ParamSpec, TypeVar
 from collections.abc import Callable
 from functools import wraps
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 def time_and_resource_function(
@@ -23,7 +26,7 @@ def time_and_resource_function(
     monitor_page_faults: bool = True,
     interval: float = 0.1,
     logger: logging.Logger | None = None,
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
     Decorator to measure the execution time and optionally the maximum memory, CPU usage, I/O operations, network usage, disk usage, number of threads, GC statistics, context switches, open files, and page faults of a function.
 
@@ -64,9 +67,9 @@ def time_and_resource_function(
     """
     validate_logger(logger)
 
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             process = psutil.Process()
             start_time = time.time()
 

--- a/decorators/time_function.py
+++ b/decorators/time_function.py
@@ -1,14 +1,17 @@
 import time
 import logging
-from typing import Any
+from typing import ParamSpec, TypeVar
 from collections.abc import Callable
 from functools import wraps
 from logger_functions.logger import validate_logger
 
+P = ParamSpec("P")
+R = TypeVar("R")
+
 
 def time_function(
     logger: logging.Logger | None = None,
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
     A decorator that measures and logs or prints the execution time of a function.
 
@@ -29,9 +32,9 @@ def time_function(
     """
     validate_logger(logger)
 
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             """
             The wrapper function that measures the execution time.
 

--- a/decorators/validate_args.py
+++ b/decorators/validate_args.py
@@ -1,13 +1,16 @@
 import logging
-from typing import Any
+from typing import ParamSpec, TypeVar
 from collections.abc import Callable
 from functools import wraps
 from logger_functions.logger import validate_logger
 
+P = ParamSpec("P")
+R = TypeVar("R")
+
 
 def validate_args(
-    validation_func: Callable[..., bool], logger: logging.Logger | None = None
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    validation_func: Callable[P, bool], logger: logging.Logger | None = None
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
     A decorator that validates the arguments of a function using a provided validation function.
 
@@ -36,7 +39,7 @@ def validate_args(
             )
         raise TypeError("validation_func must be callable")
 
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         """
         The actual decorator function.
 
@@ -52,7 +55,7 @@ def validate_args(
         """
 
         @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             """
             The wrapper function that validates the arguments.
 


### PR DESCRIPTION
## Summary
- use `ParamSpec` and `TypeVar` across decorators
- propagate wrapped function signatures with `Callable[P, R]`
- support additional argument injection using `Concatenate`

## Testing
- `mypy decorators` *(fails: python-utils is not a valid Python package name)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1711571c832592ceff5582929d60