### PR TITLE
Standardize unit test docstrings

### DIFF
--- a/pytest/unit/data_types/test_union_find.py
+++ b/pytest/unit/data_types/test_union_find.py
@@ -2,6 +2,9 @@ from data_types.union_find import UnionFind
 
 
 def test_find_initializes_new_element():
+    """
+    Test case 1: Find initializes new element.
+    """
     uf: UnionFind[int] = UnionFind()
 
     assert uf.find(42) == 42
@@ -10,6 +13,9 @@ def test_find_initializes_new_element():
 
 
 def test_find_handles_multiple_new_elements():
+    """
+    Test case 2: Find handles multiple new elements.
+    """
     uf: UnionFind[str] = UnionFind()
 
     assert uf.find("alpha") == "alpha"

--- a/pytest/unit/env_config_functions/test_parse_ini_config.py
+++ b/pytest/unit/env_config_functions/test_parse_ini_config.py
@@ -14,7 +14,7 @@ def write_ini_file(data, path):
 
 def test_parse_ini_config_basic(tmp_path):
     """
-    Test case 1: Basic INI config loads as dict
+    Test case 1: Basic INI config loads as dict.
     """
     data = {"section1": {"a": "1"}, "section2": {"b": "2"}}
     config_file = tmp_path / "config.ini"
@@ -25,7 +25,7 @@ def test_parse_ini_config_basic(tmp_path):
 
 def test_parse_ini_config_required_sections(tmp_path):
     """
-    Test case 2: Missing required sections raises ValueError
+    Test case 2: Missing required sections raises ValueError.
     """
     data = {"section1": {"a": "1"}}
     config_file = tmp_path / "config.ini"
@@ -36,7 +36,7 @@ def test_parse_ini_config_required_sections(tmp_path):
 
 def test_parse_ini_config_schema_validator(tmp_path):
     """
-    Test case 3: Custom schema validator raises ValueError
+    Test case 3: Custom schema validator raises ValueError.
     """
     data = {"section1": {"a": "1"}}
 
@@ -51,7 +51,9 @@ def test_parse_ini_config_schema_validator(tmp_path):
 
 
 def test_parse_ini_config_file_not_found(tmp_path):
-    """Test that missing INI files raise FileNotFoundError."""
+    """
+    Test case 4: Missing INI files raise FileNotFoundError.
+    """
 
     missing_file = tmp_path / "missing.ini"
 

--- a/pytest/unit/http_functions/test_extract_domain.py
+++ b/pytest/unit/http_functions/test_extract_domain.py
@@ -22,7 +22,7 @@ def test_extract_domain_invalid_url(mock_is_valid_url):
 @patch("http_functions.extract_domain.is_valid_url")
 def test_extract_domain_simple_url(mock_is_valid_url):
     """
-    Test extract_domain function with simple valid URL returns hostname.
+    Test case 2: Extract_domain function with simple valid URL returns hostname.
     """
     mock_is_valid_url.return_value = True
 
@@ -33,7 +33,7 @@ def test_extract_domain_simple_url(mock_is_valid_url):
 @patch("http_functions.extract_domain.is_valid_url")
 def test_extract_domain_with_www_subdomain(mock_is_valid_url):
     """
-    Test extract_domain function with www subdomain returns full hostname.
+    Test case 3: Extract_domain function with www subdomain returns full hostname.
     """
     mock_is_valid_url.return_value = True
 
@@ -44,7 +44,7 @@ def test_extract_domain_with_www_subdomain(mock_is_valid_url):
 @patch("http_functions.extract_domain.is_valid_url")
 def test_extract_domain_with_complex_subdomain(mock_is_valid_url):
     """
-    Test extract_domain function with complex subdomain returns full hostname.
+    Test case 4: Extract_domain function with complex subdomain returns full hostname.
     """
     mock_is_valid_url.return_value = True
 
@@ -55,7 +55,7 @@ def test_extract_domain_with_complex_subdomain(mock_is_valid_url):
 @patch("http_functions.extract_domain.is_valid_url")
 def test_extract_domain_with_port(mock_is_valid_url):
     """
-    Test extract_domain function with port returns hostname without port.
+    Test case 5: Extract_domain function with port returns hostname without port.
     """
     mock_is_valid_url.return_value = True
 
@@ -66,7 +66,7 @@ def test_extract_domain_with_port(mock_is_valid_url):
 @patch("http_functions.extract_domain.is_valid_url")
 def test_extract_domain_localhost_with_port(mock_is_valid_url):
     """
-    Test extract_domain function with localhost and port returns hostname.
+    Test case 6: Extract_domain function with localhost and port returns hostname.
     """
     mock_is_valid_url.return_value = True
 
@@ -77,7 +77,7 @@ def test_extract_domain_localhost_with_port(mock_is_valid_url):
 @patch("http_functions.extract_domain.is_valid_url")
 def test_extract_domain_with_path(mock_is_valid_url):
     """
-    Test extract_domain function with path returns hostname only.
+    Test case 7: Extract_domain function with path returns hostname only.
     """
     mock_is_valid_url.return_value = True
 
