### PR TITLE
Refactor safe_json_load kwargs handling and export

### DIFF
--- a/json_functions/safe_json_load.py
+++ b/json_functions/safe_json_load.py
@@ -1,7 +1,5 @@
 import json
-from typing import Any, Optional, Type, TypeVar
-
-T = TypeVar('T')
+from typing import Any, Optional, Type
 
 def safe_json_load(json_string: str, object_hook: Optional[Any] = None, default: Optional[Any] = None, decoder: Optional[Type[json.JSONDecoder]] = None) -> Any:
     """
@@ -31,6 +29,14 @@ def safe_json_load(json_string: str, object_hook: Optional[Any] = None, default:
     {'error': True}
     """
     try:
-        return json.loads(json_string, object_hook=object_hook, cls=decoder) if decoder else json.loads(json_string, object_hook=object_hook)
+        kwargs = {}
+        if object_hook is not None:
+            kwargs['object_hook'] = object_hook
+        if decoder is not None:
+            kwargs['cls'] = decoder
+        return json.loads(json_string, **kwargs)
     except (json.JSONDecodeError, TypeError, ValueError):
         return default
+
+
+__all__ = ['safe_json_load']


### PR DESCRIPTION
## Summary
- remove unused `TypeVar` and streamline imports
- build kwargs for `json.loads` and call once
- explicitly export `safe_json_load` with `__all__`

## Testing
- `pytest`
- `pytest pytest/unit/json_functions/test_safe_json_load.py`


------
https://chatgpt.com/codex/tasks/task_e_68b19c1dab748325893f979a73c0a0a8