### PR TITLE
modernize type annotations

### DIFF
--- a/asyncio_functions/async_await_with_error_handling.py
+++ b/asyncio_functions/async_await_with_error_handling.py
@@ -16,14 +16,14 @@ async def async_await_with_error_handling(
 
     Parameters
     ----------
-    tasks : List[Callable[[], Awaitable[T]]]
+    tasks : list[Callable[[], Awaitable[T]]]
         A list of asynchronous functions to execute.
     error_handler : Callable[[Exception], None]
         A function to handle any exceptions that occur during task execution.
 
     Returns
     -------
-    List[T]
+    list[T]
         A list of results from successful tasks.
 
     Raises

--- a/asyncio_functions/async_batch.py
+++ b/asyncio_functions/async_batch.py
@@ -17,16 +17,16 @@ async def async_batch(
 
     Parameters
     ----------
-    func : Callable[[List[T]], List[R]]
+    func : Callable[[list[T]], list[R]]
         The asynchronous function to apply to each batch of items.
-    items : List[T]
+    items : list[T]
         The list of items to process.
     batch_size : int
         The size of each batch.
 
     Returns
     -------
-    List[R]
+    list[R]
         A list of results from processing all the batches.
 
     Raises
@@ -36,7 +36,7 @@ async def async_batch(
 
     Examples
     --------
-    >>> async def process_batch(batch: List[int]) -> List[int]:
+    >>> async def process_batch(batch: list[int]) -> list[int]:
     >>>     await asyncio.sleep(1)
     >>>     return [x * 2 for x in batch]
     >>> asyncio.run(async_batch(process_batch, [1, 2, 3, 4, 5], batch_size=2))

--- a/asyncio_functions/async_chain.py
+++ b/asyncio_functions/async_chain.py
@@ -15,7 +15,7 @@ async def async_chain(
 
     Parameters
     ----------
-    functions : List[Callable[[Union[T, R]], Awaitable[R]]]
+    functions : list[Callable[[T | R], Awaitable[R]]]
         A list of asynchronous functions to chain.
     input_value : T
         The initial input value for the first function.

--- a/asyncio_functions/gather_with_timeout.py
+++ b/asyncio_functions/gather_with_timeout.py
@@ -22,7 +22,7 @@ async def gather_with_timeout(
 
     Returns
     -------
-    List[T]
+    list[T]
         The results of the awaitables that completed before the timeout.
 
     Raises

--- a/compression_functions/decompress_number.py
+++ b/compression_functions/decompress_number.py
@@ -11,7 +11,7 @@ def decompress_number(text: str, index: int) -> tuple[int, int]:
 
     Returns
     -------
-    Tuple[int, int]
+    tuple[int, int]
         Index to start decoding the next number and the number decoded
         in the current function call.
 

--- a/compression_functions/polyline_decoding_list_of_ints.py
+++ b/compression_functions/polyline_decoding_list_of_ints.py
@@ -12,7 +12,7 @@ def polyline_decoding_list_of_ints(encoded_text: str) -> list[float]:
 
     Returns
     -------
-    List[float]
+    list[float]
         List with the decoded numbers.
 
     Raises

--- a/compression_functions/polyline_encoding_list_of_ints.py
+++ b/compression_functions/polyline_encoding_list_of_ints.py
@@ -4,7 +4,7 @@ def polyline_encoding_list_of_ints(list_of_ints: list[int]) -> str:
 
     Parameters
     ----------
-    list_of_ints : List[int]
+    list_of_ints : list[int]
         List of integers to be encoded.
 
     Returns

--- a/data_types/avl_node.py
+++ b/data_types/avl_node.py
@@ -12,9 +12,9 @@ class AVLNode(Generic[T]):
     ----------
     key : T
         The key of the node.
-    left : Optional[AVLNode[T]]
+    left : AVLNode[T | None]
         The left child of the node.
-    right : Optional[AVLNode[T]]
+    right : AVLNode[T | None]
         The right child of the node.
     height : int
         The height of the node.
@@ -33,7 +33,7 @@ class AVLTree(Generic[T]):
 
     Attributes
     ----------
-    root : Optional[AVLNode[T]]
+    root : AVLNode[T | None]
         The root node of the AVL tree.
 
     Methods
@@ -42,7 +42,7 @@ class AVLTree(Generic[T]):
         Inserts a key into the AVL tree.
     delete(key: T) -> None
         Deletes a key from the AVL tree.
-    search(key: T) -> Optional[AVLNode[T]]
+    search(key: T) -> AVLNode[T | None]
         Searches for a key in the AVL tree.
     """
 
@@ -140,7 +140,7 @@ class AVLTree(Generic[T]):
 
         Returns
         -------
-        Optional[AVLNode[T]]
+        AVLNode[T | None]
             The node containing the key, or None if not found.
         """
         return self._search(self.root, key)

--- a/data_types/binary_tree.py
+++ b/data_types/binary_tree.py
@@ -12,9 +12,9 @@ class BinaryTreeNode(Generic[T]):
     ----------
     data : T
         The data stored in the node.
-    left : Optional[BinaryTreeNode[T]]
+    left : BinaryTreeNode[T | None]
         The left child of the node.
-    right : Optional[BinaryTreeNode[T]]
+    right : BinaryTreeNode[T | None]
         The right child of the node.
     """
 
@@ -30,7 +30,7 @@ class BinaryTree(Generic[T]):
 
     Attributes
     ----------
-    root : Optional[BinaryTreeNode[T]]
+    root : BinaryTreeNode[T | None]
         The root node of the binary tree.
 
     Methods
@@ -39,11 +39,11 @@ class BinaryTree(Generic[T]):
         Inserts data into the binary tree.
     search(data: T) -> bool
         Searches for data in the binary tree.
-    inorder_traversal() -> List[T]
+    inorder_traversal() -> list[T]
         Performs an in-order traversal of the tree.
-    preorder_traversal() -> List[T]
+    preorder_traversal() -> list[T]
         Performs a pre-order traversal of the tree.
-    postorder_traversal() -> List[T]
+    postorder_traversal() -> list[T]
         Performs a post-order traversal of the tree.
 
     Raises
@@ -116,7 +116,7 @@ class BinaryTree(Generic[T]):
 
         Parameters
         ----------
-        node : Optional[BinaryTreeNode[T]]
+        node : BinaryTreeNode[T | None]
             The current node to check for data.
         data : T
             The data to search for.
@@ -141,7 +141,7 @@ class BinaryTree(Generic[T]):
 
         Returns
         -------
-        List[T]
+        list[T]
             A list of data in in-order.
         """
         return self._inorder_traversal_recursive(self.root)
@@ -152,12 +152,12 @@ class BinaryTree(Generic[T]):
 
         Parameters
         ----------
-        node : Optional[BinaryTreeNode[T]]
+        node : BinaryTreeNode[T | None]
             The current node to traverse.
 
         Returns
         -------
-        List[T]
+        list[T]
             A list of data in in-order.
         """
         if node is None:
@@ -174,7 +174,7 @@ class BinaryTree(Generic[T]):
 
         Returns
         -------
-        List[T]
+        list[T]
             A list of data in pre-order.
         """
         return self._preorder_traversal_recursive(self.root)
@@ -185,12 +185,12 @@ class BinaryTree(Generic[T]):
 
         Parameters
         ----------
-        node : Optional[BinaryTreeNode[T]]
+        node : BinaryTreeNode[T | None]
             The current node to traverse.
 
         Returns
         -------
-        List[T]
+        list[T]
             A list of data in pre-order.
         """
         if node is None:
@@ -207,7 +207,7 @@ class BinaryTree(Generic[T]):
 
         Returns
         -------
-        List[T]
+        list[T]
             A list of data in post-order.
         """
         return self._postorder_traversal_recursive(self.root)
@@ -218,12 +218,12 @@ class BinaryTree(Generic[T]):
 
         Parameters
         ----------
-        node : Optional[BinaryTreeNode[T]]
+        node : BinaryTreeNode[T | None]
             The current node to traverse.
 
         Returns
         -------
-        List[T]
+        list[T]
             A list of data in post-order.
         """
         if node is None:

--- a/data_types/circular_queue.py
+++ b/data_types/circular_queue.py
@@ -12,7 +12,7 @@ class CircularQueue(Generic[T]):
     ----------
     capacity : int
         The maximum number of items the queue can hold.
-    queue : list[Optional[T]]
+    queue : list[T | None]
         The list of items in the queue.
     front : int
         The index of the front of the queue.
@@ -23,9 +23,9 @@ class CircularQueue(Generic[T]):
     -------
     enqueue(item: T) -> bool
         Adds an item to the queue.
-    dequeue() -> Optional[T]
+    dequeue() -> T | None
         Removes and returns the front item of the queue.
-    peek() -> Optional[T]
+    peek() -> T | None
         Returns the front item without removing it.
     is_empty() -> bool
         Checks if the queue is empty.
@@ -78,7 +78,7 @@ class CircularQueue(Generic[T]):
 
         Returns
         -------
-        Optional[T]
+        T | None
             The front item of the queue, or None if the queue is empty.
         """
         if self.is_empty():
@@ -96,7 +96,7 @@ class CircularQueue(Generic[T]):
 
         Returns
         -------
-        Optional[T]
+        T | None
             The front item of the queue, or None if the queue is empty.
         """
         if self.is_empty():

--- a/data_types/graph.py
+++ b/data_types/graph.py
@@ -10,7 +10,7 @@ class Graph(Generic[T]):
 
     Attributes
     ----------
-    adjacency_list : Dict[T, Set[T]]
+    adjacency_list : dict[T, set[T]]
         The dictionary representing the graph, where keys are vertices and values are sets of adjacent vertices.
 
     Methods
@@ -19,7 +19,7 @@ class Graph(Generic[T]):
         Adds a vertex to the graph.
     add_edge(vertex1: T, vertex2: T) -> None
         Adds an edge between two vertices.
-    get_neighbors(vertex: T) -> List[T]
+    get_neighbors(vertex: T) -> list[T]
         Returns a list of neighbors for a given vertex.
     """
 
@@ -70,7 +70,7 @@ class Graph(Generic[T]):
 
         Returns
         -------
-        List[T]
+        list[T]
             A list of neighbors for the given vertex.
         """
         return list(self.adjacency_list.get(vertex, set()))

--- a/data_types/hash_table.py
+++ b/data_types/hash_table.py
@@ -13,7 +13,7 @@ class HashTable(Generic[K, V]):
     ----------
     size : int
         The number of buckets in the hash table.
-    table : List[List[Tuple[K, V]]]
+    table : list[List[tuple[K, V]]]
         The list of buckets where each bucket stores key-value pairs as tuples.
 
     Methods

--- a/data_types/linked_list.py
+++ b/data_types/linked_list.py
@@ -13,7 +13,7 @@ class Node(Generic[T]):
     ----------
     data : T
         The data stored in the node.
-    next : Optional[Node[T]]
+    next : Node[T | None]
         The next node in the linked list, or None if it is the last node.
     """
 
@@ -36,7 +36,7 @@ class LinkedList(Generic[T]):
 
     Attributes
     ----------
-    head : Optional[Node[T]]
+    head : Node[T | None]
         The first node in the linked list.
 
     Methods

--- a/data_types/red_black_tree.py
+++ b/data_types/red_black_tree.py
@@ -6,13 +6,13 @@ class RedBlackNode:
     ----------
     key : int
         The key of the node.
-    left : Optional[RedBlackNode]
+    left : RedBlackNode | None
         The left child of the node.
-    right : Optional[RedBlackNode]
+    right : RedBlackNode | None
         The right child of the node.
     color : str
         The color of the node ('RED' or 'BLACK').
-    parent : Optional[RedBlackNode]
+    parent : RedBlackNode | None
         The parent of the node.
     """
 
@@ -30,7 +30,7 @@ class RedBlackTree:
 
     Attributes
     ----------
-    root : Optional[RedBlackNode]
+    root : RedBlackNode | None
         The root node of the Red-Black Tree.
 
     Methods

--- a/data_types/segment_tree.py
+++ b/data_types/segment_tree.py
@@ -4,14 +4,14 @@ class SegmentTree:
 
     Attributes
     ----------
-    tree : List[int]
+    tree : list[int]
         A list representing the segment tree.
     n : int
         The size of the input array.
 
     Methods
     -------
-    build(arr: List[int]) -> None
+    build(arr: list[int]) -> None
         Builds the segment tree from the input array.
     update(index: int, value: int) -> None
         Updates the value at the specified index.
@@ -29,7 +29,7 @@ class SegmentTree:
 
         Parameters
         ----------
-        arr : List[int]
+        arr : list[int]
             The array to build the segment tree from.
         """
         self.n = len(arr)

--- a/data_types/skip_list.py
+++ b/data_types/skip_list.py
@@ -9,7 +9,7 @@ class SkipNode:
     ----------
     key : int
         The key of the node.
-    forward : List[Optional[SkipNode]]
+    forward : list[SkipNode | None]
         A list of forward pointers to other nodes in the Skip List at different levels.
     """
 
@@ -35,7 +35,7 @@ class SkipList:
     -------
     insert(key: int) -> None
         Inserts a key into the Skip List.
-    search(key: int) -> Optional[SkipNode]
+    search(key: int) -> SkipNode | None
         Searches for a key in the Skip List.
     delete(key: int) -> None
         Deletes a key from the Skip List.
@@ -84,7 +84,7 @@ class SkipList:
 
         Returns
         -------
-        Optional[SkipNode]
+        SkipNode | None
             The node containing the key, or None if not found.
         """
         current = self.header

--- a/data_types/splay_tree.py
+++ b/data_types/splay_tree.py
@@ -6,11 +6,11 @@ class SplayNode:
     ----------
     key : int
         The key of the node.
-    left : Optional[SplayNode]
+    left : SplayNode | None
         The left child of the node.
-    right : Optional[SplayNode]
+    right : SplayNode | None
         The right child of the node.
-    parent : Optional[SplayNode]
+    parent : SplayNode | None
         The parent of the node.
     """
 
@@ -27,14 +27,14 @@ class SplayTree:
 
     Attributes
     ----------
-    root : Optional[SplayNode]
+    root : SplayNode | None
         The root node of the Splay Tree.
 
     Methods
     -------
     insert(key: int) -> None
         Inserts a key into the Splay Tree.
-    search(key: int) -> Optional[SplayNode]
+    search(key: int) -> SplayNode | None
         Searches for a key in the Splay Tree.
     _rotate_left(node: SplayNode) -> None
         Performs a left rotation on a node.
@@ -85,7 +85,7 @@ class SplayTree:
 
         Returns
         -------
-        Optional[SplayNode]
+        SplayNode | None
             The node containing the key, or None if not found.
         """
         node = self.root

--- a/data_types/trie.py
+++ b/data_types/trie.py
@@ -4,7 +4,7 @@ class TrieNode:
 
     Attributes
     ----------
-    children : Dict[str, TrieNode]
+    children : dict[str, TrieNode]
         A dictionary storing child nodes indexed by characters.
     is_end_of_word : bool
         Indicates if the node marks the end of a word.

--- a/data_types/union_find.py
+++ b/data_types/union_find.py
@@ -10,9 +10,9 @@ class UnionFind(Generic[T]):
 
     Attributes
     ----------
-    parent : Dict[T, T]
+    parent : dict[T, T]
         A dictionary that maps each element to its parent.
-    rank : Dict[T, int]
+    rank : dict[T, int]
         A dictionary that stores the rank (or depth) of each element's tree.
 
     Methods

--- a/data_validation/schema_validation/validate_cerberus_schema.py
+++ b/data_validation/schema_validation/validate_cerberus_schema.py
@@ -31,9 +31,9 @@ def validate_cerberus_schema(
 
     Parameters
     ----------
-    data : Dict[str, Any]
+    data : dict[str, Any]
         The dictionary data to validate against the schema.
-    schema : Dict[str, Any]
+    schema : dict[str, Any]
         Cerberus schema definition dictionary.
     allow_unknown : bool, optional
         Whether to allow fields not defined in schema (by default False).
@@ -44,7 +44,7 @@ def validate_cerberus_schema(
 
     Returns
     -------
-    Dict[str, Any]
+    dict[str, Any]
         Validated and optionally normalized data dictionary.
 
     Raises

--- a/data_validation/schema_validation/validate_pydantic_schema.py
+++ b/data_validation/schema_validation/validate_pydantic_schema.py
@@ -39,7 +39,7 @@ def validate_pydantic_schema(
 
     Parameters
     ----------
-    data : Dict[str, Any] | Any
+    data : dict[str, Any] | Any
         The data to validate against the schema.
     schema_model : Type[T]
         Pydantic model class to validate against.

--- a/decorators/async_wrapper.py
+++ b/decorators/async_wrapper.py
@@ -17,7 +17,7 @@ def async_wrapper(
 
     Parameters
     ----------
-    logger : Optional[logging.Logger]
+    logger : logging.Logger | None
         The logger to use for logging errors. If None, the default logger will be used.
 
     Returns

--- a/decorators/chain.py
+++ b/decorators/chain.py
@@ -19,7 +19,7 @@ def chain(func: Callable[P, T]) -> Callable[P, T | Any]:
 
     Returns
     -------
-    Callable[P, Union[T, Any]]
+    Callable[P, T | Any]
         A wrapper function that calls the 'chain' method on the result of the input function if it exists.
     """
 
@@ -37,7 +37,7 @@ def chain(func: Callable[P, T]) -> Callable[P, T | Any]:
 
         Returns
         -------
-        Union[T, Any]
+        T | Any
             The result of the wrapped function, or the result of calling its 'chain' method if it exists.
 
         Raises

--- a/decorators/conditional_execute.py
+++ b/decorators/conditional_execute.py
@@ -20,7 +20,7 @@ def conditional_execute(
 
     Returns
     -------
-    Callable[[Callable[P, T]], Callable[P, Optional[T]]]
+    Callable[[Callable[P, T]], Callable[P, T | None]]
         A decorator that wraps the input function with conditional execution logic.
 
     Raises
@@ -42,7 +42,7 @@ def conditional_execute(
 
         Returns
         -------
-        Callable[P, Optional[T]]
+        Callable[P, T | None]
             The wrapped function with conditional execution logic.
         """
 
@@ -60,7 +60,7 @@ def conditional_execute(
 
             Returns
             -------
-            Optional[T]
+            T | None
                 The result of the wrapped function if the predicate returns True, otherwise None.
 
             Raises

--- a/decorators/deprecated.py
+++ b/decorators/deprecated.py
@@ -16,7 +16,7 @@ def deprecated(
 
     Parameters
     ----------
-    logger : Optional[logging.Logger]
+    logger : logging.Logger | None
         The logger to use for logging the deprecation warning. If None, the default logger will be used.
 
     Returns

--- a/decorators/enforce_types.py
+++ b/decorators/enforce_types.py
@@ -16,7 +16,7 @@ def enforce_types(
 
     Parameters
     ----------
-    logger : Optional[logging.Logger]
+    logger : logging.Logger | None
         The logger to use for logging type errors.
 
     Returns

--- a/decorators/env_config.py
+++ b/decorators/env_config.py
@@ -26,9 +26,9 @@ def env_config(
         Whether the environment variable is required (default is True).
     var_type : Type, optional
         The expected type of the environment variable (default is str).
-    custom_message : Optional[str], optional
+    custom_message : str | None, optional
         Custom error message if the environment variable is missing or invalid (default is None).
-    logger : Optional[logging.Logger], optional
+    logger : logging.Logger | None, optional
         The logger to use for logging errors (default is None).
 
     Returns

--- a/decorators/event_trigger.py
+++ b/decorators/event_trigger.py
@@ -13,7 +13,7 @@ class EventManager(Generic[P, R]):
 
     Attributes
     ----------
-    events : Dict[str, List[Callable[P, R]]]
+    events : dict[str, list[Callable[P, R]]]
         A dictionary where the keys are event names and the values are lists of callback functions.
 
     Methods
@@ -80,7 +80,7 @@ def event_trigger(
         The event manager to use for triggering events.
     event_name : str
         The name of the event to trigger.
-    logger : Optional[logging.Logger]
+    logger : logging.Logger | None
         The logger to use for logging errors.
 
     Returns

--- a/decorators/handle_error.py
+++ b/decorators/handle_error.py
@@ -18,7 +18,7 @@ def handle_error(
     ----------
     error_message : str
         The error message to log if an exception occurs.
-    logger : Optional[logging.Logger]
+    logger : logging.Logger | None
         The logger to use for logging. If None, logging is disabled.
 
     Returns

--- a/decorators/log_signature.py
+++ b/decorators/log_signature.py
@@ -16,7 +16,7 @@ def log_signature(
 
     Parameters
     ----------
-    logger : Optional[logging.Logger]
+    logger : logging.Logger | None
         The logger to use for logging. If None, a default logger is used.
 
     Returns

--- a/decorators/manipulate_output.py
+++ b/decorators/manipulate_output.py
@@ -17,7 +17,7 @@ def manipulate_output(
     ----------
     manipulation_func : Callable[[Any], Any]
         The function to manipulate the output of the decorated function.
-    logger : Optional[logging.Logger]
+    logger : logging.Logger | None
         The logger to use for logging manipulation warnings.
 
     Returns

--- a/decorators/multi_decorator.py
+++ b/decorators/multi_decorator.py
@@ -15,9 +15,9 @@ def multi_decorator(
 
     Parameters
     ----------
-    decorators : List[Callable[[Callable[P, R]], Callable[P, R]]]
+    decorators : list[Callable[[Callable[P, R]], Callable[P, R]]]
         A list of decorators to apply.
-    logger : Optional[logging.Logger], optional
+    logger : logging.Logger | None, optional
         The logger to use for logging errors (default is None).
 
     Returns

--- a/decorators/normalize_input.py
+++ b/decorators/normalize_input.py
@@ -17,7 +17,7 @@ def normalize_input(
     ----------
     normalization_func : Callable[[Any], Any]
         The function to normalize each input argument.
-    logger : Optional[logging.Logger], optional
+    logger : logging.Logger | None, optional
         The logger to use for logging normalization errors (default is None).
 
     Returns

--- a/decorators/rate_limit.py
+++ b/decorators/rate_limit.py
@@ -28,9 +28,9 @@ def rate_limit(
         The maximum number of allowed calls within the period.
     period : int
         The time period in seconds.
-    logger : Optional[logging.Logger]
+    logger : logging.Logger | None
         The logger to use for logging rate limit warnings.
-    exception_message : Optional[str]
+    exception_message : str | None
         Custom exception message when the rate limit is exceeded.
 
     Returns

--- a/decorators/redirect_output.py
+++ b/decorators/redirect_output.py
@@ -18,7 +18,7 @@ def redirect_output(
     ----------
     file_path : str
         The path to the file where the output should be redirected.
-    logger : Optional[logging.Logger], optional
+    logger : logging.Logger | None, optional
         The logger to use for logging errors (default is None).
 
     Returns

--- a/decorators/requires_permission.py
+++ b/decorators/requires_permission.py
@@ -17,7 +17,7 @@ def requires_permission(
     ----------
     permission : str
         The required permission that the user must have.
-    logger : Optional[logging.Logger], optional
+    logger : logging.Logger | None, optional
         The logger to use for logging errors (default is None).
 
     Returns
@@ -65,7 +65,7 @@ def requires_permission(
 
             Parameters
             ----------
-            user_permissions : List[str]
+            user_permissions : list[str]
                 The list of permissions that the user has.
             *args : Any
                 Positional arguments for the decorated function.

--- a/decorators/retry.py
+++ b/decorators/retry.py
@@ -18,9 +18,9 @@ def retry(
     ----------
     max_retries : int
         The maximum number of retry attempts.
-    delay : Union[int, float], optional
+    delay : int | float, optional
         The delay between retry attempts in seconds (default is 1.0).
-    logger : Optional[logging.Logger], optional
+    logger : logging.Logger | None, optional
         The logger to use for logging errors (default is None).
 
     Returns

--- a/decorators/serialize_output.py
+++ b/decorators/serialize_output.py
@@ -18,7 +18,7 @@ def serialize_output(
     ----------
     format : str
         The format to serialize the output into. Currently supports 'json'.
-    logger : Optional[logging.Logger], optional
+    logger : logging.Logger | None, optional
         The logger to use for logging errors (default is None).
 
     Returns

--- a/decorators/throttle.py
+++ b/decorators/throttle.py
@@ -18,7 +18,7 @@ def throttle(
     ----------
     rate_limit : float
         The minimum time interval (in seconds) between consecutive calls to the function.
-    logger : Optional[logging.Logger], optional
+    logger : logging.Logger | None, optional
         The logger to use for logging errors (default is None).
 
     Returns

--- a/decorators/time_function.py
+++ b/decorators/time_function.py
@@ -16,7 +16,7 @@ def time_function(
 
     Parameters
     ----------
-    logger : Optional[logging.Logger]
+    logger : logging.Logger | None
         The logger to use for logging the execution time. If None, the execution time is printed to the console.
 
     Returns

--- a/decorators/timeout.py
+++ b/decorators/timeout.py
@@ -26,7 +26,7 @@ def timeout(
     ----------
     seconds : int
         The maximum number of seconds the function is allowed to run.
-    logger : Optional[logging.Logger]
+    logger : logging.Logger | None
         The logger to use for logging timeout messages. If None, messages are printed to the console.
 
     Returns

--- a/decorators/validate_args.py
+++ b/decorators/validate_args.py
@@ -17,7 +17,7 @@ def validate_args(
     ----------
     validation_func : Callable[P, bool]
         The validation function that takes the same arguments as the decorated function and returns a boolean.
-    logger : Optional[logging.Logger]
+    logger : logging.Logger | None
         The logger to use for logging validation failure messages. If None, messages are printed to the console.
 
     Returns

--- a/file_functions/data_format_operations/json_to_dict.py
+++ b/file_functions/data_format_operations/json_to_dict.py
@@ -13,7 +13,7 @@ def json_to_dict(file_path: str) -> dict[str, Any]:
 
     Returns
     -------
-    Dict[str, Any]
+    dict[str, Any]
         Dictionary representation of the JSON contents.
 
     Raises

--- a/file_functions/data_format_operations/read_tabular.py
+++ b/file_functions/data_format_operations/read_tabular.py
@@ -14,7 +14,7 @@ def read_tabular(input_file: str, delimiter: str = "\t") -> list[list[str]]:
 
     Returns
     -------
-    List[List[str]]
+    list[List[str]]
         A list with a sublist per line in the input file. Each sublist has the fields that were separated by the defined delimiter.
     """
     with open(input_file) as infile:

--- a/file_functions/data_format_operations/write_dict_to_json.py
+++ b/file_functions/data_format_operations/write_dict_to_json.py
@@ -12,9 +12,9 @@ def write_dict_to_json(
     ----------
     file_path : str
         Path to the JSON file to write.
-    data : Dict[str, Any]
+    data : dict[str, Any]
         Dictionary to serialize and write to the file.
-    indent : Optional[int]
+    indent : int | None
         Number of spaces to use for indentation in the output file (default is None).
 
     Returns

--- a/file_functions/data_format_operations/write_dict_to_tsv.py
+++ b/file_functions/data_format_operations/write_dict_to_tsv.py
@@ -10,7 +10,7 @@ def write_dict_to_tsv(file_path: str, data: dict[str, list[Any]]) -> None:
     ----------
     file_path : str
         The file path to save the TSV file.
-    data : Dict[str, List[Any]]
+    data : dict[str, list[Any]]
         The dictionary where keys are column names and values are lists of values for each column.
 
     Returns

--- a/file_functions/directory_operations/cleanup.py
+++ b/file_functions/directory_operations/cleanup.py
@@ -11,7 +11,7 @@ def cleanup(directory: str, exclude: list[str]) -> None:
     ----------
     directory : str
         The path to the directory to clean up.
-    exclude : List[str]
+    exclude : list[str]
         A list of filenames or subdirectory names to exclude from removal.
         Entries may be provided either as absolute paths or names relative to
         ``directory``. Absolute paths are normalized to their base names before

--- a/file_functions/file_operations/read_lines.py
+++ b/file_functions/file_operations/read_lines.py
@@ -13,12 +13,12 @@ def read_lines(
         Path to the input file.
     strip : bool, optional
         Specify if lines should be stripped of leading and trailing white spaces and new line characters (default is True).
-    num_lines : Union[int, None], optional
+    num_lines : int | None, optional
         Number of lines to read from the file (default is None, which reads all lines).
 
     Returns
     -------
-    List[str]
+    list[str]
         List with the lines read from the input file.
     """
     with open(input_file) as infile:

--- a/file_functions/file_operations/write_lines.py
+++ b/file_functions/file_operations/write_lines.py
@@ -9,7 +9,7 @@ def write_lines(
 
     Parameters
     ----------
-    lines : List[str]
+    lines : list[str]
         List with the lines/strings to write to the output file.
     output_file : str
         Path to the output file.

--- a/file_functions/path_operations/get_paths_dict.py
+++ b/file_functions/path_operations/get_paths_dict.py
@@ -19,7 +19,7 @@ def get_paths_dict(directory: str, type_: str) -> dict[str, str]:
 
     Returns
     -------
-    Dict[str, str]
+    dict[str, str]
         A dictionary with filenames as keys and their full paths as values. The contents
         are filtered based on the `type_` parameter.
 

--- a/file_functions/path_operations/get_paths_in_directory.py
+++ b/file_functions/path_operations/get_paths_in_directory.py
@@ -22,7 +22,7 @@ def get_paths_in_directory(directory: str, type_: str) -> list[str]:
 
     Returns
     -------
-    List[str]
+    list[str]
         A list containing the full paths of the items in the directory, filtered by the specified type.
 
     Raises

--- a/file_functions/path_operations/get_paths_in_directory_with_suffix.py
+++ b/file_functions/path_operations/get_paths_in_directory_with_suffix.py
@@ -14,7 +14,7 @@ def get_paths_in_directory_with_suffix(directory: str, suffix: str) -> list[str]
 
     Returns
     -------
-    List[str]
+    list[str]
         List that contains all of the file paths with the specified suffix.
     """
     all_items: list[str] = os.listdir(directory)

--- a/iterable_functions/dictionary_operations/sort_subdict_by_tuple.py
+++ b/iterable_functions/dictionary_operations/sort_subdict_by_tuple.py
@@ -10,14 +10,14 @@ def sort_subdict_by_tuple(
 
     Parameters
     ----------
-    dict_ : Dict[str, Dict[str, Any]]
+    dict_ : dict[str, dict[str, Any]]
         The input dictionary containing sub-dictionaries as values.
-    order : Tuple[str, ...]
+    order : tuple[str, ...]
         A tuple specifying the desired order of keys in the sorted sub-dictionaries.
 
     Returns
     -------
-    Dict[str, OrderedDict]
+    dict[str, OrderedDict[str, Any]]
         A new dictionary with each sub-dictionary sorted according to the specified order.
 
     Raises

--- a/iterable_functions/list_operations/chunk_by_size.py
+++ b/iterable_functions/list_operations/chunk_by_size.py
@@ -15,14 +15,14 @@ def chunk_by_size(items: list[T], chunk_size: int) -> list[list[T]]:
 
     Parameters
     ----------
-    items : List[T]
+    items : list[T]
         The list to be chunked.
     chunk_size : int
         The size of each chunk.
 
     Returns
     -------
-    List[List[T]]
+    list[List[T]]
         List of chunks, where each chunk is a list of items.
 
     Raises

--- a/iterable_functions/list_operations/find_duplicates.py
+++ b/iterable_functions/list_operations/find_duplicates.py
@@ -17,12 +17,12 @@ def find_duplicates(items: list[T]) -> dict[T, int]:
 
     Parameters
     ----------
-    items : List[T]
+    items : list[T]
         The list to analyze for duplicates.
 
     Returns
     -------
-    Dict[T, int]
+    dict[T, int]
         Dictionary mapping duplicate elements to their occurrence counts.
         Only elements that appear more than once are included.
 

--- a/iterable_functions/list_operations/group_by.py
+++ b/iterable_functions/list_operations/group_by.py
@@ -20,7 +20,7 @@ def group_by(
 
     Parameters
     ----------
-    items : List[T]
+    items : list[T]
         The list of items to group.
     key_func : Callable[[T], K] | None, optional
         Function to extract the grouping key from each item.
@@ -28,7 +28,7 @@ def group_by(
 
     Returns
     -------
-    Dict[K, List[T]]
+    dict[K, list[T]]
         Dictionary where keys are the grouping values and values are lists of items.
 
     Raises

--- a/iterable_functions/list_operations/sliding_window.py
+++ b/iterable_functions/list_operations/sliding_window.py
@@ -16,14 +16,14 @@ def sliding_window(items: list[T], window_size: int) -> Iterator[list[T]]:
 
     Parameters
     ----------
-    items : List[T]
+    items : list[T]
         The list to create windows from.
     window_size : int
         The size of each window.
 
     Yields
     ------
-    List[T]
+    list[T]
         Sliding windows of the specified size.
 
     Raises

--- a/iterable_functions/set_operations/count_combinations.py
+++ b/iterable_functions/set_operations/count_combinations.py
@@ -18,7 +18,7 @@ def count_combinations(input_set: set[T], r: int) -> int:
 
     Parameters
     ----------
-    input_set : Set[T]
+    input_set : set[T]
         The input set.
     r : int
         The number of elements in each combination.

--- a/iterable_functions/set_operations/get_combinations.py
+++ b/iterable_functions/set_operations/get_combinations.py
@@ -18,14 +18,14 @@ def get_combinations(input_set: set[T], r: int) -> list[list[T]]:
 
     Parameters
     ----------
-    input_set : Set[T]
+    input_set : set[T]
         The input set to generate combinations from.
     r : int
         The number of elements in each combination.
 
     Returns
     -------
-    List[List[T]]
+    list[List[T]]
         List of all combinations, where each combination is a sorted list.
 
     Raises

--- a/iterable_functions/set_operations/get_combinations_with_replacement.py
+++ b/iterable_functions/set_operations/get_combinations_with_replacement.py
@@ -18,14 +18,14 @@ def get_combinations_with_replacement(input_set: set[T], r: int) -> list[list[T]
 
     Parameters
     ----------
-    input_set : Set[T]
+    input_set : set[T]
         The input set to generate combinations from.
     r : int
         The number of elements in each combination.
 
     Returns
     -------
-    List[List[T]]
+    list[List[T]]
         List of all combinations with replacement, sorted lexicographically.
 
     Raises

--- a/iterable_functions/set_operations/get_permutations.py
+++ b/iterable_functions/set_operations/get_permutations.py
@@ -18,14 +18,14 @@ def get_permutations(input_set: set[T], r: int | None = None) -> list[list[T]]:
 
     Parameters
     ----------
-    input_set : Set[T]
+    input_set : set[T]
         The input set to generate permutations from.
     r : int | None, optional
         The number of elements in each permutation. If None, uses all elements.
 
     Returns
     -------
-    List[List[T]]
+    list[List[T]]
         List of all permutations, sorted lexicographically.
 
     Raises

--- a/iterable_functions/set_operations/get_set_partitions.py
+++ b/iterable_functions/set_operations/get_set_partitions.py
@@ -18,14 +18,14 @@ def get_set_partitions(input_set: set[T], k: int) -> list[list[set[T]]]:
 
     Parameters
     ----------
-    input_set : Set[T]
+    input_set : set[T]
         The input set to partition.
     k : int
         Number of subsets to partition into.
 
     Returns
     -------
-    List[List[Set[T]]]
+    list[List[set[T]]]
         List of all possible partitions, where each partition is a list of k subsets.
 
     Raises

--- a/iterable_functions/set_operations/get_subsets_of_size.py
+++ b/iterable_functions/set_operations/get_subsets_of_size.py
@@ -15,14 +15,14 @@ def get_subsets_of_size(input_set: set[T], size: int) -> list[list[T]]:
 
     Parameters
     ----------
-    input_set : Set[T]
+    input_set : set[T]
         The input set to generate subsets from.
     size : int
         The desired size of subsets.
 
     Returns
     -------
-    List[List[T]]
+    list[List[T]]
         List of subsets of the specified size, sorted lexicographically.
 
     Raises

--- a/iterable_functions/set_operations/get_unique_elements_across_sets.py
+++ b/iterable_functions/set_operations/get_unique_elements_across_sets.py
@@ -18,12 +18,12 @@ def get_unique_elements_across_sets(*sets: set[T]) -> list[T]:
 
     Parameters
     ----------
-    *sets : Set[T]
+    *sets : set[T]
         Variable number of sets to analyze.
 
     Returns
     -------
-    List[T]
+    list[T]
         List of elements that appear in exactly one set.
 
     Raises
@@ -71,12 +71,12 @@ def set_symmetric_difference(*sets: set[T]) -> set[T]:
 
     Parameters
     ----------
-    *sets : Set[T]
+    *sets : set[T]
         Variable number of sets to compute symmetric difference.
 
     Returns
     -------
-    Set[T]
+    set[T]
         Symmetric difference of all input sets.
 
     Raises

--- a/iterable_functions/set_operations/partition_set_by_sizes.py
+++ b/iterable_functions/set_operations/partition_set_by_sizes.py
@@ -15,14 +15,14 @@ def partition_set_by_sizes(input_set: set[T], sizes: list[int]) -> list[set[T]]:
 
     Parameters
     ----------
-    input_set : Set[T]
+    input_set : set[T]
         The set to partition.
-    sizes : List[int]
+    sizes : list[int]
         List of subset sizes. Sum must equal len(input_set).
 
     Returns
     -------
-    List[Set[T]]
+    list[set[T]]
         List of subsets with the specified sizes.
 
     Raises

--- a/iterable_functions/set_operations/partition_set_into_n_parts.py
+++ b/iterable_functions/set_operations/partition_set_into_n_parts.py
@@ -17,14 +17,14 @@ def partition_set_into_n_parts(input_set: set[T], n: int) -> list[set[T]]:
 
     Parameters
     ----------
-    input_set : Set[T]
+    input_set : set[T]
         The input set to partition.
     n : int
         Number of partitions to create.
 
     Returns
     -------
-    List[Set[T]]
+    list[set[T]]
         List of n subsets. The union of all subsets equals the input set,
         and all subsets are pairwise disjoint.
 

--- a/iterable_functions/set_operations/set_cartesian_product.py
+++ b/iterable_functions/set_operations/set_cartesian_product.py
@@ -19,12 +19,12 @@ def set_cartesian_product(*sets: set[T]) -> set[tuple[T, ...]]:
 
     Parameters
     ----------
-    *sets : Set[T]
+    *sets : set[T]
         Variable number of sets to compute cartesian product.
 
     Returns
     -------
-    Set[Tuple[T, ...]]
+    set[tuple[T, ...]]
         Set of tuples representing the cartesian product.
 
     Raises

--- a/iterable_functions/set_operations/set_cartesian_product_as_list.py
+++ b/iterable_functions/set_operations/set_cartesian_product_as_list.py
@@ -19,12 +19,12 @@ def set_cartesian_product_as_list(*sets: set[T]) -> list[tuple[T, ...]]:
 
     Parameters
     ----------
-    *sets : Set[T]
+    *sets : set[T]
         Variable number of sets to compute cartesian product.
 
     Returns
     -------
-    List[Tuple[T, ...]]
+    list[tuple[T, ...]]
         List of tuples representing the cartesian product.
 
     Raises

--- a/iterable_functions/set_operations/set_partition.py
+++ b/iterable_functions/set_operations/set_partition.py
@@ -18,14 +18,14 @@ def partition_set_by_predicate(input_set: set[T], predicate) -> tuple[set[T], se
 
     Parameters
     ----------
-    input_set : Set[T]
+    input_set : set[T]
         The input set to partition.
     predicate : callable
         Function that takes an element and returns True or False.
 
     Returns
     -------
-    Tuple[Set[T], Set[T]]
+    tuple[set[T], set[T]]
         Tuple of (true_set, false_set) where true_set contains elements
         where predicate(element) is True, and false_set contains elements
         where predicate(element) is False.

--- a/iterable_functions/set_operations/set_power_set.py
+++ b/iterable_functions/set_operations/set_power_set.py
@@ -18,12 +18,12 @@ def set_power_set(input_set: set[T]) -> set[frozenset[T]]:
 
     Parameters
     ----------
-    input_set : Set[T]
+    input_set : set[T]
         The input set to generate power set for.
 
     Returns
     -------
-    Set[FrozenSet[T]]
+    set[FrozenSet[T]]
         Power set of the input set, where each subset is a frozenset.
 
     Raises

--- a/iterable_functions/set_operations/set_power_set_as_lists.py
+++ b/iterable_functions/set_operations/set_power_set_as_lists.py
@@ -17,12 +17,12 @@ def set_power_set_as_lists(input_set: set[T]) -> list[list[T]]:
 
     Parameters
     ----------
-    input_set : Set[T]
+    input_set : set[T]
         The input set to generate power set for.
 
     Returns
     -------
-    List[List[T]]
+    list[List[T]]
         Power set as a list of lists, sorted by subset size and lexicographically.
 
     Raises

--- a/iterable_functions/set_operations/set_symmetric_difference.py
+++ b/iterable_functions/set_operations/set_symmetric_difference.py
@@ -18,12 +18,12 @@ def set_symmetric_difference(*sets: set[T]) -> set[T]:
 
     Parameters
     ----------
-    *sets : Set[T]
+    *sets : set[T]
         Variable number of sets to compute symmetric difference.
 
     Returns
     -------
-    Set[T]
+    set[T]
         Symmetric difference of all input sets.
 
     Raises
@@ -89,12 +89,12 @@ def get_unique_elements_across_sets(*sets: set[T]) -> list[T]:
 
     Parameters
     ----------
-    *sets : Set[T]
+    *sets : set[T]
         Variable number of sets to analyze.
 
     Returns
     -------
-    List[T]
+    list[T]
         List of elements that appear in exactly one set.
 
     Raises

--- a/multiprocessing_functions/parallel_accumulate.py
+++ b/multiprocessing_functions/parallel_accumulate.py
@@ -26,7 +26,7 @@ def parallel_accumulate(
     ----------
     func : Callable[[T, T], T]
         The function to combine two elements into one cumulative value.
-    data : List[T]
+    data : list[T]
         The list of data items to process.
     num_processes : int | None, optional
         The number of processes to use for parallel execution. If None, it defaults
@@ -36,7 +36,7 @@ def parallel_accumulate(
 
     Returns
     -------
-    List[T]
+    list[T]
         The list of cumulative results.
 
     Examples

--- a/multiprocessing_functions/parallel_apply_with_args.py
+++ b/multiprocessing_functions/parallel_apply_with_args.py
@@ -20,7 +20,7 @@ def parallel_apply_with_args(
     ----------
     func : Callable[[T, Any], R]
         The function to apply to each item in the list.
-    data : List[T]
+    data : list[T]
         The list of data items to process.
     args : Tuple, optional
         Additional arguments to pass to the function (by default an empty tuple).
@@ -30,7 +30,7 @@ def parallel_apply_with_args(
 
     Returns
     -------
-    List[R]
+    list[R]
         The list of results after applying the function to each item with the additional arguments in parallel.
 
     Examples

--- a/multiprocessing_functions/parallel_broadcast.py
+++ b/multiprocessing_functions/parallel_broadcast.py
@@ -19,7 +19,7 @@ def parallel_broadcast(
         The function to apply to each item in the list. It takes two arguments: the item and the shared input.
     shared_input : T
         The shared input to broadcast to all processes.
-    data : List[T]
+    data : list[T]
         The list of data items to process.
     num_processes : int | None, optional
         The number of processes to use for parallel execution. If None, it defaults
@@ -27,7 +27,7 @@ def parallel_broadcast(
 
     Returns
     -------
-    List[R]
+    list[R]
         The list of results after applying the function to each item with the shared input.
 
     Examples

--- a/multiprocessing_functions/parallel_dynamic_distribute.py
+++ b/multiprocessing_functions/parallel_dynamic_distribute.py
@@ -20,7 +20,7 @@ def parallel_dynamic_distribute(
     ----------
     func : Callable[[T], R]
         The function to apply to each item in the list.
-    data : List[T]
+    data : list[T]
         The list of data items to process.
     num_processes : int | None, optional
         The number of processes to use for parallel execution. If None, it defaults
@@ -30,7 +30,7 @@ def parallel_dynamic_distribute(
 
     Returns
     -------
-    List[R]
+    list[R]
         The list of results after applying the function to each item in parallel.
 
     Examples

--- a/multiprocessing_functions/parallel_filter.py
+++ b/multiprocessing_functions/parallel_filter.py
@@ -16,7 +16,7 @@ def parallel_filter(
     ----------
     condition : Callable[[T], bool]
         A function that takes an item as input and returns `True` if the item should be kept, `False` otherwise.
-    data : List[T]
+    data : list[T]
         The list of data items to filter.
     num_processes : int | None, optional
         The number of processes to use for parallel execution. If None, it defaults
@@ -24,7 +24,7 @@ def parallel_filter(
 
     Returns
     -------
-    List[T]
+    list[T]
         A list containing only the items that satisfy the condition.
 
     Examples

--- a/multiprocessing_functions/parallel_gather_errors.py
+++ b/multiprocessing_functions/parallel_gather_errors.py
@@ -17,7 +17,7 @@ def parallel_gather_errors(
     ----------
     func : Callable[[T], R]
         The function to apply to each item in the list.
-    data : List[T]
+    data : list[T]
         The list of data items to process.
     num_processes : int | None, optional
         The number of processes to use for parallel execution. If None, it defaults
@@ -25,7 +25,7 @@ def parallel_gather_errors(
 
     Returns
     -------
-    Tuple[List[R], List[Exception]]
+    tuple[list[R], list[Exception]]
         A tuple containing the list of results and the list of exceptions. If an exception occurs
         for an item, its corresponding result is not included in the result list.
 

--- a/multiprocessing_functions/parallel_map.py
+++ b/multiprocessing_functions/parallel_map.py
@@ -16,7 +16,7 @@ def parallel_map(
     ----------
     func : Callable[[T], R]
         The function to apply to each item in the list.
-    data : List[T]
+    data : list[T]
         The list of data items to process.
     num_processes : int | None, optional
         The number of processes to use for parallel execution. If ``None``,
@@ -25,7 +25,7 @@ def parallel_map(
 
     Returns
     -------
-    List[R]
+    list[R]
         The list of results after applying the function to each item in parallel.
 
     Examples

--- a/multiprocessing_functions/parallel_pipeline.py
+++ b/multiprocessing_functions/parallel_pipeline.py
@@ -23,9 +23,9 @@ def parallel_pipeline(
 
     Parameters
     ----------
-    funcs : List[Callable[[T], T]]
+    funcs : list[Callable[[T], T]]
         A list of functions to apply sequentially to each item.
-    data : List[T]
+    data : list[T]
         The list of data items to process.
     num_processes : int | None, optional
         The number of processes to use for parallel execution. If None, it defaults
@@ -33,7 +33,7 @@ def parallel_pipeline(
 
     Returns
     -------
-    List[R]
+    list[R]
         The list of results after applying the pipeline of functions to each item.
 
     Examples

--- a/multiprocessing_functions/parallel_progress_bar.py
+++ b/multiprocessing_functions/parallel_progress_bar.py
@@ -18,7 +18,7 @@ def parallel_progress_bar(
     ----------
     func : Callable[[T], R]
         The function to apply to each item in the list.
-    data : List[T]
+    data : list[T]
         The list of data items to process.
     num_processes : int | None, optional
         The number of processes to use for parallel execution. If ``None``,
@@ -27,7 +27,7 @@ def parallel_progress_bar(
 
     Returns
     -------
-    List[R]
+    list[R]
         The list of results after applying the function to each item in parallel.
 
     Examples

--- a/multiprocessing_functions/parallel_reduce.py
+++ b/multiprocessing_functions/parallel_reduce.py
@@ -26,7 +26,7 @@ def parallel_reduce(
     ----------
     func : Callable[[T, T], T]
         A function that takes two elements and returns a single value.
-    data : List[T]
+    data : list[T]
         The list of data items to reduce.
     num_processes : int | None, optional
         The number of processes to use for parallel execution. If None, it defaults

--- a/multiprocessing_functions/parallel_sort.py
+++ b/multiprocessing_functions/parallel_sort.py
@@ -25,7 +25,7 @@ def parallel_sort(
 
     Parameters
     ----------
-    data : List[int]
+    data : list[int]
         The list of integers to sort.
     num_processes : int | None, optional
         The number of processes to use for parallel execution. If None, it defaults
@@ -35,7 +35,7 @@ def parallel_sort(
 
     Returns
     -------
-    List[int]
+    list[int]
         The sorted list of integers.
 
     Examples

--- a/multiprocessing_functions/parallel_starmap.py
+++ b/multiprocessing_functions/parallel_starmap.py
@@ -15,7 +15,7 @@ def parallel_starmap(
     ----------
     func : Callable[..., R]
         The function to apply to each set of arguments.
-    data : List[Tuple]
+    data : list[Tuple]
         A list of tuples, where each tuple contains the arguments for the function.
     num_processes : int | None, optional
         The number of processes to use for parallel execution. If None, it defaults
@@ -23,7 +23,7 @@ def parallel_starmap(
 
     Returns
     -------
-    List[R]
+    list[R]
         The list of results after applying the function to each set of arguments in parallel.
 
     Examples

--- a/multiprocessing_functions/parallel_unique.py
+++ b/multiprocessing_functions/parallel_unique.py
@@ -18,7 +18,7 @@ def parallel_unique(
 
     Parameters
     ----------
-    data : List[T]
+    data : list[T]
         The list of data items to process.
     num_processes : int | None, optional
         The number of processes to use for parallel execution. If None, it defaults
@@ -28,7 +28,7 @@ def parallel_unique(
 
     Returns
     -------
-    List[T]
+    list[T]
         A list containing the unique elements from the input list.
 
     Examples

--- a/security_functions/token_generation/generate_jwt_token.py
+++ b/security_functions/token_generation/generate_jwt_token.py
@@ -23,7 +23,7 @@ def generate_jwt_token(
 
     Parameters
     ----------
-    payload : Dict[str, Any]
+    payload : dict[str, Any]
         The payload data to include in the JWT token.
     secret_key : str
         The secret key used for signing the token.

--- a/security_functions/token_generation/verify_jwt_token.py
+++ b/security_functions/token_generation/verify_jwt_token.py
@@ -29,7 +29,7 @@ def verify_jwt_token(
 
     Returns
     -------
-    Dict[str, Any]
+    dict[str, Any]
         The decoded payload if the token is valid.
 
     Raises

--- a/strings_utility/replace_multiple_substrings.py
+++ b/strings_utility/replace_multiple_substrings.py
@@ -6,7 +6,7 @@ def replace_multiple_substrings(s: str, replacements: dict[str, str]) -> str:
     ----------
     s : str
         The input string.
-    replacements : Dict[str, str]
+    replacements : dict[str, str]
         A dictionary where keys are substrings to be replaced and values are the replacements.
 
     Returns

--- a/strings_utility/split_string.py
+++ b/strings_utility/split_string.py
@@ -11,7 +11,7 @@ def split_string(s: str, delimiter: str = " ") -> list[str]:
 
     Returns
     -------
-    List[str]
+    list[str]
         A list of substrings.
 
     Raises


### PR DESCRIPTION
## Summary
- replace deprecated `typing` collection aliases with built-in generics
- use `| None` syntax instead of `Optional`
- update typing in documentation and auxiliary helpers

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'file_functions.file_operations.write_to_file')*

------
https://chatgpt.com/codex/tasks/task_e_68c1903da6fc8325aefd8d61ec2ad635