### PR TITLE
Remove leading pytest module docstrings

### DIFF
--- a/pytest/conftest.py
+++ b/pytest/conftest.py
@@ -1,4 +1,2 @@
-"""Pytest fixtures and configuration for tests."""
-
 # This file intentionally left blank; path adjustments are handled via
 # pyproject.toml [tool.pytest.ini_options].

--- a/pytest/unit/data_validation/basic_validation/__init__.py
+++ b/pytest/unit/data_validation/basic_validation/__init__.py
@@ -1,7 +1,1 @@
-"""
-Unit tests for basic data validation functions.
 
-This module contains comprehensive tests for basic validation functions
-including type validation, range validation, collection validation, string validation,
-and email validation.
-"""

--- a/pytest/unit/data_validation/basic_validation/test_validate_collection.py
+++ b/pytest/unit/data_validation/basic_validation/test_validate_collection.py
@@ -1,10 +1,3 @@
-"""
-Unit tests for validate_collection function.
-
-This module contains comprehensive tests for the validate_collection function,
-including type checking, length validation, element type validation, and various collection types.
-"""
-
 import pytest
 from data_validation import validate_collection
 

--- a/pytest/unit/data_validation/basic_validation/test_validate_email.py
+++ b/pytest/unit/data_validation/basic_validation/test_validate_email.py
@@ -1,10 +1,3 @@
-"""
-Unit tests for validate_email function.
-
-This module contains comprehensive tests for the validate_email function,
-including format validation, Unicode support, and domain checking.
-"""
-
 from unittest.mock import patch
 
 import pytest

--- a/pytest/unit/data_validation/basic_validation/test_validate_range.py
+++ b/pytest/unit/data_validation/basic_validation/test_validate_range.py
@@ -1,10 +1,3 @@
-"""
-Unit tests for validate_range function.
-
-This module contains comprehensive tests for the validate_range function,
-including numeric ranges, string ranges, date ranges, and boundary conditions.
-"""
-
 from datetime import date, datetime
 from decimal import Decimal
 

--- a/pytest/unit/data_validation/basic_validation/test_validate_string.py
+++ b/pytest/unit/data_validation/basic_validation/test_validate_string.py
@@ -1,10 +1,3 @@
-"""
-Unit tests for validate_string function.
-
-This module contains comprehensive tests for the validate_string function,
-including length validation, pattern matching, character restrictions, and edge cases.
-"""
-
 import re
 
 import pytest

--- a/pytest/unit/data_validation/basic_validation/test_validate_type.py
+++ b/pytest/unit/data_validation/basic_validation/test_validate_type.py
@@ -1,10 +1,3 @@
-"""
-Unit tests for validate_type function.
-
-This module contains comprehensive tests for the validate_type function,
-including type checking, union types, None handling, and error cases.
-"""
-
 import pytest
 from data_validation import validate_type
 

--- a/pytest/unit/data_validation/schema_validation/__init__.py
+++ b/pytest/unit/data_validation/schema_validation/__init__.py
@@ -1,6 +1,1 @@
-"""
-Unit tests for schema validation functions.
 
-This module contains comprehensive tests for schema validation functions
-including Pydantic schema validation and Cerberus schema validation.
-"""

--- a/pytest/unit/data_validation/schema_validation/test_validate_cerberus_schema.py
+++ b/pytest/unit/data_validation/schema_validation/test_validate_cerberus_schema.py
@@ -1,11 +1,3 @@
-"""
-Unit tests for validate_cerberus_schema function.
-
-This module contains comprehensive tests for the validate_cerberus_schema function,
-including schema validation, normalization, and error handling.
-Note: These tests will be skipped if Cerberus is not installed.
-"""
-
 import pytest
 
 # Try to import cerberus - tests will be skipped if not available

--- a/pytest/unit/data_validation/schema_validation/test_validate_pydantic_schema.py
+++ b/pytest/unit/data_validation/schema_validation/test_validate_pydantic_schema.py
@@ -1,11 +1,3 @@
-"""
-Unit tests for validate_pydantic_schema function.
-
-This module contains comprehensive tests for the validate_pydantic_schema function,
-including schema validation, error handling, and edge cases.
-Note: These tests will be skipped if Pydantic is not installed.
-"""
-
 import importlib
 
 import pytest

