### PR TITLE
Ensure async cancellable task timeout docstring matches format

### DIFF
--- a/pytest/unit/asyncio_functions/test_async_cancellable_task.py
+++ b/pytest/unit/asyncio_functions/test_async_cancellable_task.py
@@ -43,7 +43,7 @@ async def test_async_cancellable_task_cancelled_when_event_set():
 
 @pytest.mark.asyncio
 async def test_async_cancellable_task_timeout():
-    """A timeout raises asyncio.TimeoutError when reached first."""
+    """Test case 3: A timeout raises asyncio.TimeoutError when reached first."""
 
     cancel_event = asyncio.Event()
 


### PR DESCRIPTION
## Summary
- ensure the async cancellable task timeout test docstring follows the "Test case x" convention

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68e6b30b2b908325a78642fead70312a