### PR TITLE
Make num_processes optional in multiprocessing helpers

### DIFF
--- a/multiprocessing_functions/parallel_accumulate.py
+++ b/multiprocessing_functions/parallel_accumulate.py
@@ -16,7 +16,7 @@ def _partial_accumulate(chunk_func: tuple[list[T], Callable[[T, T], T]]) -> list
 def parallel_accumulate(
     func: Callable[[T, T], T],
     data: list[T],
-    num_processes: int = None,
+    num_processes: int | None = None,
     chunk_size: int = 1,
 ) -> list[T]:
     """
@@ -28,7 +28,7 @@ def parallel_accumulate(
         The function to combine two elements into one cumulative value.
     data : List[T]
         The list of data items to process.
-    num_processes : int, optional
+    num_processes : int | None, optional
         The number of processes to use for parallel execution. If None, it defaults
         to the number of available CPUs (by default None).
     chunk_size : int, optional

--- a/multiprocessing_functions/parallel_apply_with_args.py
+++ b/multiprocessing_functions/parallel_apply_with_args.py
@@ -11,7 +11,7 @@ def parallel_apply_with_args(
     func: Callable[[T, Any], R],
     data: list[T],
     args: tuple = (),
-    num_processes: int = None,
+    num_processes: int | None = None,
 ) -> list[R]:
     """
     Apply a function to a list of items in parallel, passing additional arguments to the function.