--- a/pytest/unit/file_functions/file_hashing/test_calculate_md5_hash.py
+++ b/pytest/unit/file_functions/file_hashing/test_calculate_md5_hash.py
@@ -1,7 +1,3 @@
-"""
-Unit tests for calculate_md5_hash function.
-"""
-
 import hashlib
 import tempfile
 from pathlib import Path

--- a/pytest/unit/file_functions/file_hashing/test_calculate_sha1_hash.py
+++ b/pytest/unit/file_functions/file_hashing/test_calculate_sha1_hash.py
@@ -1,7 +1,3 @@
-"""
-Unit tests for calculate_sha1_hash function.
-"""
-
 import hashlib
 import tempfile
 from pathlib import Path

--- a/pytest/unit/file_functions/file_hashing/test_calculate_sha256_hash.py
+++ b/pytest/unit/file_functions/file_hashing/test_calculate_sha256_hash.py
@@ -1,7 +1,3 @@
-"""
-Unit tests for calculate_sha256_hash function.
-"""
-
 import hashlib
 import tempfile
 from pathlib import Path

--- a/pytest/unit/file_functions/file_hashing/test_compare_file_hashes.py
+++ b/pytest/unit/file_functions/file_hashing/test_compare_file_hashes.py
@@ -1,7 +1,3 @@
-"""
-Unit tests for compare_file_hashes function.
-"""
-
 import tempfile
 from pathlib import Path
 

--- a/pytest/unit/file_functions/file_operations/test_write_lines.py
+++ b/pytest/unit/file_functions/file_operations/test_write_lines.py
@@ -1,7 +1,3 @@
-"""
-Unit tests for write_lines function.
-"""
-
 import os
 import tempfile
 

--- a/pytest/unit/file_functions/file_operations/test_write_to_file.py
+++ b/pytest/unit/file_functions/file_operations/test_write_to_file.py
@@ -1,7 +1,3 @@
-"""
-Unit tests for write_to_file function.
-"""
-
 import os
 import tempfile
 

--- a/pytest/unit/file_functions/recursive_search/test_find_files_by_extension.py
+++ b/pytest/unit/file_functions/recursive_search/test_find_files_by_extension.py
@@ -1,7 +1,3 @@
-"""
-Unit tests for find_files_by_extension function.
-"""
-
 import tempfile
 from pathlib import Path
 from unittest.mock import patch

--- a/pytest/unit/file_functions/recursive_search/test_find_files_by_mtime.py
+++ b/pytest/unit/file_functions/recursive_search/test_find_files_by_mtime.py
@@ -1,7 +1,3 @@
-"""
-Unit tests for find_files_by_mtime function.
-"""
-
 import os
 import tempfile
 import time

--- a/pytest/unit/file_functions/recursive_search/test_find_files_by_pattern.py
+++ b/pytest/unit/file_functions/recursive_search/test_find_files_by_pattern.py
@@ -1,7 +1,3 @@
-"""
-Unit tests for find_files_by_pattern function.
-"""
-
 import tempfile
 from pathlib import Path
 from unittest.mock import patch

--- a/pytest/unit/file_functions/recursive_search/test_find_files_by_size.py
+++ b/pytest/unit/file_functions/recursive_search/test_find_files_by_size.py
@@ -1,7 +1,3 @@
-"""
-Unit tests for find_files_by_size function.
-"""
-
 import tempfile
 import os
 from pathlib import Path

--- a/pytest/unit/file_functions/temp_management/test_cleanup_temp_files.py
+++ b/pytest/unit/file_functions/temp_management/test_cleanup_temp_files.py
@@ -1,7 +1,3 @@
-"""
-Unit tests for cleanup_temp_files function.
-"""
-
 import os
 import tempfile
 import time

--- a/pytest/unit/file_functions/temp_management/test_create_temp_directory.py
+++ b/pytest/unit/file_functions/temp_management/test_create_temp_directory.py
@@ -1,7 +1,3 @@
-"""
-Unit tests for create_temp_directory function.
-"""
-
 import shutil
 import tempfile
 from pathlib import Path