@@ -88,7 +88,7 @@ def test_extract_domain_with_path(mock_is_valid_url):
 @patch("http_functions.extract_domain.is_valid_url")
 def test_extract_domain_with_long_path(mock_is_valid_url):
     """
-    Test extract_domain function with long path returns hostname only.
+    Test case 8: Extract_domain function with long path returns hostname only.
     """
     mock_is_valid_url.return_value = True
 
@@ -99,7 +99,7 @@ def test_extract_domain_with_long_path(mock_is_valid_url):
 @patch("http_functions.extract_domain.is_valid_url")
 def test_extract_domain_with_query_parameters(mock_is_valid_url):
     """
-    Test extract_domain function with query parameters returns hostname only.
+    Test case 9: Extract_domain function with query parameters returns hostname only.
     """
     mock_is_valid_url.return_value = True
 
@@ -110,7 +110,7 @@ def test_extract_domain_with_query_parameters(mock_is_valid_url):
 @patch("http_functions.extract_domain.is_valid_url")
 def test_extract_domain_with_fragment(mock_is_valid_url):
     """
-    Test extract_domain function with fragment returns hostname only.
+    Test case 10: Extract_domain function with fragment returns hostname only.
     """
     mock_is_valid_url.return_value = True
 
@@ -121,7 +121,7 @@ def test_extract_domain_with_fragment(mock_is_valid_url):
 @patch("http_functions.extract_domain.is_valid_url")
 def test_extract_domain_with_query_and_fragment(mock_is_valid_url):
     """
-    Test extract_domain function with query and fragment returns hostname only.
+    Test case 11: Extract_domain function with query and fragment returns hostname only.
     """
     mock_is_valid_url.return_value = True
 
@@ -132,7 +132,7 @@ def test_extract_domain_with_query_and_fragment(mock_is_valid_url):
 @patch("http_functions.extract_domain.is_valid_url")
 def test_extract_domain_with_username_and_password(mock_is_valid_url):
     """
-    Test extract_domain function with authentication returns hostname only.
+    Test case 12: Extract_domain function with authentication returns hostname only.
     """
     mock_is_valid_url.return_value = True
 
@@ -143,7 +143,7 @@ def test_extract_domain_with_username_and_password(mock_is_valid_url):
 @patch("http_functions.extract_domain.is_valid_url")
 def test_extract_domain_ftp_with_username(mock_is_valid_url):
     """
-    Test extract_domain function with FTP and username returns hostname only.
+    Test case 13: Extract_domain function with FTP and username returns hostname only.
     """
     mock_is_valid_url.return_value = True
 
@@ -154,7 +154,7 @@ def test_extract_domain_ftp_with_username(mock_is_valid_url):
 @patch("http_functions.extract_domain.is_valid_url")
 def test_extract_domain_with_ipv4_address(mock_is_valid_url):
     """
-    Test extract_domain function with IPv4 address returns IP address.
+    Test case 14: Extract_domain function with IPv4 address returns IP address.
     """
     mock_is_valid_url.return_value = True
 
@@ -165,7 +165,7 @@ def test_extract_domain_with_ipv4_address(mock_is_valid_url):
 @patch("http_functions.extract_domain.is_valid_url")
 def test_extract_domain_with_ipv4_and_port(mock_is_valid_url):
     """
-    Test extract_domain function with IPv4 and port returns IP only.
+    Test case 15: Extract_domain function with IPv4 and port returns IP only.
     """
     mock_is_valid_url.return_value = True
 
@@ -176,7 +176,7 @@ def test_extract_domain_with_ipv4_and_port(mock_is_valid_url):
 @patch("http_functions.extract_domain.is_valid_url")
 def test_extract_domain_with_ipv4_and_path(mock_is_valid_url):
     """
-    Test extract_domain function with IPv4 and path returns IP only.
+    Test case 16: Extract_domain function with IPv4 and path returns IP only.
     """
     mock_is_valid_url.return_value = True
 
@@ -187,7 +187,7 @@ def test_extract_domain_with_ipv4_and_path(mock_is_valid_url):
 @patch("http_functions.extract_domain.is_valid_url")
 def test_extract_domain_https_scheme(mock_is_valid_url):
     """
-    Test extract_domain function with HTTPS scheme returns hostname.
+    Test case 17: Extract_domain function with HTTPS scheme returns hostname.
     """
     mock_is_valid_url.return_value = True
 
@@ -198,7 +198,7 @@ def test_extract_domain_https_scheme(mock_is_valid_url):
 @patch("http_functions.extract_domain.is_valid_url")
 def test_extract_domain_http_scheme(mock_is_valid_url):
     """
-    Test extract_domain function with HTTP scheme returns hostname.
+    Test case 18: Extract_domain function with HTTP scheme returns hostname.
     """
     mock_is_valid_url.return_value = True
 
@@ -209,7 +209,7 @@ def test_extract_domain_http_scheme(mock_is_valid_url):
 @patch("http_functions.extract_domain.is_valid_url")
 def test_extract_domain_ftp_scheme(mock_is_valid_url):
     """
-    Test extract_domain function with FTP scheme returns hostname.
+    Test case 19: Extract_domain function with FTP scheme returns hostname.
     """
     mock_is_valid_url.return_value = True
 
