### PR TITLE
Align unit test docstrings with ordered test case labels

### DIFF
--- a/pytest/unit/asyncio_functions/test_async_parallel_download.py
+++ b/pytest/unit/asyncio_functions/test_async_parallel_download.py
@@ -89,7 +89,7 @@ async def test_async_parallel_download_normal_operation(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_async_parallel_download_more_chunks_than_size(tmp_path: Path) -> None:
     """
-    Test case 11: Ensure chunks are capped by file size so each chunk has at least one byte.
+    Test case 2: Ensure chunks are capped by file size so each chunk has at least one byte.
     """
 
     url = "https://example.com/small.bin"
@@ -178,7 +178,7 @@ async def test_async_parallel_download_more_chunks_than_size(tmp_path: Path) -> 
 @pytest.mark.asyncio
 async def test_async_parallel_download_type_error_url(tmp_path: Path) -> None:
     """
-    Test case 2: TypeError for non-string URL.
+    Test case 3: TypeError for non-string URL.
     """
     dest = tmp_path / "file.zip"
     with pytest.raises(TypeError, match="url must be str"):
@@ -188,7 +188,7 @@ async def test_async_parallel_download_type_error_url(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_async_parallel_download_type_error_dest_path() -> None:
     """
-    Test case 3: TypeError for non-string dest_path.
+    Test case 4: TypeError for non-string dest_path.
     """
     with pytest.raises(TypeError, match="dest_path must be str"):
         await async_parallel_download("https://example.com/file.zip", 123)
@@ -197,7 +197,7 @@ async def test_async_parallel_download_type_error_dest_path() -> None:
 @pytest.mark.asyncio
 async def test_async_parallel_download_value_error_url(tmp_path: Path) -> None:
     """
-    Test case 4: ValueError for empty URL.
+    Test case 5: ValueError for empty URL.
     """
     dest = tmp_path / "file.zip"
     with pytest.raises(ValueError, match="url cannot be empty"):
@@ -207,7 +207,7 @@ async def test_async_parallel_download_value_error_url(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_async_parallel_download_type_error_num_chunks(tmp_path: Path) -> None:
     """
-    Test case 5: TypeError for invalid num_chunks type.
+    Test case 6: TypeError for invalid num_chunks type.
     """
     dest = tmp_path / "file.zip"
     with pytest.raises(TypeError, match="num_chunks must be int"):
@@ -219,7 +219,7 @@ async def test_async_parallel_download_type_error_num_chunks(tmp_path: Path) -> 
 @pytest.mark.asyncio
 async def test_async_parallel_download_value_error_num_chunks(tmp_path: Path) -> None:
     """
-    Test case 6: ValueError for num_chunks < 1.
+    Test case 7: ValueError for num_chunks < 1.
     """
     dest = tmp_path / "file.zip"
     with pytest.raises(ValueError, match="num_chunks must be >= 1"):
@@ -231,7 +231,7 @@ async def test_async_parallel_download_value_error_num_chunks(tmp_path: Path) ->
 @pytest.mark.asyncio
 async def test_async_parallel_download_type_error_timeout(tmp_path: Path) -> None:
     """
-    Test case 7: TypeError for invalid timeout type.
+    Test case 8: TypeError for invalid timeout type.
     """
     dest = tmp_path / "file.zip"
     with pytest.raises(TypeError, match="timeout must be a number"):
@@ -243,7 +243,7 @@ async def test_async_parallel_download_type_error_timeout(tmp_path: Path) -> Non
 @pytest.mark.asyncio
 async def test_async_parallel_download_value_error_timeout(tmp_path: Path) -> None:
     """
-    Test case 8: ValueError for non-positive timeout.
+    Test case 9: ValueError for non-positive timeout.
     """
     dest = tmp_path / "file.zip"
     with pytest.raises(ValueError, match="timeout must be positive"):
@@ -255,7 +255,7 @@ async def test_async_parallel_download_value_error_timeout(tmp_path: Path) -> No
 @pytest.mark.asyncio
 async def test_async_parallel_download_runtime_error_no_range(tmp_path: Path) -> None:
     """
-    Test case 9: RuntimeError if server does not support range requests.
+    Test case 10: RuntimeError if server does not support range requests.
     """
     url = "https://example.com/file.zip"
     dest = tmp_path / "file.zip"
@@ -294,7 +294,7 @@ async def test_async_parallel_download_runtime_error_no_range(tmp_path: Path) ->
 @pytest.mark.asyncio
 async def test_async_parallel_download_runtime_error_download(tmp_path: Path) -> None:
     """
-    Test case 10: RuntimeError for download failure.
+    Test case 11: RuntimeError for download failure.
     """
     url = "https://example.com/file.zip"
     dest = tmp_path / "file.zip"

--- a/pytest/unit/bioinformatics_functions/motif_functions/test_sequence_pattern_match.py
+++ b/pytest/unit/bioinformatics_functions/motif_functions/test_sequence_pattern_match.py
@@ -63,6 +63,6 @@ def test_sequence_pattern_match_invalid_iupac() -> None:
 
 
 def test_sequence_pattern_match_invalid_sequence_type() -> None:
-    """Test case 11: TypeError for non-string seq."""
+    """Test case 10: TypeError for non-string seq."""
     with pytest.raises(TypeError, match="seq must be a string"):
         sequence_pattern_match(123, "ATG")

--- a/pytest/unit/decorators/test_serialize_output.py
+++ b/pytest/unit/decorators/test_serialize_output.py
@@ -123,7 +123,7 @@ def test_invalid_format_type_with_logger(caplog):
 
 def test_invalid_format():
     """
-    Test case 6: Invalid format
+    Test case 9: Invalid format
     """
     with pytest.raises(
         ValueError, match="Unsupported format. Currently, only 'json' is supported."
@@ -136,7 +136,7 @@ def test_invalid_format():
 
 def test_invalid_format_with_logger(caplog):
     """
-    Test case 7: Invalid format with logger
+    Test case 10: Invalid format with logger
     """
     with caplog.at_level(logging.ERROR):
         with pytest.raises(


### PR DESCRIPTION
## Summary
- renumber the async parallel download test docstrings so their "Test case" labels are sequential
- correct the decorator serialization error-handling docstrings to use the proper test case numbers
- fix the motif sequence pattern matching invalid sequence type docstring label

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6b5e4bc2c83259f0729a3a32a3454