### PR TITLE
Seed RNG for deterministic tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,8 @@ pytest --alluredir=allure-results
 allure serve allure-results
 ```
 
+All tests that involve randomness use a fixed seed (`random.seed(0)`) to ensure reproducible results.
+
 ### Test Structure
 ```
 pytest/

--- a/pytest/unit/mathematical_functions/advanced/test_fourier_analysis.py
+++ b/pytest/unit/mathematical_functions/advanced/test_fourier_analysis.py
@@ -273,11 +273,13 @@ def test_spectral_analysis_noisy_signal() -> None:
     Test case 20: Test spectral analysis with noisy signal.
     """
     import random
-    
+
+    random.seed(0)  # Fixed seed for reproducibility
+
     # Create noisy sine wave
     N = 1000
     sampling_rate = 100
-    signal = [math.sin(2*math.pi*15*i/sampling_rate) + 0.1*random.gauss(0, 1) 
+    signal = [math.sin(2*math.pi*15*i/sampling_rate) + 0.1*random.gauss(0, 1)
               for i in range(N)]
     
     result = spectral_analysis(signal, sampling_rate)

--- a/pytest/unit/mathematical_functions/statistics/test_random_floats.py
+++ b/pytest/unit/mathematical_functions/statistics/test_random_floats.py
@@ -1,5 +1,12 @@
+import random
 import pytest
 from mathematical_functions.random.random_floats import random_floats
+
+
+@pytest.fixture(autouse=True)
+def fixed_seed() -> None:
+    """Seed RNG for reproducibility."""
+    random.seed(0)
 
 
 def test_random_floats_default_range() -> None:


### PR DESCRIPTION
## Summary
- Ensure Fourier analysis noisy signal test uses a fixed random seed
- Seed RNG via autouse fixture in random floats tests
- Document deterministic random seed usage in README

## Testing
- `pytest pytest/unit/mathematical_functions/advanced/test_fourier_analysis.py::test_spectral_analysis_noisy_signal pytest/unit/mathematical_functions/statistics/test_random_floats.py`


------
https://chatgpt.com/codex/tasks/task_e_68acad0dc0c883258ab3d9f2eb2bb6a0