### PR TITLE
Add array clipping and modulo utilities

### DIFF
--- a/numpy_functions/__init__.py
+++ b/numpy_functions/__init__.py
@@ -10,10 +10,12 @@ from .array_cumsum import array_cumsum
 from .array_diff import array_diff
 from .array_sort import array_sort
 from .array_unique import array_unique
+from .array_clip import array_clip
 from .dot_product import dot_product
 from .elementwise_sum import elementwise_sum
 from .elementwise_product import elementwise_product
 from .elementwise_divide import elementwise_divide
+from .elementwise_mod import elementwise_mod
 from .elementwise_subtract import elementwise_subtract
 from .elementwise_power import elementwise_power
 from .matrix_multiply import matrix_multiply
@@ -32,10 +34,12 @@ __all__ = [
     "array_diff",
     "array_sort",
     "array_unique",
+    "array_clip",
     "dot_product",
     "elementwise_sum",
     "elementwise_product",
     "elementwise_divide",
+    "elementwise_mod",
     "elementwise_subtract",
     "elementwise_power",
     "matrix_multiply",

--- a/numpy_functions/array_clip.py
+++ b/numpy_functions/array_clip.py
@@ -1,0 +1,41 @@
+import numpy as np
+
+
+def array_clip(arr: np.ndarray, min_value: float, max_value: float) -> np.ndarray:
+    """
+    Clip the values in a NumPy array within the specified interval.
+
+    Parameters
+    ----------
+    arr : np.ndarray
+        Array containing numerical values.
+    min_value : float
+        Minimum allowable value.
+    max_value : float
+        Maximum allowable value.
+
+    Returns
+    -------
+    np.ndarray
+        Array with values clipped between ``min_value`` and ``max_value``.
+
+    Raises
+    ------
+    TypeError
+        If `arr` is not a NumPy ndarray.
+    ValueError
+        If ``min_value`` is greater than ``max_value``.
+
+    Examples
+    --------
+    >>> array_clip(np.array([1, 2, 3, 4]), 2, 3)
+    array([2, 2, 3, 3])
+    """
+    if not isinstance(arr, np.ndarray):
+        raise TypeError("arr must be a numpy.ndarray.")
+    if min_value > max_value:
+        raise ValueError("min_value must be less than or equal to max_value.")
+    return np.clip(arr, min_value, max_value)
+
+
+__all__ = ["array_clip"]

--- a/numpy_functions/elementwise_mod.py
+++ b/numpy_functions/elementwise_mod.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+
+def elementwise_mod(arr1: np.ndarray, arr2: np.ndarray) -> np.ndarray:
+    """
+    Compute the element-wise modulo of two NumPy arrays.
+
+    Parameters
+    ----------
+    arr1 : np.ndarray
+        Dividend array.
+    arr2 : np.ndarray
+        Divisor array.
+
+    Returns
+    -------
+    np.ndarray
+        Array containing the element-wise modulo of ``arr1`` and ``arr2``.
+
+    Raises
+    ------
+    TypeError
+        If either input is not a NumPy ndarray.
+    ValueError
+        If the arrays do not have the same shape.
+        If ``arr2`` contains zeros.
+
+    Examples
+    --------
+    >>> elementwise_mod(np.array([5, 7]), np.array([2, 3]))
+    array([1, 1])
+    """
+    if not isinstance(arr1, np.ndarray) or not isinstance(arr2, np.ndarray):
+        raise TypeError("Both inputs must be numpy.ndarray.")
+    if arr1.shape != arr2.shape:
+        raise ValueError("Arrays must have the same shape.")
+    if np.any(arr2 == 0):
+        raise ValueError("Divisor array must not contain zeros.")
+    return np.mod(arr1, arr2)
+
+
+__all__ = ["elementwise_mod"]

--- a/pytest/unit/numpy_functions/test_array_clip.py
+++ b/pytest/unit/numpy_functions/test_array_clip.py
@@ -1,0 +1,22 @@
+import numpy as np
+import pytest
+from numpy_functions.array_clip import array_clip
+
+
+def test_array_clip_basic() -> None:
+    """Test array_clip with values outside the clip range."""
+    result = array_clip(np.array([1, 2, 3, 4]), 2, 3)
+    expected = np.array([2, 2, 3, 3])
+    assert np.array_equal(result, expected), "Failed to clip array within range"
+
+
+def test_array_clip_invalid_type() -> None:
+    """Test array_clip with invalid array type."""
+    with pytest.raises(TypeError):
+        array_clip([1, 2, 3], 0, 1)
+
+
+def test_array_clip_invalid_bounds() -> None:
+    """Test array_clip with min_value greater than max_value."""
+    with pytest.raises(ValueError):
+        array_clip(np.array([1, 2, 3]), 5, 1)

--- a/pytest/unit/numpy_functions/test_elementwise_mod.py
+++ b/pytest/unit/numpy_functions/test_elementwise_mod.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+from numpy_functions.elementwise_mod import elementwise_mod
+
+
+def test_elementwise_mod_basic() -> None:
+    """Test elementwise_mod with arrays of the same shape."""
+    result = elementwise_mod(np.array([5, 7]), np.array([2, 3]))
+    expected = np.array([1, 1])
+    assert np.array_equal(result, expected), "Failed on basic element-wise modulo"
+
+
+def test_elementwise_mod_mismatched_shapes() -> None:
+    """Test elementwise_mod with arrays of different shapes."""
+    with pytest.raises(ValueError):
+        elementwise_mod(np.array([1, 2]), np.array([1, 2, 3]))
+
+
+def test_elementwise_mod_zero_division() -> None:
+    """Test elementwise_mod when the divisor contains zero."""
+    with pytest.raises(ValueError):
+        elementwise_mod(np.array([1, 2]), np.array([1, 0]))
+
+
+def test_elementwise_mod_invalid_type() -> None:
+    """Test elementwise_mod with invalid input types."""
+    with pytest.raises(TypeError):
+        elementwise_mod([1, 2], np.array([1, 2]))


### PR DESCRIPTION
## Summary
- add `array_clip` to limit array values within a range
- add `elementwise_mod` for element-wise modulo between arrays
- include comprehensive unit tests and export new utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa243bf190832590be42b3fd744e24