### PR TITLE
refactor: add generic type variable T in iterable helpers

### DIFF
--- a/iterable_functions/check_if_all_elements_are_duplicates.py
+++ b/iterable_functions/check_if_all_elements_are_duplicates.py
@@ -1,14 +1,15 @@
-from typing import Any
+from typing import TypeVar
 from collections import Counter
 
+T = TypeVar("T")
 
-def check_if_all_elements_are_duplicates(input_list: list[Any]) -> bool:
+def check_if_all_elements_are_duplicates(input_list: list[T]) -> bool:
     """
     Check if all elements in the list are duplicates.
 
     Parameters
     ----------
-    input_list : list
+    input_list : list[T]
         The list to check for duplicate elements.
 
     Returns

--- a/iterable_functions/get_common_elements_in_lists.py
+++ b/iterable_functions/get_common_elements_in_lists.py
@@ -1,18 +1,19 @@
-from typing import Any
+from typing import TypeVar
 
+T = TypeVar("T")
 
-def get_common_elements_in_lists(list_of_lists: list[list[Any]]) -> list[Any]:
+def get_common_elements_in_lists(list_of_lists: list[list[T]]) -> list[T]:
     """
     Finds common elements between various lists.
 
     Parameters
     ----------
-    list_of_lists : list
+    list_of_lists : list[list[T]]
         Contains a list of lists.
 
     Returns
     -------
-    list
+    list[T]
         Returns a list that contains the intersection of all elements inside the list of lists.
 
     Raises

--- a/iterable_functions/get_shared_elements.py
+++ b/iterable_functions/get_shared_elements.py
@@ -1,19 +1,20 @@
-from typing import Any
+from typing import TypeVar
 from collections import Counter
 
+T = TypeVar("T")
 
-def get_shared_elements(dict_: dict[str, list[Any]]) -> list[Any]:
+def get_shared_elements(dict_: dict[str, list[T]]) -> list[T]:
     """
     Identify elements that appear in at least two lists within a dictionary.
 
     Parameters
     ----------
-    dict_ : dict
+    dict_ : dict[str, list[T]]
         A dictionary where the values are lists of elements.
 
     Returns
     -------
-    list
+    list[T]
         A list containing elements that appear in at least two lists within the dictionary.
 
     Raises

--- a/iterable_functions/get_unique_sublists.py
+++ b/iterable_functions/get_unique_sublists.py
@@ -1,18 +1,19 @@
-from typing import Any
+from typing import TypeVar
 
+T = TypeVar("T")
 
-def get_unique_sublists(list_of_lists: list[list[Any]]) -> list[list[Any]]:
+def get_unique_sublists(list_of_lists: list[list[T]]) -> list[list[T]]:
     """
     Identify unique sublists within a list of lists.
 
     Parameters
     ----------
-    list_of_lists : list
+    list_of_lists : list[list[T]]
         The list containing various sublists.
 
     Returns
     -------
-    list
+    list[list[T]]
         List containing unique sublists.
 
     Raises

--- a/iterable_functions/partially_contains_sublist.py
+++ b/iterable_functions/partially_contains_sublist.py
@@ -1,18 +1,19 @@
-from typing import Any
+from typing import TypeVar
 from iterable_functions.any_match_lists import any_match_lists
 
+T = TypeVar("T")
 
 def partially_contains_sublist(
-    main_list: list[Any], list_of_lists: list[list[Any]]
+    main_list: list[T], list_of_lists: list[list[T]]
 ) -> bool:
     """
     Check if elements of the main list are partially contained in any sublist of the list of lists.
 
     Parameters
     ----------
-    main_list : list
+    main_list : list[T]
         The query list to check for partial containment.
-    list_of_lists : list
+    list_of_lists : list[list[T]]
         The subject list containing sublists to compare against the query list.
 
     Returns


### PR DESCRIPTION
## Summary
- refine iterable utility functions with a reusable `TypeVar` `T`
- add generic type annotations to collections instead of `Any`
- update function docstrings accordingly

## Testing
- `pytest -q` *(fails: TypeError in requires_permission wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68aaedab15fc832588241a58476a1b4c