### PR TITLE
Add numpy array ceiling and sign utilities with tests

### DIFF
--- a/numpy_functions/__init__.py
+++ b/numpy_functions/__init__.py
@@ -14,10 +14,12 @@ from .array_sort import array_sort
 from .array_unique import array_unique
 from .array_clip import array_clip
 from .array_abs import array_abs
+from .array_sign import array_sign
 from .array_sqrt import array_sqrt
 from .array_exp import array_exp
 from .array_log import array_log
 from .array_floor import array_floor
+from .array_ceil import array_ceil
 from .array_round import array_round
 from .array_reshape import array_reshape
 from .array_percentile import array_percentile
@@ -54,10 +56,12 @@ __all__ = [
     "array_unique",
     "array_clip",
     "array_abs",
+    "array_sign",
     "array_sqrt",
     "array_exp",
     "array_log",
     "array_floor",
+    "array_ceil",
     "array_round",
     "array_reshape",
     "array_percentile",

--- a/numpy_functions/array_ceil.py
+++ b/numpy_functions/array_ceil.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+
+def array_ceil(arr: np.ndarray) -> np.ndarray:
+    """
+    Compute the ceiling of each element in a NumPy array.
+
+    Parameters
+    ----------
+    arr : np.ndarray
+        Array containing numerical values.
+
+    Returns
+    -------
+    np.ndarray
+        Array containing the ceiling of each element in ``arr``.
+
+    Raises
+    ------
+    TypeError
+        If ``arr`` is not a NumPy ndarray.
+
+    Examples
+    --------
+    >>> array_ceil(np.array([1.2, -2.7, 0.0]))
+    array([ 2., -2.,  0.])
+    """
+    if not isinstance(arr, np.ndarray):
+        raise TypeError("arr must be a numpy.ndarray.")
+    return np.ceil(arr)
+
+
+__all__ = ["array_ceil"]

--- a/numpy_functions/array_sign.py
+++ b/numpy_functions/array_sign.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+
+def array_sign(arr: np.ndarray) -> np.ndarray:
+    """
+    Compute the sign of each element in a NumPy array.
+
+    Parameters
+    ----------
+    arr : np.ndarray
+        Array containing numerical values.
+
+    Returns
+    -------
+    np.ndarray
+        Array containing the sign of each element in ``arr`` (-1, 0, or 1).
+
+    Raises
+    ------
+    TypeError
+        If ``arr`` is not a NumPy ndarray.
+
+    Examples
+    --------
+    >>> array_sign(np.array([-2.5, 0.0, 3.1]))
+    array([-1.,  0.,  1.])
+    """
+    if not isinstance(arr, np.ndarray):
+        raise TypeError("arr must be a numpy.ndarray.")
+    return np.sign(arr)
+
+
+__all__ = ["array_sign"]

--- a/pytest/unit/numpy_functions/test_array_ceil.py
+++ b/pytest/unit/numpy_functions/test_array_ceil.py
@@ -1,0 +1,16 @@
+import numpy as np
+import pytest
+from numpy_functions.array_ceil import array_ceil
+
+
+def test_array_ceil_basic() -> None:
+    """Test array_ceil with positive and negative decimals."""
+    result = array_ceil(np.array([1.2, -2.7, 0.0]))
+    expected = np.array([2.0, -2.0, 0.0])
+    assert np.array_equal(result, expected), "Failed on basic ceil operation"
+
+
+def test_array_ceil_invalid_type() -> None:
+    """Test array_ceil with an invalid input type."""
+    with pytest.raises(TypeError):
+        array_ceil([1.2, -2.7])  # type: ignore[arg-type]

--- a/pytest/unit/numpy_functions/test_array_sign.py
+++ b/pytest/unit/numpy_functions/test_array_sign.py
@@ -1,0 +1,16 @@
+import numpy as np
+import pytest
+from numpy_functions.array_sign import array_sign
+
+
+def test_array_sign_basic() -> None:
+    """Test array_sign with negative, zero, and positive values."""
+    result = array_sign(np.array([-2.5, 0.0, 3.1]))
+    expected = np.array([-1.0, 0.0, 1.0])
+    assert np.array_equal(result, expected), "Failed on basic sign operation"
+
+
+def test_array_sign_invalid_type() -> None:
+    """Test array_sign with an invalid input type."""
+    with pytest.raises(TypeError):
+        array_sign([-2.5, 0.0, 3.1])  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- add `array_ceil` to compute the ceiling of each value in a NumPy array
- add `array_sign` to return the sign (-1, 0, 1) of array values
- expose new utilities in `numpy_functions.__init__`
- include unit tests for new functions

## Testing
- `pytest pytest/unit/numpy_functions/test_array_ceil.py pytest/unit/numpy_functions/test_array_sign.py -q`
- `pytest -q` *(fails: TypeError: sample_function() takes 0 positional arguments but 1 was given in `test_requires_permission_success`)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf162ab98832589846d5bcdb13899