### PR TITLE
Fix mathematical function test imports

### DIFF
--- a/pytest/unit/mathematical_functions/random/test_random_floats.py
+++ b/pytest/unit/mathematical_functions/random/test_random_floats.py
@@ -1,5 +1,5 @@
 import pytest
-from statistics_functions.random_floats import random_floats
+from mathematical_functions.random.random_floats import random_floats
 
 
 def test_random_floats_default_range() -> None:

--- a/pytest/unit/mathematical_functions/random/test_random_integers.py
+++ b/pytest/unit/mathematical_functions/random/test_random_integers.py
@@ -1,5 +1,5 @@
 import pytest
-from statistics_functions.random_integers import random_integers
+from mathematical_functions.random.random_integers import random_integers
 
 
 def test_random_integers_default_range() -> None:

--- a/pytest/unit/mathematical_functions/random/test_random_normal.py
+++ b/pytest/unit/mathematical_functions/random/test_random_normal.py
@@ -1,6 +1,6 @@
 import pytest
 import math
-from statistics_functions.random_normal import random_normal
+from mathematical_functions.random.random_normal import random_normal
 
 
 def test_random_normal_default_parameters() -> None:

--- a/pytest/unit/mathematical_functions/random/test_random_sample.py
+++ b/pytest/unit/mathematical_functions/random/test_random_sample.py
@@ -1,5 +1,5 @@
 import pytest
-from statistics_functions.random_sample import random_sample
+from mathematical_functions.random.random_sample import random_sample
 
 
 def test_random_sample_without_replacement() -> None:

--- a/pytest/unit/mathematical_functions/statistics/test_median.py
+++ b/pytest/unit/mathematical_functions/statistics/test_median.py
@@ -1,5 +1,5 @@
 import pytest
-from statistics_functions.median import median
+from mathematical_functions.statistics.median import median
 
 
 def test_median_odd_length() -> None:

--- a/pytest/unit/mathematical_functions/statistics/test_mode.py
+++ b/pytest/unit/mathematical_functions/statistics/test_mode.py
@@ -1,5 +1,5 @@
 import pytest
-from statistics_functions.mode import mode
+from mathematical_functions.statistics.mode import mode
 
 
 def test_mode_single_mode() -> None:

--- a/pytest/unit/mathematical_functions/statistics/test_random_floats.py
+++ b/pytest/unit/mathematical_functions/statistics/test_random_floats.py
@@ -1,5 +1,5 @@
 import pytest
-from statistics_functions.random_floats import random_floats
+from mathematical_functions.random.random_floats import random_floats
 
 
 def test_random_floats_default_range() -> None:

--- a/pytest/unit/mathematical_functions/statistics/test_random_integers.py
+++ b/pytest/unit/mathematical_functions/statistics/test_random_integers.py
@@ -1,5 +1,5 @@
 import pytest
-from statistics_functions.random_integers import random_integers
+from mathematical_functions.random.random_integers import random_integers
 
 
 def test_random_integers_default_range() -> None:

--- a/pytest/unit/mathematical_functions/statistics/test_random_normal.py
+++ b/pytest/unit/mathematical_functions/statistics/test_random_normal.py
@@ -1,6 +1,6 @@
 import pytest
 import math
-from statistics_functions.random_normal import random_normal
+from mathematical_functions.random.random_normal import random_normal
 
 
 def test_random_normal_default_parameters() -> None:

--- a/pytest/unit/mathematical_functions/statistics/test_random_sample.py
+++ b/pytest/unit/mathematical_functions/statistics/test_random_sample.py
@@ -1,5 +1,5 @@
 import pytest
-from statistics_functions.random_sample import random_sample
+from mathematical_functions.random.random_sample import random_sample
 
 
 def test_random_sample_without_replacement() -> None:

--- a/pytest/unit/mathematical_functions/statistics/test_stddev.py
+++ b/pytest/unit/mathematical_functions/statistics/test_stddev.py
@@ -1,6 +1,6 @@
 import pytest
 import math
-from statistics_functions.stddev import stddev
+from mathematical_functions.statistics.stddev import stddev
 
 
 def test_stddev_sample() -> None:


### PR DESCRIPTION
## Summary
- replace statistics_functions imports in mathematical function tests with proper mathematical_functions module paths

## Testing
- `pytest pytest/unit/mathematical_functions/random`
- `pytest pytest/unit/mathematical_functions/statistics/test_mode.py pytest/unit/mathematical_functions/statistics/test_median.py pytest/unit/mathematical_functions/statistics/test_stddev.py pytest/unit/mathematical_functions/statistics/test_random_sample.py pytest/unit/mathematical_functions/statistics/test_random_integers.py pytest/unit/mathematical_functions/statistics/test_random_normal.py pytest/unit/mathematical_functions/statistics/test_random_floats.py`


------
https://chatgpt.com/codex/tasks/task_e_68aca9f90a54832592d0f9f48e77f60d