--- a/pytest/unit/file_functions/temp_management/test_create_temp_file.py
+++ b/pytest/unit/file_functions/temp_management/test_create_temp_file.py
@@ -1,7 +1,3 @@
-"""
-Unit tests for create_temp_file function.
-"""
-
 import tempfile
 from pathlib import Path
 from unittest.mock import patch

--- a/pytest/unit/file_functions/temp_management/test_get_temp_dir_info.py
+++ b/pytest/unit/file_functions/temp_management/test_get_temp_dir_info.py
@@ -1,7 +1,3 @@
-"""
-Unit tests for get_temp_dir_info function.
-"""
-
 import tempfile
 from pathlib import Path
 from unittest.mock import patch

--- a/pytest/unit/http_functions/test_build_url.py
+++ b/pytest/unit/http_functions/test_build_url.py
@@ -1,5 +1,3 @@
-"""Unit tests for URL building functionality."""
-
 import pytest
 from http_functions.build_url import build_url
 

--- a/pytest/unit/http_functions/test_download_file.py
+++ b/pytest/unit/http_functions/test_download_file.py
@@ -1,6 +1,3 @@
-"""Unit tests for file download functionality."""
-
-
 import urllib.error
 from pathlib import Path
 from unittest.mock import Mock, mock_open, patch, MagicMock

--- a/pytest/unit/http_functions/test_extract_domain.py
+++ b/pytest/unit/http_functions/test_extract_domain.py
@@ -1,5 +1,3 @@
-"""Unit tests for domain extraction functionality."""
-
 from unittest.mock import patch
 
 import pytest

--- a/pytest/unit/http_functions/test_get_query_params.py
+++ b/pytest/unit/http_functions/test_get_query_params.py
@@ -1,5 +1,3 @@
-"""Unit tests for query parameters extraction functionality."""
-
 import pytest
 from http_functions.get_query_params import get_query_params
 

--- a/pytest/unit/http_functions/test_http_get.py
+++ b/pytest/unit/http_functions/test_http_get.py
@@ -1,5 +1,3 @@
-"""Unit tests for HTTP GET functionality."""
-
 import urllib.error
 from unittest.mock import Mock, patch
 

--- a/pytest/unit/http_functions/test_http_post.py
+++ b/pytest/unit/http_functions/test_http_post.py
@@ -1,5 +1,3 @@
-"""Unit tests for HTTP POST functionality."""
-
 import json
 import urllib.error
 from unittest.mock import Mock, patch

--- a/pytest/unit/http_functions/test_is_valid_url.py
+++ b/pytest/unit/http_functions/test_is_valid_url.py
@@ -1,5 +1,3 @@
-"""Unit tests for URL validation functionality."""
-
 from http_functions.is_valid_url import is_valid_url
 
 

--- a/pytest/unit/http_functions/test_parse_url.py
+++ b/pytest/unit/http_functions/test_parse_url.py
@@ -1,5 +1,3 @@
-"""Unit tests for URL parsing functionality."""
-
 import pytest
 from http_functions.parse_url import parse_url
 

--- a/pytest/unit/http_functions/test_upload_file.py
+++ b/pytest/unit/http_functions/test_upload_file.py
@@ -1,5 +1,3 @@
-"""Unit tests for file upload functionality."""
-
 import urllib.error
 from unittest.mock import Mock, mock_open, patch
 

--- a/pytest/unit/security_functions/encryption_helpers/test_decrypt_data_aes.py
+++ b/pytest/unit/security_functions/encryption_helpers/test_decrypt_data_aes.py
@@ -1,7 +1,3 @@
-"""
-Unit tests for decrypt_data_aes function.
-"""
-
 import pytest
 from security_functions.encryption_helpers.decrypt_data_aes import decrypt_data_aes
 from security_functions.encryption_helpers.encrypt_data_aes import encrypt_data_aes

--- a/pytest/unit/security_functions/encryption_helpers/test_decrypt_xor.py
+++ b/pytest/unit/security_functions/encryption_helpers/test_decrypt_xor.py
@@ -1,7 +1,3 @@
-"""
-Unit tests for decrypt_xor function.
-"""
-
 import pytest
 from security_functions.encryption_helpers.decrypt_xor import decrypt_xor
 from security_functions.encryption_helpers.encrypt_xor import encrypt_xor