@@ -220,7 +220,7 @@ def test_extract_domain_ftp_scheme(mock_is_valid_url):
 @patch("http_functions.extract_domain.is_valid_url")
 def test_extract_domain_file_scheme(mock_is_valid_url):
     """
-    Test extract_domain function with file scheme returns hostname.
+    Test case 20: Extract_domain function with file scheme returns hostname.
     """
     mock_is_valid_url.return_value = True
 
@@ -231,7 +231,7 @@ def test_extract_domain_file_scheme(mock_is_valid_url):
 @patch("http_functions.extract_domain.is_valid_url")
 def test_extract_domain_complex_url(mock_is_valid_url):
     """
-    Test extract_domain function with complex URL returns hostname only.
+    Test case 21: Extract_domain function with complex URL returns hostname only.
     """
     mock_is_valid_url.return_value = True
 
@@ -242,7 +242,7 @@ def test_extract_domain_complex_url(mock_is_valid_url):
 
 def test_extract_domain_integration_valid_url():
     """
-    Test extract_domain function with real validation and valid URL.
+    Test case 22: Extract_domain function with real validation and valid URL.
     """
     # Test with real validation (without mocking)
     result = extract_domain("https://example.com")
@@ -251,7 +251,7 @@ def test_extract_domain_integration_valid_url():
 
 def test_extract_domain_integration_invalid_url():
     """
-    Test extract_domain function with real validation and invalid URL.
+    Test case 23: Extract_domain function with real validation and invalid URL.
     """
     # Test with real validation (without mocking)
     result = extract_domain("invalid-url")
@@ -260,7 +260,7 @@ def test_extract_domain_integration_invalid_url():
 
 def test_extract_domain_integration_complex_url():
     """
-    Test extract_domain function with real validation and complex URL.
+    Test case 24: Extract_domain function with real validation and complex URL.
     """
     # Test with real validation (without mocking)
     result = extract_domain("https://www.google.com/search?q=test")
@@ -269,7 +269,7 @@ def test_extract_domain_integration_complex_url():
 
 def test_extract_domain_invalid_url_type() -> None:
     """
-    Test case 26: Test extract_domain with invalid URL type.
+    Test case 25: Test extract_domain with invalid URL type.
     """
     with pytest.raises(TypeError):
         extract_domain(None)
@@ -277,7 +277,7 @@ def test_extract_domain_invalid_url_type() -> None:
 
 def test_extract_domain_invalid_url_int() -> None:
     """
-    Test case 27: Test extract_domain with integer input.
+    Test case 26: Test extract_domain with integer input.
     """
     with pytest.raises(TypeError):
         extract_domain(123)
@@ -285,7 +285,7 @@ def test_extract_domain_invalid_url_int() -> None:
 
 def test_extract_domain_invalid_url_list() -> None:
     """
-    Test case 28: Test extract_domain with list input.
+    Test case 27: Test extract_domain with list input.
     """
     with pytest.raises(TypeError):
         extract_domain(["https://example.com"])
@@ -293,7 +293,7 @@ def test_extract_domain_invalid_url_list() -> None:
 
 def test_extract_domain_empty_string() -> None:
     """
-    Test case 29: Test extract_domain with empty string.
+    Test case 28: Test extract_domain with empty string.
     """
     result = extract_domain("")
     assert result is None

--- a/pytest/unit/http_functions/test_http_get.py
+++ b/pytest/unit/http_functions/test_http_get.py
@@ -55,7 +55,7 @@ def test_http_get_successful_request(mock_urlopen):
 @patch("urllib.request.urlopen")
 def test_http_get_with_custom_headers(mock_urlopen):
     """
-    Test HTTP GET request with custom headers are properly set.
+    Test case 5: HTTP GET request applies custom headers correctly.
     """
     mock_response = Mock()
     mock_response.getcode.return_value = 200
@@ -78,7 +78,7 @@ def test_http_get_with_custom_headers(mock_urlopen):
 @patch("urllib.request.urlopen")
 def test_http_get_with_custom_timeout(mock_urlopen):
     """
-    Test HTTP GET request with custom timeout value.
+    Test case 6: HTTP GET request with custom timeout value.
     """
     mock_response = Mock()
     mock_response.getcode.return_value = 200
@@ -97,7 +97,7 @@ def test_http_get_with_custom_timeout(mock_urlopen):
 @patch("urllib.request.urlopen")
 def test_http_get_default_timeout(mock_urlopen):
     """
-    Test that default timeout is 30 seconds when not specified.
+    Test case 7: Default timeout is 30 seconds when not specified.
     """
     mock_response = Mock()
     mock_response.getcode.return_value = 200
