### PR TITLE
Refactor typing usage

### DIFF
--- a/data_types/hash_table.py
+++ b/data_types/hash_table.py
@@ -13,7 +13,7 @@ class HashTable(Generic[K, V]):
     ----------
     size : int
         The number of buckets in the hash table.
-    table : list[List[tuple[K, V]]]
+    table : list[list[tuple[K, V]]]
         The list of buckets where each bucket stores key-value pairs as tuples.
 
     Methods

--- a/datetime_functions/__init__.py
+++ b/datetime_functions/__init__.py
@@ -18,7 +18,7 @@ from .days_between import days_between
 from .calculate_age import calculate_age
 from .compare_dates import compare_dates
 from .get_current_datetime_iso_utc import get_current_datetime_iso_utc
-from .get_date_parts import get_date_parts, DateParts
+from .get_date_parts import get_date_parts
 from .get_days_in_month import get_days_in_month
 from .get_days_of_week import get_days_of_week
 from .get_end_of_month import get_end_of_month
@@ -49,7 +49,6 @@ __all__ = [
     'get_current_datetime_iso_utc',
     'get_current_datetime_iso_utc',
     'get_date_parts',
-    'DateParts',
     'get_days_in_month',
     'get_days_of_week',
     'get_end_of_month',

--- a/datetime_functions/get_date_parts.py
+++ b/datetime_functions/get_date_parts.py
@@ -1,42 +1,38 @@
 """Get date parts from a date object."""
 
 from datetime import datetime, date
-from typing import NamedTuple
 
 
-class DateParts(NamedTuple):
-    """Named tuple for date parts."""
-    year: int
-    month: int
-    day: int
-    weekday: int  # 0=Monday, 6=Sunday
-    day_of_year: int
+def get_date_parts(date_obj: datetime | date) -> dict[str, int]:
+    """Return key date attributes in a dictionary.
 
+    Parameters
+    ----------
+    date_obj : datetime | date
+        The date object to extract parts from.
 
-def get_date_parts(date_obj: datetime | date) -> DateParts:
-    """
-    Get various parts of a date as a named tuple.
-    
-    Args:
-        date_obj: The date object to extract parts from
-        
-    Returns:
-        DateParts named tuple with year, month, day, weekday, day_of_year
-        
-    Raises:
-        TypeError: If date_obj is not a datetime or date object
+    Returns
+    -------
+    dict[str, int]
+        Dictionary containing ``year``, ``month``, ``day``, ``weekday``
+        (0=Monday) and ``day_of_year``.
+
+    Raises
+    ------
+    TypeError
+        If ``date_obj`` is not a ``datetime`` or ``date`` instance.
     """
     if not isinstance(date_obj, (datetime, date)):
         raise TypeError("date_obj must be a datetime or date object")
-    
+
     # Convert datetime to date if needed
     if isinstance(date_obj, datetime):
         date_obj = date_obj.date()
-    
-    return DateParts(
-        year=date_obj.year,
-        month=date_obj.month,
-        day=date_obj.day,
-        weekday=date_obj.weekday(),
-        day_of_year=date_obj.timetuple().tm_yday
-    )
+
+    return {
+        "year": date_obj.year,
+        "month": date_obj.month,
+        "day": date_obj.day,
+        "weekday": date_obj.weekday(),
+        "day_of_year": date_obj.timetuple().tm_yday,
+    }

--- a/file_functions/data_format_operations/read_tabular.py
+++ b/file_functions/data_format_operations/read_tabular.py
@@ -14,8 +14,9 @@ def read_tabular(input_file: str, delimiter: str = "\t") -> list[list[str]]:
 
     Returns
     -------
-    list[List[str]]
-        A list with a sublist per line in the input file. Each sublist has the fields that were separated by the defined delimiter.
+    list[list[str]]
+        A list with a sublist per line in the input file. Each sublist has
+        the fields that were separated by the defined delimiter.
     """
     with open(input_file) as infile:
         reader = csv.reader(infile, delimiter=delimiter)

--- a/iterable_functions/list_operations/chunk_by_size.py
+++ b/iterable_functions/list_operations/chunk_by_size.py
@@ -22,7 +22,7 @@ def chunk_by_size(items: list[T], chunk_size: int) -> list[list[T]]:
 
     Returns
     -------
-    list[List[T]]
+    list[list[T]]
         List of chunks, where each chunk is a list of items.
 
     Raises

--- a/iterable_functions/set_operations/get_combinations.py
+++ b/iterable_functions/set_operations/get_combinations.py
@@ -25,7 +25,7 @@ def get_combinations(input_set: set[T], r: int) -> list[list[T]]:
 
     Returns
     -------
-    list[List[T]]
+    list[list[T]]
         List of all combinations, where each combination is a sorted list.
 
     Raises

--- a/iterable_functions/set_operations/get_combinations_with_replacement.py
+++ b/iterable_functions/set_operations/get_combinations_with_replacement.py
@@ -25,7 +25,7 @@ def get_combinations_with_replacement(input_set: set[T], r: int) -> list[list[T]
 
     Returns
     -------
-    list[List[T]]
+    list[list[T]]
         List of all combinations with replacement, sorted lexicographically.
 
     Raises

--- a/iterable_functions/set_operations/get_permutations.py
+++ b/iterable_functions/set_operations/get_permutations.py
@@ -25,7 +25,7 @@ def get_permutations(input_set: set[T], r: int | None = None) -> list[list[T]]:
 
     Returns
     -------
-    list[List[T]]
+    list[list[T]]
         List of all permutations, sorted lexicographically.
 
     Raises

--- a/iterable_functions/set_operations/get_set_partitions.py
+++ b/iterable_functions/set_operations/get_set_partitions.py
@@ -25,8 +25,9 @@ def get_set_partitions(input_set: set[T], k: int) -> list[list[set[T]]]:
 
     Returns
     -------
-    list[List[set[T]]]
-        List of all possible partitions, where each partition is a list of k subsets.
+    list[list[set[T]]]
+        List of all possible partitions, where each partition is a list of
+        ``k`` subsets.
 
     Raises
     ------

--- a/iterable_functions/set_operations/get_subsets_of_size.py
+++ b/iterable_functions/set_operations/get_subsets_of_size.py
@@ -22,7 +22,7 @@ def get_subsets_of_size(input_set: set[T], size: int) -> list[list[T]]:
 
     Returns
     -------
-    list[List[T]]
+    list[list[T]]
         List of subsets of the specified size, sorted lexicographically.
 
     Raises

--- a/iterable_functions/set_operations/set_power_set_as_lists.py
+++ b/iterable_functions/set_operations/set_power_set_as_lists.py
@@ -22,8 +22,9 @@ def set_power_set_as_lists(input_set: set[T]) -> list[list[T]]:
 
     Returns
     -------
-    list[List[T]]
-        Power set as a list of lists, sorted by subset size and lexicographically.
+    list[list[T]]
+        Power set as a list of lists, sorted by subset size and
+        lexicographically.
 
     Raises
     ------

--- a/pytest/unit/datetime_functions/test_get_date_parts.py
+++ b/pytest/unit/datetime_functions/test_get_date_parts.py
@@ -1,5 +1,7 @@
+from datetime import date, datetime
+
 import pytest
-from datetime import datetime, date
+
 from datetime_functions.get_date_parts import get_date_parts
 
 


### PR DESCRIPTION
## Summary
- replace get_date_parts NamedTuple with plain dict
- remove deprecated typing mentions in docstrings and hash table
- clean up date parts unit test imports

## Testing
- `pytest` *(fails: 59 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c00e4e588325b49cc67d4309cd40