@@ -24,7 +24,7 @@ def parallel_apply_with_args(
         The list of data items to process.
     args : Tuple, optional
         Additional arguments to pass to the function (by default an empty tuple).
-    num_processes : int, optional
+    num_processes : int | None, optional
         The number of processes to use for parallel execution. If None, it defaults
         to the number of available CPUs (by default None).
 

--- a/multiprocessing_functions/parallel_broadcast.py
+++ b/multiprocessing_functions/parallel_broadcast.py
@@ -8,7 +8,7 @@ R = TypeVar("R")
 
 
 def parallel_broadcast(
-    func: Callable[[T, T], R], shared_input: T, data: list[T], num_processes: int = None
+    func: Callable[[T, T], R], shared_input: T, data: list[T], num_processes: int | None = None
 ) -> list[R]:
     """
     Apply a function in parallel to a list of items, with a shared input broadcasted to all processes.
@@ -21,7 +21,7 @@ def parallel_broadcast(
         The shared input to broadcast to all processes.
     data : List[T]
         The list of data items to process.
-    num_processes : int, optional
+    num_processes : int | None, optional
         The number of processes to use for parallel execution. If None, it defaults
         to the number of available CPUs (by default None).
 

--- a/multiprocessing_functions/parallel_dynamic_distribute.py
+++ b/multiprocessing_functions/parallel_dynamic_distribute.py
@@ -10,7 +10,7 @@ R = TypeVar("R")
 def parallel_dynamic_distribute(
     func: Callable[[T], R],
     data: list[T],
-    num_processes: int = None,
+    num_processes: int | None = None,
     chunk_size: int = 1,
 ) -> list[R]:
     """
@@ -22,7 +22,7 @@ def parallel_dynamic_distribute(
         The function to apply to each item in the list.
     data : List[T]
         The list of data items to process.
-    num_processes : int, optional
+    num_processes : int | None, optional
         The number of processes to use for parallel execution. If None, it defaults
         to the number of available CPUs (by default None).
     chunk_size : int, optional

--- a/multiprocessing_functions/parallel_filter.py
+++ b/multiprocessing_functions/parallel_filter.py
@@ -7,7 +7,7 @@ T = TypeVar("T")
 
 
 def parallel_filter(
-    condition: Callable[[T], bool], data: list[T], num_processes: int = None
+    condition: Callable[[T], bool], data: list[T], num_processes: int | None = None
 ) -> list[T]:
     """
     Filter a list of items in parallel, keeping only those that satisfy the condition.
@@ -18,7 +18,7 @@ def parallel_filter(
         A function that takes an item as input and returns `True` if the item should be kept, `False` otherwise.
     data : List[T]
         The list of data items to filter.
-    num_processes : int, optional
+    num_processes : int | None, optional
         The number of processes to use for parallel execution. If None, it defaults
         to the number of available CPUs (by default None).
 

--- a/multiprocessing_functions/parallel_gather_errors.py
+++ b/multiprocessing_functions/parallel_gather_errors.py
@@ -8,7 +8,7 @@ R = TypeVar("R")
 
 
 def parallel_gather_errors(
-    func: Callable[[T], R], data: list[T], num_processes: int = None
+    func: Callable[[T], R], data: list[T], num_processes: int | None = None
 ) -> tuple[list[R], list[Exception]]:
     """
     Apply a function to a list of items in parallel and gather any exceptions raised by the processes.
@@ -19,7 +19,7 @@ def parallel_gather_errors(
         The function to apply to each item in the list.
     data : List[T]
         The list of data items to process.
-    num_processes : int, optional
+    num_processes : int | None, optional
         The number of processes to use for parallel execution. If None, it defaults
         to the number of available CPUs (by default None).
 

--- a/multiprocessing_functions/parallel_map.py
+++ b/multiprocessing_functions/parallel_map.py
@@ -7,7 +7,7 @@ R = TypeVar("R")
 
 
 def parallel_map(
-    func: Callable[[T], R], data: list[T], num_processes: int = None
+    func: Callable[[T], R], data: list[T], num_processes: int | None = None
 ) -> list[R]:
     """
     Apply a function to a list of items in parallel.
@@ -18,7 +18,7 @@ def parallel_map(
         The function to apply to each item in the list.
     data : List[T]
         The list of data items to process.
-    num_processes : int, optional
+    num_processes : int | None, optional
         The number of processes to use for parallel execution. If ``None``,
         it defaults to the number of available CPUs minus one with a minimum
         of one process.

--- a/multiprocessing_functions/parallel_pipeline.py
+++ b/multiprocessing_functions/parallel_pipeline.py
@@ -16,7 +16,7 @@ def _apply_pipeline(args: tuple[T, list[Callable[[T], T]]]) -> R:
 
 
 def parallel_pipeline(
-    funcs: list[Callable[[T], T]], data: list[T], num_processes: int = None
+    funcs: list[Callable[[T], T]], data: list[T], num_processes: int | None = None
 ) -> list[R]:
     """
     Apply multiple functions in a pipeline to a list of items in parallel.
@@ -27,7 +27,7 @@ def parallel_pipeline(
         A list of functions to apply sequentially to each item.
     data : List[T]
         The list of data items to process.
-    num_processes : int, optional
+    num_processes : int | None, optional
         The number of processes to use for parallel execution. If None, it defaults
         to the number of available CPUs (by default None).
 

--- a/multiprocessing_functions/parallel_progress_bar.py
+++ b/multiprocessing_functions/parallel_progress_bar.py
@@ -9,7 +9,7 @@ R = TypeVar("R")
 
 
 def parallel_progress_bar(
-    func: Callable[[T], R], data: list[T], num_processes: int = None
+    func: Callable[[T], R], data: list[T], num_processes: int | None = None
 ) -> list[R]:
     """
     Apply a function to a list of items in parallel and display a progress bar.
@@ -20,7 +20,7 @@ def parallel_progress_bar(
         The function to apply to each item in the list.
     data : List[T]
         The list of data items to process.
-    num_processes : int, optional
+    num_processes : int | None, optional
         The number of processes to use for parallel execution. If ``None``,
         it defaults to the number of available CPUs minus one with a minimum
         of one process.

--- a/multiprocessing_functions/parallel_reduce.py
+++ b/multiprocessing_functions/parallel_reduce.py
@@ -16,7 +16,7 @@ def _pair_reduce(args: tuple[list[T], Callable[[T, T], T]]) -> T:
 def parallel_reduce(
     func: Callable[[T, T], T],
     data: list[T],
-    num_processes: int = None,
+    num_processes: int | None = None,
     chunk_size: int = 1,
 ) -> T:
     """
@@ -28,7 +28,7 @@ def parallel_reduce(
         A function that takes two elements and returns a single value.
     data : List[T]
         The list of data items to reduce.
-    num_processes : int, optional
+    num_processes : int | None, optional
         The number of processes to use for parallel execution. If None, it defaults
         to the number of available CPUs (by default None).
     chunk_size : int, optional

--- a/multiprocessing_functions/parallel_sort.py
+++ b/multiprocessing_functions/parallel_sort.py
@@ -18,7 +18,7 @@ def _merge(left: list[int], right: list[int]) -> list[int]:
 
 
 def parallel_sort(
-    data: list[int], num_processes: int = None, chunk_size: int = 1
+    data: list[int], num_processes: int | None = None, chunk_size: int = 1
 ) -> list[int]:
     """
     Sort a list of integers in parallel.
@@ -27,7 +27,7 @@ def parallel_sort(
     ----------
     data : List[int]
         The list of integers to sort.
-    num_processes : int, optional
+    num_processes : int | None, optional
         The number of processes to use for parallel execution. If None, it defaults
         to the number of available CPUs (by default None).
     chunk_size : int, optional

--- a/multiprocessing_functions/parallel_starmap.py
+++ b/multiprocessing_functions/parallel_starmap.py
@@ -6,7 +6,7 @@ R = TypeVar("R")
 
 
 def parallel_starmap(
-    func: Callable[..., R], data: list[tuple], num_processes: int = None
+    func: Callable[..., R], data: list[tuple], num_processes: int | None = None
 ) -> list[R]:
     """
     Apply a function to multiple arguments in parallel using `starmap`.
@@ -17,7 +17,7 @@ def parallel_starmap(
         The function to apply to each set of arguments.
     data : List[Tuple]
         A list of tuples, where each tuple contains the arguments for the function.
-    num_processes : int, optional
+    num_processes : int | None, optional
         The number of processes to use for parallel execution. If None, it defaults
         to the number of available CPUs (by default None).
 

--- a/multiprocessing_functions/parallel_sum.py
+++ b/multiprocessing_functions/parallel_sum.py
@@ -2,7 +2,7 @@ from multiprocessing import Pool, cpu_count
 
 
 def parallel_sum(
-    data: list[int], num_processes: int = None, chunk_size: int = 1
+    data: list[int], num_processes: int | None = None, chunk_size: int = 1
 ) -> int:
     """
     Sum a list of integers in parallel.
@@ -11,7 +11,7 @@ def parallel_sum(
     ----------
     data : List[int]
         The list of integers to sum.
-    num_processes : int, optional
+    num_processes : int | None, optional
         The number of processes to use for parallel execution. If None, it defaults
         to the number of available CPUs (by default None).
     chunk_size : int, optional

--- a/multiprocessing_functions/parallel_unique.py
+++ b/multiprocessing_functions/parallel_unique.py
@@ -11,7 +11,7 @@ def _unique(chunk: list[T]) -> list[T]:
 
 
 def parallel_unique(
-    data: list[T], num_processes: int = None, chunk_size: int = 1
+    data: list[T], num_processes: int | None = None, chunk_size: int = 1
 ) -> list[T]:
     """
     Get the unique elements from a list in parallel.
@@ -20,7 +20,7 @@ def parallel_unique(
     ----------
     data : List[T]
         The list of data items to process.
-    num_processes : int, optional
+    num_processes : int | None, optional
         The number of processes to use for parallel execution. If None, it defaults
         to the number of available CPUs (by default None).
     chunk_size : int, optional


### PR DESCRIPTION
## Summary
- make `num_processes` parameters optional across multiprocessing helpers
- note optionality in docstrings

## Testing
- `mypy multiprocessing_functions` *(fails: python-utils is not a valid Python package name)*
- `pytest pytest/unit/multiprocessing_functions` *(fails: interrupted after 8 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa170e50148325b592d5cdf7ebebeb