### PR TITLE
Optimize CPU info retrieval with reusable frequency and interval parameter

### DIFF
--- a/linux_functions/get_cpu_info.py
+++ b/linux_functions/get_cpu_info.py
@@ -2,14 +2,20 @@
 Module for getting CPU information.
 """
 
-import psutil
 import os
 from typing import Dict, Union, List
 
+import psutil
 
-def get_cpu_info() -> Dict[str, Union[int, float, List[float]]]:
+
+def get_cpu_info(interval: float = 0.1) -> Dict[str, Union[int, float, List[float]]]:
     """
     Get CPU information and usage statistics.
+
+    Parameters
+    ----------
+    interval : float, optional
+        Interval in seconds to wait in between each call to ``psutil.cpu_percent``.
 
     Returns
     -------
@@ -24,12 +30,14 @@ def get_cpu_info() -> Dict[str, Union[int, float, List[float]]]:
     >>> cpu_info['cpu_count'] > 0
     True
     """
+    freq = psutil.cpu_freq()
+
     return {
         'cpu_count': os.cpu_count(),
-        'cpu_percent': psutil.cpu_percent(interval=1),
-        'cpu_percent_per_core': psutil.cpu_percent(interval=1, percpu=True),
-        'cpu_freq_current': psutil.cpu_freq().current if psutil.cpu_freq() else None,
-        'cpu_freq_min': psutil.cpu_freq().min if psutil.cpu_freq() else None,
-        'cpu_freq_max': psutil.cpu_freq().max if psutil.cpu_freq() else None,
+        'cpu_percent': psutil.cpu_percent(interval=interval),
+        'cpu_percent_per_core': psutil.cpu_percent(interval=interval, percpu=True),
+        'cpu_freq_current': freq.current if freq else None,
+        'cpu_freq_min': freq.min if freq else None,
+        'cpu_freq_max': freq.max if freq else None,
         'load_average': os.getloadavg() if hasattr(os, 'getloadavg') else None
     }

--- a/pytest/unit/linux_functions/test_get_cpu_info.py
+++ b/pytest/unit/linux_functions/test_get_cpu_info.py
@@ -3,11 +3,14 @@ from typing import Dict, Union, List
 from linux_functions.get_cpu_info import get_cpu_info
 
 
-def test_get_cpu_info_returns_valid_dict() -> None:
-    """
-    Test case 1: Test the get_cpu_info function returns a valid dictionary with CPU information.
-    """
-    cpu_info: Dict[str, Union[int, float, List[float]]] = get_cpu_info()
+@pytest.mark.parametrize("interval", [None, 0.05])
+def test_get_cpu_info_returns_valid_dict(interval: float | None) -> None:
+    """Test the get_cpu_info function returns a valid dictionary with CPU information."""
+    cpu_info: Dict[str, Union[int, float, List[float]]]
+    if interval is None:
+        cpu_info = get_cpu_info()
+    else:
+        cpu_info = get_cpu_info(interval=interval)
     
     # Check return type
     assert isinstance(cpu_info, dict)


### PR DESCRIPTION
## Summary
- add `interval` parameter to `get_cpu_info` to control `psutil.cpu_percent` delay
- cache `psutil.cpu_freq()` result and reuse for frequency fields
- parameterize CPU info tests to cover custom interval

## Testing
- `pytest -q` *(fails: import file mismatch in unrelated statistics tests)*
- `pytest pytest/unit/linux_functions/test_get_cpu_info.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68adef3939608325b295974fa7690825