--- a/pytest/unit/security_functions/encryption_helpers/test_encrypt_data_aes.py
+++ b/pytest/unit/security_functions/encryption_helpers/test_encrypt_data_aes.py
@@ -1,7 +1,3 @@
-"""
-Unit tests for encrypt_data_aes function.
-"""
-
 import base64
 
 import pytest

--- a/pytest/unit/security_functions/encryption_helpers/test_encrypt_xor.py
+++ b/pytest/unit/security_functions/encryption_helpers/test_encrypt_xor.py
@@ -1,7 +1,3 @@
-"""
-Unit tests for encrypt_xor function.
-"""
-
 import pytest
 from security_functions.encryption_helpers.encrypt_xor import encrypt_xor
 

--- a/pytest/unit/security_functions/password_hashing/test_hash_password_bcrypt.py
+++ b/pytest/unit/security_functions/password_hashing/test_hash_password_bcrypt.py
@@ -1,7 +1,3 @@
-"""
-Unit tests for hash_password_bcrypt function.
-"""
-
 import pytest
 from security_functions.password_hashing.hash_password_bcrypt import (
     hash_password_bcrypt,

--- a/pytest/unit/security_functions/password_hashing/test_hash_password_pbkdf2.py
+++ b/pytest/unit/security_functions/password_hashing/test_hash_password_pbkdf2.py
@@ -1,7 +1,3 @@
-"""
-Unit tests for hash_password_pbkdf2 function.
-"""
-
 import pytest
 from security_functions.password_hashing.hash_password_pbkdf2 import (
     hash_password_pbkdf2,

--- a/pytest/unit/security_functions/password_hashing/test_verify_password_bcrypt.py
+++ b/pytest/unit/security_functions/password_hashing/test_verify_password_bcrypt.py
@@ -1,7 +1,3 @@
-"""
-Unit tests for verify_password_bcrypt function.
-"""
-
 import pytest
 from security_functions.password_hashing.hash_password_bcrypt import (
     hash_password_bcrypt,

--- a/pytest/unit/security_functions/password_hashing/test_verify_password_pbkdf2.py
+++ b/pytest/unit/security_functions/password_hashing/test_verify_password_pbkdf2.py
@@ -1,7 +1,3 @@
-"""
-Unit tests for verify_password_pbkdf2 function.
-"""
-
 import pytest
 from security_functions.password_hashing.hash_password_pbkdf2 import (
     hash_password_pbkdf2,

--- a/pytest/unit/security_functions/token_generation/test_generate_jwt_token.py
+++ b/pytest/unit/security_functions/token_generation/test_generate_jwt_token.py
@@ -1,7 +1,3 @@
-"""
-Unit tests for generate_jwt_token function.
-"""
-
 import base64
 import json
 from datetime import datetime, timezone

--- a/pytest/unit/security_functions/token_generation/test_generate_secure_token.py
+++ b/pytest/unit/security_functions/token_generation/test_generate_secure_token.py
@@ -1,7 +1,3 @@
-"""
-Unit tests for generate_secure_token function.
-"""
-
 import string
 
 import pytest

--- a/pytest/unit/security_functions/token_generation/test_generate_url_safe_token.py
+++ b/pytest/unit/security_functions/token_generation/test_generate_url_safe_token.py
@@ -1,7 +1,3 @@
-"""
-Unit tests for generate_url_safe_token function.
-"""
-
 import pytest
 from security_functions.token_generation.generate_url_safe_token import (
     generate_url_safe_token,

--- a/pytest/unit/security_functions/token_generation/test_verify_jwt_token.py
+++ b/pytest/unit/security_functions/token_generation/test_verify_jwt_token.py
@@ -1,7 +1,3 @@
-"""
-Unit tests for verify_jwt_token function.
-"""
-
 import base64
 import json
 from datetime import datetime, timedelta, timezone


### PR DESCRIPTION
## Summary
- remove introductory module docstrings from pytest unit test modules so imports are at the top of each file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7e9652f848325be832a0b068d9346