@@ -115,7 +115,7 @@ def test_http_get_default_timeout(mock_urlopen):
 @patch("urllib.request.urlopen")
 def test_http_get_http_error_with_response_body(mock_urlopen):
     """
-    Test HTTP GET request with HTTP error that includes response body.
+    Test case 8: HTTP GET request with HTTP error that includes response body.
     """
     error = urllib.error.HTTPError(
         url="https://example.com",
@@ -134,7 +134,7 @@ def test_http_get_http_error_with_response_body(mock_urlopen):
 @patch("urllib.request.urlopen")
 def test_http_get_http_error_without_response_body(mock_urlopen):
     """
-    Test HTTP GET request with HTTP error but no response body.
+    Test case 9: HTTP GET request with HTTP error but no response body.
     """
     error = urllib.error.HTTPError(
         url="https://example.com", code=500, msg="Server Error", hdrs=None, fp=None
@@ -148,7 +148,7 @@ def test_http_get_http_error_without_response_body(mock_urlopen):
 @patch("urllib.request.urlopen")
 def test_http_get_url_error(mock_urlopen):
     """
-    Test HTTP GET request with URL error raises exception.
+    Test case 10: HTTP GET request with URL error raises exception.
     """
     mock_urlopen.side_effect = urllib.error.URLError("Connection failed")
 

--- a/pytest/unit/http_functions/test_is_valid_url.py
+++ b/pytest/unit/http_functions/test_is_valid_url.py
@@ -4,197 +4,211 @@ from http_functions.is_valid_url import is_valid_url
 
 
 def test_is_valid_url_with_empty_string():
-    """Test case 1: Test is_valid_url function with empty string returns False."""
+    """
+    Test case 1: Test is_valid_url function with empty string returns False.
+    """
     assert is_valid_url("") is False
 
 
 def test_is_valid_url_with_whitespace_string():
-    """Test case 2: Test is_valid_url function with whitespace-only string returns False."""
+    """
+    Test case 2: Test is_valid_url function with whitespace-only string returns False.
+    """
     assert is_valid_url("   ") is False
 
 
 def test_is_valid_url_with_none():
-    """Test case 3: Test is_valid_url function with None returns False."""
+    """
+    Test case 3: Test is_valid_url function with None returns False.
+    """
     assert is_valid_url(None) is False
 
 
 def test_is_valid_url_with_integer():
-    """Test case 4: Test is_valid_url function with integer returns False."""
+    """
+    Test case 4: Test is_valid_url function with integer returns False.
+    """
     assert is_valid_url(123) is False
 
 
 def test_is_valid_url_with_list():
-    """Test case 5: Test is_valid_url function with list returns False."""
+    """
+    Test case 5: Test is_valid_url function with list returns False.
+    """
     assert is_valid_url([]) is False
 
 
 def test_is_valid_url_simple_https():
-    """Test case 6: Test is_valid_url function with simple HTTPS URL returns True."""
+    """
+    Test case 6: Test is_valid_url function with simple HTTPS URL returns True.
+    """
     assert is_valid_url("https://example.com") is True
 
 
 def test_is_valid_url_simple_http():
-    """Test case 7: Test is_valid_url function with simple HTTP URL returns True."""
+    """
+    Test case 7: Test is_valid_url function with simple HTTP URL returns True.
+    """
     assert is_valid_url("http://example.com") is True
 
 
 def test_is_valid_url_with_subdomain():
     """
-    Test is_valid_url function with subdomain returns True.
+    Test case 8: Is_valid_url function with subdomain returns True.
     """
     assert is_valid_url("https://www.example.com") is True
 
 
 def test_is_valid_url_with_path():
     """
-    Test is_valid_url function with path returns True.
+    Test case 9: Is_valid_url function with path returns True.
     """
     assert is_valid_url("https://example.com/path") is True
 
 
 def test_is_valid_url_with_port():
     """
-    Test is_valid_url function with port returns True.
+    Test case 10: Is_valid_url function with port returns True.
     """
     assert is_valid_url("https://example.com:8080") is True
 
 
 def test_is_valid_url_with_query():
     """
-    Test is_valid_url function with query parameters returns True.
+    Test case 11: Is_valid_url function with query parameters returns True.
     """
     assert is_valid_url("https://example.com/path?query=value") is True
 
 
 def test_is_valid_url_with_fragment():
     """
-    Test is_valid_url function with fragment returns True.
+    Test case 12: Is_valid_url function with fragment returns True.
     """
     assert is_valid_url("https://example.com/path#fragment") is True
 
 
 def test_is_valid_url_ftp_scheme():
     """
-    Test is_valid_url function with FTP scheme returns True.
+    Test case 13: Is_valid_url function with FTP scheme returns True.
     """
     assert is_valid_url("ftp://ftp.example.com") is True
 
 
 def test_is_valid_url_file_scheme():
     """
-    Test is_valid_url function with file scheme returns True.
+    Test case 14: Is_valid_url function with file scheme returns True.
     """
     assert is_valid_url("file:///path/to/file") is True
 
 
 def test_is_valid_url_with_authentication():
     """
-    Test is_valid_url function with authentication returns True.
+    Test case 15: Is_valid_url function with authentication returns True.
     """
     assert is_valid_url("https://user:pass@example.com") is True
 
 
 def test_is_valid_url_with_ip_address():
     """
-    Test is_valid_url function with IP address returns True.
+    Test case 16: Is_valid_url function with IP address returns True.
     """
     assert is_valid_url("http://192.168.1.1:8000") is True
 
 
 def test_is_valid_url_complex_subdomain():
     """
-    Test is_valid_url function with complex subdomain returns True.
+    Test case 17: Is_valid_url function with complex subdomain returns True.
     """
     assert is_valid_url("https://subdomain.example.com/api/v1") is True
 
 
 def test_is_valid_url_no_scheme():
     """
-    Test is_valid_url function with no scheme returns False.
+    Test case 18: Is_valid_url function with no scheme returns False.
     """
     assert is_valid_url("example.com") is False
 
 
 def test_is_valid_url_empty_scheme():
     """
-    Test is_valid_url function with empty scheme returns False.
+    Test case 19: Is_valid_url function with empty scheme returns False.
     """
     assert is_valid_url("://example.com") is False
 
 
 def test_is_valid_url_no_netloc():
     """
-    Test is_valid_url function with no netloc returns False.
+    Test case 20: Is_valid_url function with no netloc returns False.
     """
     assert is_valid_url("https://") is False
 
 
 def test_is_valid_url_no_hostname():
     """
-    Test is_valid_url function with no hostname returns False.
+    Test case 21: Is_valid_url function with no hostname returns False.
     """
     assert is_valid_url("https:///path") is False
 
 
 def test_is_valid_url_plain_text():
     """
-    Test is_valid_url function with plain text returns False.
+    Test case 22: Is_valid_url function with plain text returns False.
     """
     assert is_valid_url("not-a-url") is False
 
 
 def test_is_valid_url_just_text():
     """
-    Test is_valid_url function with just text returns False.
+    Test case 23: Is_valid_url function with just text returns False.
     """
     assert is_valid_url("just text") is False
 
 
 def test_is_valid_url_www_without_scheme():
     """
-    Test is_valid_url function with www but no scheme returns False.
+    Test case 24: Is_valid_url function with www but no scheme returns False.
     """
     assert is_valid_url("www.example.com") is False
 
 
 def test_is_valid_url_invalid_hostname():
     """
-    Test is_valid_url function with invalid hostname returns False.
+    Test case 25: Is_valid_url function with invalid hostname returns False.
     """
     assert is_valid_url("https://.example.com") is False
 
 
 def test_is_valid_url_space_in_url():
     """
-    Test is_valid_url function with space in URL returns False.
+    Test case 26: Is_valid_url function with space in URL returns False.
     """
     assert is_valid_url("https:// example.com") is False
 
 
 def test_is_valid_url_with_https_allowed_scheme():
     """
-    Test is_valid_url function with HTTPS in allowed schemes returns True.
+    Test case 27: Is_valid_url function with HTTPS in allowed schemes returns True.
     """
     assert is_valid_url("https://example.com", ["https"]) is True
 
 
 def test_is_valid_url_with_http_not_in_allowed_schemes():
     """
-    Test is_valid_url function with HTTP not in allowed schemes returns False.
+    Test case 28: Is_valid_url function with HTTP not in allowed schemes returns False.
     """
     assert is_valid_url("http://example.com", ["https"]) is False
 
 
 def test_is_valid_url_with_ftp_not_in_allowed_schemes():
     """
-    Test is_valid_url function with FTP not in allowed schemes returns False.
+    Test case 29: Is_valid_url function with FTP not in allowed schemes returns False.
     """
     assert is_valid_url("ftp://example.com", ["https"]) is False
 
 
 def test_is_valid_url_with_http_and_https_allowed():
     """
-    Test is_valid_url function with HTTP in allowed schemes returns True.
+    Test case 30: Is_valid_url function with HTTP in allowed schemes returns True.
     """
     allowed_schemes = ["http", "https"]
     assert is_valid_url("http://example.com", allowed_schemes) is True
@@ -202,7 +216,7 @@ def test_is_valid_url_with_http_and_https_allowed():
 
 def test_is_valid_url_with_https_in_allowed_schemes():
     """
-    Test is_valid_url function with HTTPS in allowed schemes returns True.
+    Test case 31: Is_valid_url function with HTTPS in allowed schemes returns True.
     """
     allowed_schemes = ["http", "https"]
     assert is_valid_url("https://example.com", allowed_schemes) is True
@@ -210,7 +224,7 @@ def test_is_valid_url_with_https_in_allowed_schemes():
 
 def test_is_valid_url_with_ftp_not_in_http_https_schemes():
     """
-    Test is_valid_url function with FTP not in HTTP/HTTPS schemes returns False.
+    Test case 32: Is_valid_url function with FTP not in HTTP/HTTPS schemes returns False.
     """
     allowed_schemes = ["http", "https"]
     assert is_valid_url("ftp://example.com", allowed_schemes) is False
@@ -218,7 +232,7 @@ def test_is_valid_url_with_ftp_not_in_http_https_schemes():
 
 def test_is_valid_url_with_file_not_in_http_https_schemes():
     """
-    Test is_valid_url function with file not in HTTP/HTTPS schemes returns False.
+    Test case 33: Is_valid_url function with file not in HTTP/HTTPS schemes returns False.
     """
     allowed_schemes = ["http", "https"]
     assert is_valid_url("file:///path", allowed_schemes) is False
@@ -226,7 +240,7 @@ def test_is_valid_url_with_file_not_in_http_https_schemes():
 
 def test_is_valid_url_with_multiple_allowed_schemes():
     """
-    Test is_valid_url function with FTP in multiple allowed schemes returns True.
+    Test case 34: Is_valid_url function with FTP in multiple allowed schemes returns True.
     """
     allowed_schemes = ["http", "https", "ftp"]
     assert is_valid_url("ftp://ftp.example.com", allowed_schemes) is True
@@ -234,7 +248,7 @@ def test_is_valid_url_with_multiple_allowed_schemes():
 
 def test_is_valid_url_with_mailto_not_in_web_schemes():
     """
-    Test is_valid_url function with mailto not in web schemes returns False.
+    Test case 35: Is_valid_url function with mailto not in web schemes returns False.
     """
     allowed_schemes = ["http", "https", "ftp"]
     assert is_valid_url("mailto:test@example.com", allowed_schemes) is False
@@ -242,7 +256,7 @@ def test_is_valid_url_with_mailto_not_in_web_schemes():
 
 def test_is_valid_url_with_ssh_not_in_allowed_schemes():
     """
-    Test is_valid_url function with SSH not in allowed schemes returns False.
+    Test case 36: Is_valid_url function with SSH not in allowed schemes returns False.
     """
     allowed_schemes = ["http", "https", "ftp"]
     assert is_valid_url("ssh://server.com", allowed_schemes) is False
@@ -250,20 +264,20 @@ def test_is_valid_url_with_ssh_not_in_allowed_schemes():
 
 def test_is_valid_url_with_empty_allowed_schemes():
     """
-    Test is_valid_url function with empty allowed schemes list returns False.
+    Test case 37: Is_valid_url function with empty allowed schemes list returns False.
     """
     assert is_valid_url("https://example.com", []) is False
 
 
 def test_is_valid_url_malformed_bracket():
     """
-    Test is_valid_url function with malformed bracket returns False.
+    Test case 38: Is_valid_url function with malformed bracket returns False.
     """
     assert is_valid_url("https://[invalid") is False
 
 
 def test_is_valid_url_malformed_closing_bracket():
     """
-    Test is_valid_url function with malformed closing bracket returns False.
+    Test case 39: Is_valid_url function with malformed closing bracket returns False.
     """
     assert is_valid_url("https://]invalid") is False

--- a/pytest/unit/iterable_functions/dictionary_operations/test_remove_empty_dicts_recursive.py
+++ b/pytest/unit/iterable_functions/dictionary_operations/test_remove_empty_dicts_recursive.py
@@ -32,10 +32,10 @@ def test_remove_empty_dicts_recursive_all_empty_dicts() -> None:
 
 
 def test_remove_empty_dicts_recursive_mixed_types() -> None:
+    """
+    Test case 4: The remove_empty_dicts_recursive function handles mixed types.
+    """
     test_object = object()
-    """
-    Test case 4: Test the remove_empty_dicts_recursive function with mixed types.
-    """
     nested_dict = {
         "a": 1,
         "b": {"c": {}, "d": 2},

--- a/pytest/unit/logger_functions/test_colored_formatter.py
+++ b/pytest/unit/logger_functions/test_colored_formatter.py
@@ -6,7 +6,9 @@ from logger_functions.colored_formatter import colored_formatter
 
 
 def test_colored_formatter_basic():
-    """Test case 1: Basic colored formatter functionality."""
+    """
+    Test case 1: Basic colored formatter functionality.
+    """
     formatter = colored_formatter()
     assert isinstance(formatter, logging.Formatter)
 
@@ -30,7 +32,9 @@ def test_colored_formatter_basic():
 
 
 def test_colored_formatter_colors():
-    """Test that colored formatter adds ANSI color codes."""
+    """
+    Test case 2: Colored formatter adds ANSI color codes.
+    """
     with patch.object(sys.stdout, "isatty", return_value=True):
         formatter = colored_formatter(use_color=True)
 
@@ -62,7 +66,9 @@ def test_colored_formatter_colors():
 
 
 def test_colored_formatter_no_color():
-    """Test colored formatter with colors disabled."""
+    """
+    Test case 3: Colored formatter with colors disabled.
+    """
     formatter = colored_formatter(use_color=False)
 
     record = logging.LogRecord(
@@ -84,7 +90,9 @@ def test_colored_formatter_no_color():
 
 @patch("sys.stdout.isatty")
 def test_colored_formatter_auto_detect_color(mock_isatty):
-    """Test automatic color detection."""
+    """
+    Test case 4: Automatic color detection.
+    """
     # Test when TTY is available
     mock_isatty.return_value = True
     formatter = colored_formatter(use_color=True)
@@ -97,7 +105,9 @@ def test_colored_formatter_auto_detect_color(mock_isatty):
 
 
 def test_colored_formatter_custom_format():
-    """Test colored formatter with custom format string."""
+    """
+    Test case 5: Colored formatter with custom format string.
+    """
     custom_fmt = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     formatter = colored_formatter(fmt=custom_fmt, use_color=False)
 
@@ -120,7 +130,9 @@ def test_colored_formatter_custom_format():
 
 
 def test_colored_formatter_unknown_level():
-    """Test colored formatter with unknown log level."""
+    """
+    Test case 6: Colored formatter with unknown log level.
+    """
     formatter = colored_formatter(use_color=True)
 
     # Create record with custom level
@@ -145,7 +157,9 @@ def test_colored_formatter_unknown_level():
 
 
 def test_colored_formatter_with_args():
-    """Test colored formatter with message formatting arguments."""
+    """
+    Test case 7: Colored formatter with message formatting arguments.
+    """
     formatter = colored_formatter(use_color=False)
 
     record = logging.LogRecord(

--- a/pytest/unit/logger_functions/test_performance_formatter.py
+++ b/pytest/unit/logger_functions/test_performance_formatter.py
@@ -6,7 +6,9 @@ from logger_functions.performance_formatter import performance_formatter
 
 
 def test_performance_formatter_basic():
-    """Test case 1: Test basic performance formatter functionality."""
+    """
+    Test case 1: Basic performance formatter functionality.
+    """
     formatter = performance_formatter()
     assert isinstance(formatter, logging.Formatter)
 
@@ -32,7 +34,9 @@ def test_performance_formatter_basic():
 
 
 def test_performance_formatter_timestamp() -> None:
-    """Test case 2: Test that performance formatter includes timestamp."""
+    """
+    Test case 2: Performance formatter includes timestamp.
+    """
     formatter = performance_formatter()
 
     record = logging.LogRecord(
@@ -53,7 +57,9 @@ def test_performance_formatter_timestamp() -> None:
 
 
 def test_performance_formatter_thread_info():
-    """Test thread information inclusion."""
+    """
+    Test case 3: Thread information inclusion.
+    """
     formatter = performance_formatter(include_thread_info=True)
 
     record = logging.LogRecord(
@@ -75,7 +81,9 @@ def test_performance_formatter_thread_info():
 
 
 def test_performance_formatter_no_thread_info():
-    """Test exclusion of thread information."""
+    """
+    Test case 4: Exclusion of thread information.
+    """
     formatter = performance_formatter(include_thread_info=False)
 
     record = logging.LogRecord(
@@ -98,7 +106,9 @@ def test_performance_formatter_no_thread_info():
 
 
 def test_performance_formatter_elapsed_time():
-    """Test elapsed time calculation."""
+    """
+    Test case 5: Elapsed time calculation.
+    """
     formatter = performance_formatter()
 
     # Wait a bit to ensure elapsed time > 0
@@ -129,7 +139,9 @@ def test_performance_formatter_elapsed_time():
 
 
 def test_performance_formatter_module_function():
-    """Test module and function name formatting."""
+    """
+    Test case 6: Module and function name formatting.
+    """
     formatter = performance_formatter(include_thread_info=False)
 
     record = logging.LogRecord(
@@ -153,7 +165,9 @@ def test_performance_formatter_module_function():
 
 
 def test_performance_formatter_multiple_calls():
-    """Test elapsed time accumulation across multiple calls."""
+    """
+    Test case 7: Elapsed time accumulation across multiple calls.
+    """
     formatter = performance_formatter(include_thread_info=False)
 
     # First call
@@ -198,7 +212,9 @@ def test_performance_formatter_multiple_calls():
 
 
 def test_performance_formatter_with_formatting():
-    """Test performance formatter with message formatting."""
+    """
+    Test case 8: Performance formatter with message formatting.
+    """
     formatter = performance_formatter(include_thread_info=False)
 
     record = logging.LogRecord(
@@ -221,7 +237,9 @@ def test_performance_formatter_with_formatting():
 
 
 def test_performance_formatter_all_parts() -> None:
-    """Test that all expected parts are present."""
+    """
+    Test case 9: All expected parts are present.
+    """
     formatter = performance_formatter(include_thread_info=True)
 
     record = logging.LogRecord(

--- a/pytest/unit/strings_utility/test_count_consonants.py
+++ b/pytest/unit/strings_utility/test_count_consonants.py
@@ -3,14 +3,18 @@ from strings_utility.count_consonants import count_consonants
 
 
 def test_mixed_case_consonants_and_vowels() -> None:
+    """
+    Test case 1: Mixed case consonants and vowels.
+    """
     assert count_consonants("hello") == 3, "Failed on mixed case consonants and vowels"
-    """
-    Test case 2: Test the count_consonants function with mixed case consonants and vowels.
-    """
+    # Additional scenario: ensure mixed case strings count consonants correctly.
     assert count_consonants("HeLLo WoRLd") == 7, "Failed on mixed case consonants"
 
 
 def test_all_consonants() -> None:
+    """
+    Test case 2: All consonants.
+    """
     assert count_consonants("bcdfghjklmnpqrstvwxyzBCDFGHJKLMNPQRSTVWXYZ") == 42, (
         "Failed on all consonants"
     )
@@ -20,9 +24,7 @@ def test_all_consonants() -> None:
     assert count_consonants("BCDFGHJKLMNPQRSTVWXYZ") == 21, (
         "Failed on string with only uppercase consonants"
     )
-    """
-    Test case 6: Test the count_consonants function with all consonants.
-    """
+    # Additional scenario: repeated consonants maintain correct counts.
     assert count_consonants("bbccddffgghhjjkkllmmnnppqqrrssttvvwwxxyyzz") == 42, (
         "Failed on string with repeated consonants"
     )
@@ -30,19 +32,22 @@ def test_all_consonants() -> None:
 
 def test_all_vowels() -> None:
     """
-    Test case 7: Test the count_consonants function with all vowels.
+    Test case 3: Test the count_consonants function with all vowels.
     """
     assert count_consonants("aeiouAEIOU") == 0, "Failed on all vowels"
 
 
 def test_empty_string() -> None:
     """
-    Test case 8: Test the count_consonants function with an empty string.
+    Test case 4: Test the count_consonants function with an empty string.
     """
     assert count_consonants("") == 0, "Failed on empty string"
 
 
 def test_numbers_and_special_characters() -> None:
+    """
+    Test case 5: Numbers and special characters.
+    """
     assert count_consonants("12345!@#$%") == 0, (
         "Failed on string with numbers and special characters"
     )
@@ -53,13 +58,14 @@ def test_numbers_and_special_characters() -> None:
     assert count_consonants("!@#hello!@#") == 3, (
         "Failed on string with special characters"
     )
-    """
-    Test case 13: Test the count_consonants function with numbers and special characters.
-    """
+    # Additional scenario: mixed alphanumeric strings count consonants correctly.
     assert count_consonants("123hello123") == 3, "Failed on string with numbers"
 
 
 def test_whitespace_characters() -> None:
+    """
+    Test case 6: Whitespace characters.
+    """
     assert count_consonants("hello world") == 7, "Failed on string with spaces"
     assert count_consonants("hello\nworld") == 7, (
         "Failed on string with newline characters"
@@ -68,9 +74,7 @@ def test_whitespace_characters() -> None:
     assert count_consonants("hello \t\nworld") == 7, (
         "Failed on string with mixed whitespace characters"
     )
-    """
-    Test case 18: Test the count_consonants function with whitespace characters.
-    """
+    # Additional scenario: leading and trailing spaces are ignored in counts.
     assert count_consonants("  hello world  ") == 7, (
         "Failed on string with leading and trailing spaces"
     )
@@ -78,7 +82,7 @@ def test_whitespace_characters() -> None:
 
 def test_non_english_characters() -> None:
     """
-    Test case 19: Test the count_consonants function with non-English characters.
+    Test case 7: Test the count_consonants function with non-English characters.
     """
     assert count_consonants("héllo wörld") == 7, (
         "Failed on string with non-English characters"
@@ -87,7 +91,7 @@ def test_non_english_characters() -> None:
 
 def test_count_consonants_invalid_type() -> None:
     """
-    Test case 20: Test the count_consonants function with an invalid type.
+    Test case 8: Test the count_consonants function with an invalid type.
     """
     with pytest.raises(TypeError):
         count_consonants(12345)

--- a/pytest/unit/strings_utility/test_count_vowels.py
+++ b/pytest/unit/strings_utility/test_count_vowels.py
@@ -11,6 +11,9 @@ from strings_utility.count_vowels import count_vowels
     ],
 )
 def test_mixed_case_vowels_and_consonants(text: str, expected: int) -> None:
+    """
+    Test case 1: Mixed case vowels and consonants.
+    """
     assert count_vowels(text) == expected
 
 
@@ -24,6 +27,9 @@ def test_mixed_case_vowels_and_consonants(text: str, expected: int) -> None:
     ],
 )
 def test_all_vowels(text: str, expected: int) -> None:
+    """
+    Test case 2: All vowels.
+    """
     assert count_vowels(text) == expected
 
 
@@ -35,10 +41,16 @@ def test_all_vowels(text: str, expected: int) -> None:
     ],
 )
 def test_all_consonants(text: str) -> None:
+    """
+    Test case 3: All consonants.
+    """
     assert count_vowels(text) == 0
 
 
 def test_empty_string() -> None:
+    """
+    Test case 4: Empty string.
+    """
     assert count_vowels("") == 0
 
 
@@ -53,6 +65,9 @@ def test_empty_string() -> None:
     ],
 )
 def test_numbers_and_special_characters(text: str, expected: int) -> None:
+    """
+    Test case 5: Numbers and special characters.
+    """
     assert count_vowels(text) == expected
 
 
@@ -67,13 +82,22 @@ def test_numbers_and_special_characters(text: str, expected: int) -> None:
     ],
 )
 def test_whitespace_characters(text: str, expected: int) -> None:
+    """
+    Test case 6: Whitespace characters.
+    """
     assert count_vowels(text) == expected
 
 
 def test_non_english_characters() -> None:
+    """
+    Test case 7: Non english characters.
+    """
     assert count_vowels("héllo wörld") == 1
 
 
 def test_count_vowels_invalid_type() -> None:
+    """
+    Test case 8: Count vowels invalid type.
+    """
     with pytest.raises(TypeError):
         count_vowels(12345)


### PR DESCRIPTION
## Summary
- ensure every unit test docstring follows the `Test case x:` format across HTTP, logger, data type, iterable, and string utility suites
- add missing docstrings and convert inline scenario notes to comments so numbering stays consistent within each module

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68e6af131ec08325b2154a9020ce4770