### PR TITLE
Use default logger when async error handler has no logger

### DIFF
--- a/decorators/async_handle_error.py
+++ b/decorators/async_handle_error.py
@@ -16,8 +16,8 @@ def async_handle_error(
     Parameters
     ----------
     logger : logging.Logger | None, optional
-        Logger used to record errors. If ``None``, the exception is printed and
-        re-raised.
+        Logger used to record errors. If ``None``, the exception is routed
+        through the default logger and re-raised.
 
     Returns
     -------
@@ -79,8 +79,8 @@ def async_handle_error(
             Any
                 The result of the wrapped function. If an exception occurs and a
                 logger is provided, ``None`` is returned after logging. If no
-                logger is provided, the error is printed and the exception is
-                re-raised.
+                logger is provided, the error is logged using the default
+                logger and the exception is re-raised.
             """
             try:
                 # Attempt to call the original asynchronous function
@@ -93,8 +93,10 @@ def async_handle_error(
                     )
                     # Return None when logging the exception
                     return None
-                # Print the custom error message and re-raise when no logger is provided
-                print(f"An error occurred in {func.__name__}: {e}")
+                # Route error through the default logger and re-raise when no logger is provided
+                logging.getLogger().error(
+                    f"An error occurred in {func.__name__}: {e}", exc_info=True
+                )
                 raise
 
         return wrapper

--- a/pytest/unit/decorators/test_async_handle_error.py
+++ b/pytest/unit/decorators/test_async_handle_error.py
@@ -109,12 +109,20 @@ def test_non_async_function():
 
 
 @pytest.mark.asyncio
-async def test_async_function_exception():
+async def test_async_function_exception(caplog, capsys):
     """
-    Test case 7: Asynchronous function that raises an exception.
+    Test case 7: Asynchronous function that raises an exception. The error
+    should be logged via the default logger and no output should be printed.
     """
-    with pytest.raises(ValueError, match="Test exception"):
-        await sample_function_exception(1, 2)
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(ValueError, match="Test exception"):
+            await sample_function_exception(1, 2)
+    assert (
+        "An error occurred in sample_function_exception: Test exception"
+        in caplog.text
+    )
+    captured = capsys.readouterr()
+    assert captured.out == ""
 
 
 def test_non_async_function_with_logger(caplog):


### PR DESCRIPTION
## Summary
- Log asynchronous errors with the default logger when no logger is provided and re-raise the exception
- Ensure async error handler test confirms default logging and lack of printed output

## Testing
- `pytest -q` *(fails: No module named 'yaml'; import file mismatch)*
- `pytest pytest/unit/decorators/test_async_handle_error.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68acb1f6ff2c83258aa64ae5c5591947