### PR TITLE
Reorder HTTP unit tests for consistent structure

### DIFF
--- a/pytest/unit/http_functions/test_build_url.py
+++ b/pytest/unit/http_functions/test_build_url.py
@@ -2,74 +2,38 @@ import pytest
 from http_functions.build_url import build_url
 
 
-def test_build_url_with_empty_scheme():
-    """Test case 1: Test build_url function with empty scheme raises ValueError."""
-    with pytest.raises(ValueError, match="Scheme must be a non-empty string"):
-        build_url("", "example.com")
-
-
-def test_build_url_with_whitespace_scheme():
-    """Test case 2: Test build_url function with whitespace-only scheme raises ValueError."""
-    with pytest.raises(ValueError, match="Scheme must be a non-empty string"):
-        build_url("   ", "example.com")
-
-
-def test_build_url_with_none_scheme():
-    """Test case 3: Test build_url function with None scheme raises TypeError."""
-    with pytest.raises(TypeError):
-        build_url(None, "example.com")
-
-
-def test_build_url_with_empty_hostname():
-    """Test case 4: Test build_url function with empty hostname raises ValueError."""
-    with pytest.raises(ValueError, match="Hostname must be a non-empty string"):
-        build_url("https", "")
-
-
-def test_build_url_with_whitespace_hostname():
-    """Test case 5: Test build_url function with whitespace-only hostname raises ValueError."""
-    with pytest.raises(ValueError, match="Hostname must be a non-empty string"):
-        build_url("https", "   ")
-
-
-def test_build_url_with_none_hostname():
-    """Test case 6: Test build_url function with None hostname raises TypeError."""
-    with pytest.raises(TypeError):
-        build_url("https", None)
-
-
 def test_build_url_simple():
-    """Test case 7: Test build_url function with basic scheme and hostname."""
+    """Test case 1: Test build_url function with basic scheme and hostname."""
     result = build_url("https", "example.com")
     assert result == "https://example.com"
 
 
 def test_build_url_with_path():
-    """Test case 8: Test build_url function with path component."""
+    """Test case 2: Test build_url function with path component."""
     result = build_url("https", "example.com", path="/api/v1")
     assert result == "https://example.com/api/v1"
 
 
 def test_build_url_with_port():
-    """Test case 9: Test build_url function with port number."""
+    """Test case 3: Test build_url function with port number."""
     result = build_url("https", "example.com", port=8080)
     assert result == "https://example.com:8080"
 
 
 def test_build_url_with_port_and_path():
-    """Test case 10: Test build_url function with both port and path."""
+    """Test case 4: Test build_url function with both port and path."""
     result = build_url("https", "example.com", port=8080, path="/api")
     assert result == "https://example.com:8080/api"
 
 
 def test_build_url_with_single_query_param():
-    """Test case 11: Test build_url function with single query parameter."""
+    """Test case 5: Test build_url function with single query parameter."""
     result = build_url("https", "example.com", query_params={"q": "search"})
     assert result == "https://example.com?q=search"
 
 
 def test_build_url_with_multiple_query_params():
-    """Test case 12: Test build_url function with multiple query parameters."""
+    """Test case 6: Test build_url function with multiple query parameters."""
     query_params = {"q": "search", "page": "1"}
     result = build_url("https", "example.com", query_params=query_params)
     assert "q=search" in result
@@ -78,25 +42,25 @@ def test_build_url_with_multiple_query_params():
 
 
 def test_build_url_with_fragment():
-    """Test case 13: Test build_url function with fragment component."""
+    """Test case 7: Test build_url function with fragment component."""
     result = build_url("https", "example.com", fragment="section1")
     assert result == "https://example.com#section1"
 
 
 def test_build_url_with_username():
-    """Test case 14: Test build_url function with username only."""
+    """Test case 8: Test build_url function with username only."""
     result = build_url("https", "example.com", username="user")
     assert result == "https://user@example.com"
 
 
 def test_build_url_with_username_and_password():
-    """Test case 15: Test build_url function with username and password."""
+    """Test case 9: Test build_url function with username and password."""
     result = build_url("https", "example.com", username="user", password="pass")
     assert result == "https://user:pass@example.com"
 
 
 def test_build_url_complex_all_components():
-    """Test case 16: Test build_url function with all components present."""
+    """Test case 10: Test build_url function with all components present."""
     query_params = {"limit": "10", "offset": "20"}
     result = build_url(
         scheme="https",
@@ -116,57 +80,93 @@ def test_build_url_complex_all_components():
 
 
 def test_build_url_http_scheme():
-    """Test case 17: Test build_url function with HTTP scheme."""
+    """Test case 11: Test build_url function with HTTP scheme."""
     result = build_url("http", "example.com")
     assert result == "http://example.com"
 
 
 def test_build_url_with_ip_address():
-    """Test case 18: Test build_url function with IP address as hostname."""
+    """Test case 12: Test build_url function with IP address as hostname."""
     result = build_url("http", "192.168.1.1", port=8000)
     assert result == "http://192.168.1.1:8000"
 
 
 def test_build_url_with_subdomain():
-    """Test case 19: Test build_url function with subdomain hostname."""
+    """Test case 13: Test build_url function with subdomain hostname."""
     result = build_url("https", "api.example.com", path="/v1")
     assert result == "https://api.example.com/v1"
 
 
 def test_build_url_empty_path():
-    """Test case 20: Test build_url function with empty path string."""
+    """Test case 14: Test build_url function with empty path string."""
     result = build_url("https", "example.com", path="")
     assert result == "https://example.com"
 
 
 def test_build_url_empty_query_params():
-    """Test case 21: Test build_url function with empty query parameters dict."""
+    """Test case 15: Test build_url function with empty query parameters dict."""
     result = build_url("https", "example.com", query_params={})
     assert result == "https://example.com"
 
 
 def test_build_url_none_query_params():
-    """Test case 22: Test build_url function with None query parameters."""
+    """Test case 16: Test build_url function with None query parameters."""
     result = build_url("https", "example.com", query_params=None)
     assert result == "https://example.com"
 
 
 def test_build_url_none_fragment():
-    """Test case 23: Test build_url function with None fragment."""
+    """Test case 17: Test build_url function with None fragment."""
     result = build_url("https", "example.com", fragment=None)
     assert result == "https://example.com"
 
 
 def test_build_url_empty_fragment():
-    """Test case 24: Test build_url function with empty fragment string."""
+    """Test case 18: Test build_url function with empty fragment string."""
     result = build_url("https", "example.com", fragment="")
     assert result == "https://example.com"
 
 
 def test_build_url_special_characters_in_query():
-    """Test case 25: Test build_url function properly encodes special characters in query params."""
+    """Test case 19: Test build_url function properly encodes special characters in query params."""
     query_params = {"q": "hello world", "symbols": "!@#$"}
     result = build_url("https", "example.com", query_params=query_params)
 
     assert "hello+world" in result or "hello%20world" in result
     assert "%21%40%23%24" in result or "!@#$" in result
+def test_build_url_with_empty_scheme():
+    """Test case 20: Test build_url function with empty scheme raises ValueError."""
+    with pytest.raises(ValueError, match="Scheme must be a non-empty string"):
+        build_url("", "example.com")
+
+
+def test_build_url_with_whitespace_scheme():
+    """Test case 21: Test build_url function with whitespace-only scheme raises ValueError."""
+    with pytest.raises(ValueError, match="Scheme must be a non-empty string"):
+        build_url("   ", "example.com")
+
+
+def test_build_url_with_none_scheme():
+    """Test case 22: Test build_url function with None scheme raises TypeError."""
+    with pytest.raises(TypeError):
+        build_url(None, "example.com")
+
+
+def test_build_url_with_empty_hostname():
+    """Test case 23: Test build_url function with empty hostname raises ValueError."""
+    with pytest.raises(ValueError, match="Hostname must be a non-empty string"):
+        build_url("https", "")
+
+
+def test_build_url_with_whitespace_hostname():
+    """Test case 24: Test build_url function with whitespace-only hostname raises ValueError."""
+    with pytest.raises(ValueError, match="Hostname must be a non-empty string"):
+        build_url("https", "   ")
+
+
+def test_build_url_with_none_hostname():
+    """Test case 25: Test build_url function with None hostname raises TypeError."""
+    with pytest.raises(TypeError):
+        build_url("https", None)
+
+

--- a/pytest/unit/http_functions/test_download_file.py
+++ b/pytest/unit/http_functions/test_download_file.py
@@ -6,49 +6,13 @@ import pytest
 from http_functions.download_file import download_file
 
 
-def test_download_file_with_empty_url() -> None:
-    """Test case 1: Test download_file function with empty URL raises ValueError."""
-    with pytest.raises(ValueError, match="URL must be a non-empty string"):
-        download_file("", "test.txt")
-
-
-def test_download_file_with_whitespace_url() -> None:
-    """Test case 2: Test download_file function with whitespace-only URL raises ValueError."""
-    with pytest.raises(ValueError, match="URL must be a non-empty string"):
-        download_file("   ", "test.txt")
-
-
-def test_download_file_with_none_url() -> None:
-    """Test case 3: Test download_file function with None URL raises ValueError."""
-    with pytest.raises(ValueError, match="URL must be a non-empty string"):
-        download_file(None, "test.txt")
-
-
-def test_download_file_with_empty_destination() -> None:
-    """Test case 4: Test download_file function with empty destination raises ValueError."""
-    with pytest.raises(ValueError, match="Destination must be a non-empty string"):
-        download_file("https://example.com/file.txt", "")
-
-
-def test_download_file_with_whitespace_destination() -> None:
-    """Test case 5: Test download_file function with whitespace-only destination raises ValueError."""
-    with pytest.raises(ValueError, match="Destination must be a non-empty string"):
-        download_file("https://example.com/file.txt", "   ")
-
-
-def test_download_file_with_none_destination() -> None:
-    """Test case 6: Test download_file function with None destination raises ValueError."""
-    with pytest.raises(ValueError, match="Destination must be a non-empty string"):
-        download_file("https://example.com/file.txt", None)
-
-
 @patch("urllib.request.urlopen")
 @patch("builtins.open", new_callable=mock_open)
 @patch("pathlib.Path.mkdir")
 def test_download_file_successful(
     mock_mkdir: MagicMock, mock_file_open: MagicMock, mock_urlopen: MagicMock
 ) -> None:
-    """Test case 7: Test successful file download returns correct response structure."""
+    """Test case 1: Test successful file download returns correct response structure."""
     # Mock response
     mock_response = Mock()
     mock_response.headers = {"Content-Length": "1024"}
@@ -84,7 +48,7 @@ def test_download_file_successful(
 def test_download_file_with_custom_headers(
     mock_mkdir: MagicMock, mock_file_open: MagicMock, mock_urlopen: MagicMock
 ) -> None:
-    """Test case 8: Test file download with custom headers are properly set."""
+    """Test case 2: Test file download with custom headers are properly set."""
     mock_response = Mock()
     mock_response.headers = {}
     mock_response.read.side_effect = [b"test", b""]
@@ -109,7 +73,7 @@ def test_download_file_with_custom_headers(
 def test_download_file_with_progress_callback(
     mock_mkdir: MagicMock, mock_file_open: MagicMock, mock_urlopen: MagicMock
 ) -> None:
-    """Test case 9: Test file download with progress callback function called correctly."""
+    """Test case 3: Test file download with progress callback function called correctly."""
     mock_response = Mock()
     mock_response.headers = {"Content-Length": "100"}
     mock_response.read.side_effect = [b"a" * 50, b"b" * 50, b""]
@@ -141,7 +105,7 @@ def test_download_file_with_progress_callback(
 def test_download_file_no_content_length_header(
     mock_mkdir: MagicMock, mock_file_open: MagicMock, mock_urlopen: MagicMock
 ) -> None:
-    """Test case 10: Test file download when Content-Length header is missing."""
+    """Test case 4: Test file download when Content-Length header is missing."""
     mock_response = Mock()
     mock_response.headers = {}  # No Content-Length
     mock_response.read.side_effect = [b"test data", b""]
@@ -175,7 +139,7 @@ def test_download_file_no_content_length_header(
 def test_download_file_with_custom_timeout(
     mock_mkdir: MagicMock, mock_file_open: MagicMock, mock_urlopen: MagicMock
 ) -> None:
-    """Test case 11: Test file download with custom timeout value."""
+    """Test case 5: Test file download with custom timeout value."""
     mock_response = Mock()
     mock_response.headers = {}
     mock_response.read.side_effect = [b"test", b""]
@@ -197,7 +161,7 @@ def test_download_file_with_custom_timeout(
 def test_download_file_default_timeout(
     mock_mkdir: MagicMock, mock_file_open: MagicMock, mock_urlopen: MagicMock
 ) -> None:
-    """Test case 12: Test that default timeout is 30 seconds when not specified."""
+    """Test case 6: Test that default timeout is 30 seconds when not specified."""
     mock_response = Mock()
     mock_response.headers = {}
     mock_response.read.side_effect = [b"test", b""]
@@ -210,6 +174,42 @@ def test_download_file_default_timeout(
 
         # Check that timeout=30 was passed
         assert mock_urlopen.call_args[1]["timeout"] == 30
+
+
+def test_download_file_with_empty_url() -> None:
+    """Test case 7: Test download_file function with empty URL raises ValueError."""
+    with pytest.raises(ValueError, match="URL must be a non-empty string"):
+        download_file("", "test.txt")
+
+
+def test_download_file_with_whitespace_url() -> None:
+    """Test case 8: Test download_file function with whitespace-only URL raises ValueError."""
+    with pytest.raises(ValueError, match="URL must be a non-empty string"):
+        download_file("   ", "test.txt")
+
+
+def test_download_file_with_none_url() -> None:
+    """Test case 9: Test download_file function with None URL raises ValueError."""
+    with pytest.raises(ValueError, match="URL must be a non-empty string"):
+        download_file(None, "test.txt")
+
+
+def test_download_file_with_empty_destination() -> None:
+    """Test case 10: Test download_file function with empty destination raises ValueError."""
+    with pytest.raises(ValueError, match="Destination must be a non-empty string"):
+        download_file("https://example.com/file.txt", "")
+
+
+def test_download_file_with_whitespace_destination() -> None:
+    """Test case 11: Test download_file function with whitespace-only destination raises ValueError."""
+    with pytest.raises(ValueError, match="Destination must be a non-empty string"):
+        download_file("https://example.com/file.txt", "   ")
+
+
+def test_download_file_with_none_destination() -> None:
+    """Test case 12: Test download_file function with None destination raises ValueError."""
+    with pytest.raises(ValueError, match="Destination must be a non-empty string"):
+        download_file("https://example.com/file.txt", None)
 
 
 @patch("urllib.request.urlopen")

--- a/pytest/unit/http_functions/test_extract_domain.py
+++ b/pytest/unit/http_functions/test_extract_domain.py
@@ -265,9 +265,15 @@ def test_extract_domain_integration_complex_url():
     assert result == "www.google.com"
 
 
+def test_extract_domain_empty_string() -> None:
+    """
+    Test case 25: Test extract_domain with empty string.
+    """
+    result = extract_domain("")
+    assert result is None
 def test_extract_domain_invalid_url_type() -> None:
     """
-    Test case 25: Test extract_domain with invalid URL type.
+    Test case 26: Test extract_domain with invalid URL type.
     """
     with pytest.raises(TypeError):
         extract_domain(None)
@@ -275,7 +281,7 @@ def test_extract_domain_invalid_url_type() -> None:
 
 def test_extract_domain_invalid_url_int() -> None:
     """
-    Test case 26: Test extract_domain with integer input.
+    Test case 27: Test extract_domain with integer input.
     """
     with pytest.raises(TypeError):
         extract_domain(123)
@@ -283,15 +289,9 @@ def test_extract_domain_invalid_url_int() -> None:
 
 def test_extract_domain_invalid_url_list() -> None:
     """
-    Test case 27: Test extract_domain with list input.
+    Test case 28: Test extract_domain with list input.
     """
     with pytest.raises(TypeError):
         extract_domain(["https://example.com"])
 
 
-def test_extract_domain_empty_string() -> None:
-    """
-    Test case 28: Test extract_domain with empty string.
-    """
-    result = extract_domain("")
-    assert result is None

--- a/pytest/unit/http_functions/test_get_query_params.py
+++ b/pytest/unit/http_functions/test_get_query_params.py
@@ -2,61 +2,43 @@ import pytest
 from http_functions.get_query_params import get_query_params
 
 
-def test_get_query_params_with_empty_string():
-    """Test case 1: Test get_query_params function with empty string raises ValueError."""
-    with pytest.raises(ValueError, match="URL must be a non-empty string"):
-        get_query_params("")
-
-
-def test_get_query_params_with_whitespace_string():
-    """Test case 2: Test get_query_params function with whitespace-only string raises ValueError."""
-    with pytest.raises(ValueError, match="URL must be a non-empty string"):
-        get_query_params("   ")
-
-
-def test_get_query_params_with_none():
-    """Test case 3: Test get_query_params function with None raises TypeError."""
-    with pytest.raises(TypeError):
-        get_query_params(None)
-
-
 def test_get_query_params_no_query_simple_url():
-    """Test case 4: Test get_query_params function with URL containing no query parameters."""
+    """Test case 1: Test get_query_params function with URL containing no query parameters."""
     url = "https://example.com"
     result = get_query_params(url)
     assert result == {}
 
 
 def test_get_query_params_no_query_with_slash():
-    """Test case 5: Test get_query_params function with URL ending in slash but no query."""
+    """Test case 2: Test get_query_params function with URL ending in slash but no query."""
     url = "https://example.com/"
     result = get_query_params(url)
     assert result == {}
 
 
 def test_get_query_params_no_query_with_path():
-    """Test case 6: Test get_query_params function with URL containing path but no query."""
+    """Test case 3: Test get_query_params function with URL containing path but no query."""
     url = "https://example.com/path"
     result = get_query_params(url)
     assert result == {}
 
 
 def test_get_query_params_single_parameter():
-    """Test case 7: Test get_query_params function with single query parameter."""
+    """Test case 4: Test get_query_params function with single query parameter."""
     url = "https://example.com?q=search"
     result = get_query_params(url)
     assert result == {"q": ["search"]}
 
 
 def test_get_query_params_single_parameter_with_path():
-    """Test case 8: Test get_query_params function with single query parameter and path."""
+    """Test case 5: Test get_query_params function with single query parameter and path."""
     url = "https://example.com/path?page=1"
     result = get_query_params(url)
     assert result == {"page": ["1"]}
 
 
 def test_get_query_params_multiple_parameters():
-    """Test case 9: Test get_query_params function with multiple query parameters."""
+    """Test case 6: Test get_query_params function with multiple query parameters."""
     url = "https://example.com?q=search&page=1&limit=10"
     result = get_query_params(url)
 
@@ -65,7 +47,7 @@ def test_get_query_params_multiple_parameters():
 
 
 def test_get_query_params_multiple_values_same_key():
-    """Test case 10: Test get_query_params function with parameters having multiple values."""
+    """Test case 7: Test get_query_params function with parameters having multiple values."""
     url = "https://example.com?tag=python&tag=web&tag=api"
     result = get_query_params(url)
 
@@ -74,7 +56,7 @@ def test_get_query_params_multiple_values_same_key():
 
 
 def test_get_query_params_mixed_single_and_multiple_values():
-    """Test case 11: Test get_query_params function with mix of single and multiple value parameters."""
+    """Test case 8: Test get_query_params function with mix of single and multiple value parameters."""
     url = "https://example.com?q=search&page=1&tag=python&tag=web&sort=date"
     result = get_query_params(url)
 
@@ -88,7 +70,7 @@ def test_get_query_params_mixed_single_and_multiple_values():
 
 
 def test_get_query_params_empty_values():
-    """Test case 12: Test get_query_params function with empty parameter values."""
+    """Test case 9: Test get_query_params function with empty parameter values."""
     url = "https://example.com?q=&page=1&empty="
     result = get_query_params(url)
 
@@ -97,7 +79,7 @@ def test_get_query_params_empty_values():
 
 
 def test_get_query_params_parameters_without_values():
-    """Test case 13: Test get_query_params function with parameters without values."""
+    """Test case 10: Test get_query_params function with parameters without values."""
     url = "https://example.com?debug&verbose&page=1"
     result = get_query_params(url)
 
@@ -106,7 +88,7 @@ def test_get_query_params_parameters_without_values():
 
 
 def test_get_query_params_url_encoded_values():
-    """Test case 14: Test get_query_params function with URL-encoded values."""
+    """Test case 11: Test get_query_params function with URL-encoded values."""
     url = "https://example.com?q=hello%20world&message=caf%C3%A9"
     result = get_query_params(url)
 
@@ -115,7 +97,7 @@ def test_get_query_params_url_encoded_values():
 
 
 def test_get_query_params_special_characters():
-    """Test case 15: Test get_query_params function with special characters in values."""
+    """Test case 12: Test get_query_params function with special characters in values."""
     url = "https://example.com?symbols=%21%40%23%24&math=2%2B2%3D4"
     result = get_query_params(url)
 
@@ -124,7 +106,7 @@ def test_get_query_params_special_characters():
 
 
 def test_get_query_params_with_fragment():
-    """Test case 16: Test get_query_params function ignores URL fragment."""
+    """Test case 13: Test get_query_params function ignores URL fragment."""
     url = "https://example.com?q=search&page=1#section"
     result = get_query_params(url)
 
@@ -133,7 +115,7 @@ def test_get_query_params_with_fragment():
 
 
 def test_get_query_params_with_port_and_path():
-    """Test case 17: Test get_query_params function with port and path."""
+    """Test case 14: Test get_query_params function with port and path."""
     url = "https://example.com:8080/api/v1/search?q=test&limit=50"
     result = get_query_params(url)
 
@@ -142,7 +124,7 @@ def test_get_query_params_with_port_and_path():
 
 
 def test_get_query_params_complex_url():
-    """Test case 18: Test get_query_params function with complex URL."""
+    """Test case 15: Test get_query_params function with complex URL."""
     url = "https://user:pass@api.example.com:8080/v1/search?q=python&category=web&category=api&page=1&limit=20#results"
     result = get_query_params(url)
 
@@ -156,7 +138,7 @@ def test_get_query_params_complex_url():
 
 
 def test_get_query_params_duplicate_parameters():
-    """Test case 19: Test get_query_params function with duplicate parameters."""
+    """Test case 16: Test get_query_params function with duplicate parameters."""
     url = "https://example.com?filter=new&filter=popular&filter=trending"
     result = get_query_params(url)
 
@@ -165,7 +147,7 @@ def test_get_query_params_duplicate_parameters():
 
 
 def test_get_query_params_plus_encoding():
-    """Test case 20: Test get_query_params function with plus sign encoding for spaces."""
+    """Test case 17: Test get_query_params function with plus sign encoding for spaces."""
     url = "https://example.com?q=hello+world&phrase=search+term"
     result = get_query_params(url)
 
@@ -174,7 +156,7 @@ def test_get_query_params_plus_encoding():
 
 
 def test_get_query_params_malformed_query():
-    """Test case 21: Test get_query_params function with malformed query strings."""
+    """Test case 18: Test get_query_params function with malformed query strings."""
     url = "https://example.com?key1value1&key2=value2"
     result = get_query_params(url)
 
@@ -183,44 +165,62 @@ def test_get_query_params_malformed_query():
 
 
 def test_get_query_params_only_query_separator():
-    """Test case 22: Test get_query_params function with URL containing only query separator."""
+    """Test case 19: Test get_query_params function with URL containing only query separator."""
     url = "https://example.com?"
     result = get_query_params(url)
     assert result == {}
 
 
 def test_get_query_params_https_scheme():
-    """Test case 23: Test get_query_params function works with HTTPS URLs."""
+    """Test case 20: Test get_query_params function works with HTTPS URLs."""
     url = "https://example.com?q=test"
     result = get_query_params(url)
     assert result == {"q": ["test"]}
 
 
 def test_get_query_params_http_scheme():
-    """Test case 24: Test get_query_params function works with HTTP URLs."""
+    """Test case 21: Test get_query_params function works with HTTP URLs."""
     url = "http://example.com?q=test"
     result = get_query_params(url)
     assert result == {"q": ["test"]}
 
 
 def test_get_query_params_ftp_scheme():
-    """Test case 25: Test get_query_params function works with FTP URLs."""
+    """Test case 22: Test get_query_params function works with FTP URLs."""
     url = "ftp://ftp.example.com?mode=binary"
     result = get_query_params(url)
     assert result == {"mode": ["binary"]}
 
 
 def test_get_query_params_file_scheme():
-    """Test case 26: Test get_query_params function works with file URLs."""
+    """Test case 23: Test get_query_params function works with file URLs."""
     url = "file:///path/to/file?param=value"
     result = get_query_params(url)
     assert result == {"param": ["value"]}
 
 
 def test_get_query_params_preserves_order():
-    """Test case 27: Test get_query_params function preserves order of multiple values."""
+    """Test case 24: Test get_query_params function preserves order of multiple values."""
     url = "https://example.com?priority=high&priority=medium&priority=low"
     result = get_query_params(url)
 
     # The order should be preserved
     assert result["priority"] == ["high", "medium", "low"]
+def test_get_query_params_with_empty_string():
+    """Test case 25: Test get_query_params function with empty string raises ValueError."""
+    with pytest.raises(ValueError, match="URL must be a non-empty string"):
+        get_query_params("")
+
+
+def test_get_query_params_with_whitespace_string():
+    """Test case 26: Test get_query_params function with whitespace-only string raises ValueError."""
+    with pytest.raises(ValueError, match="URL must be a non-empty string"):
+        get_query_params("   ")
+
+
+def test_get_query_params_with_none():
+    """Test case 27: Test get_query_params function with None raises TypeError."""
+    with pytest.raises(TypeError):
+        get_query_params(None)
+
+

--- a/pytest/unit/http_functions/test_http_get.py
+++ b/pytest/unit/http_functions/test_http_get.py
@@ -5,34 +5,10 @@ import pytest
 from http_functions.http_get import http_get
 
 
-def test_http_get_with_empty_url():
-    """
-    Test case 1: Empty URL raises ValueError.
-    """
-    with pytest.raises(ValueError, match="URL must be a non-empty string"):
-        http_get("")
-
-
-def test_http_get_with_whitespace_url():
-    """
-    Test case 2: Whitespace-only URL raises ValueError.
-    """
-    with pytest.raises(ValueError, match="URL must be a non-empty string"):
-        http_get("   ")
-
-
-def test_http_get_with_none_url():
-    """
-    Test case 3: None URL raises TypeError.
-    """
-    with pytest.raises(TypeError):
-        http_get(None)
-
-
 @patch("urllib.request.urlopen")
 def test_http_get_successful_request(mock_urlopen):
     """
-    Test case 4: Successful HTTP GET request returns correct response structure.
+    Test case 1: Successful HTTP GET request returns correct response structure.
     """
     # Mock response
     mock_response = Mock()
@@ -53,7 +29,7 @@ def test_http_get_successful_request(mock_urlopen):
 @patch("urllib.request.urlopen")
 def test_http_get_with_custom_headers(mock_urlopen):
     """
-    Test case 5: HTTP GET request applies custom headers correctly.
+    Test case 2: HTTP GET request applies custom headers correctly.
     """
     mock_response = Mock()
     mock_response.getcode.return_value = 200
@@ -76,7 +52,7 @@ def test_http_get_with_custom_headers(mock_urlopen):
 @patch("urllib.request.urlopen")
 def test_http_get_with_custom_timeout(mock_urlopen):
     """
-    Test case 6: HTTP GET request with custom timeout value.
+    Test case 3: HTTP GET request with custom timeout value.
     """
     mock_response = Mock()
     mock_response.getcode.return_value = 200
@@ -95,7 +71,7 @@ def test_http_get_with_custom_timeout(mock_urlopen):
 @patch("urllib.request.urlopen")
 def test_http_get_default_timeout(mock_urlopen):
     """
-    Test case 7: Default timeout is 30 seconds when not specified.
+    Test case 4: Default timeout is 30 seconds when not specified.
     """
     mock_response = Mock()
     mock_response.getcode.return_value = 200
@@ -108,6 +84,30 @@ def test_http_get_default_timeout(mock_urlopen):
 
     # Check that timeout=30 was passed
     assert mock_urlopen.call_args[1]["timeout"] == 30
+
+
+def test_http_get_with_empty_url():
+    """
+    Test case 5: Empty URL raises ValueError.
+    """
+    with pytest.raises(ValueError, match="URL must be a non-empty string"):
+        http_get("")
+
+
+def test_http_get_with_whitespace_url():
+    """
+    Test case 6: Whitespace-only URL raises ValueError.
+    """
+    with pytest.raises(ValueError, match="URL must be a non-empty string"):
+        http_get("   ")
+
+
+def test_http_get_with_none_url():
+    """
+    Test case 7: None URL raises TypeError.
+    """
+    with pytest.raises(TypeError):
+        http_get(None)
 
 
 @patch("urllib.request.urlopen")

--- a/pytest/unit/http_functions/test_http_post.py
+++ b/pytest/unit/http_functions/test_http_post.py
@@ -6,27 +6,9 @@ import pytest
 from http_functions.http_post import http_post
 
 
-def test_http_post_with_empty_url():
-    """Test case 1: Test http_post function with empty URL raises ValueError."""
-    with pytest.raises(ValueError, match="URL must be a non-empty string"):
-        http_post("")
-
-
-def test_http_post_with_whitespace_url():
-    """Test case 2: Test http_post function with whitespace-only URL raises ValueError."""
-    with pytest.raises(ValueError, match="URL must be a non-empty string"):
-        http_post("   ")
-
-
-def test_http_post_with_none_url():
-    """Test case 3: Test http_post function with None URL raises TypeError."""
-    with pytest.raises(TypeError):
-        http_post(None)
-
-
 @patch("urllib.request.urlopen")
 def test_http_post_no_data(mock_urlopen):
-    """Test case 4: Test HTTP POST request with no data payload."""
+    """Test case 1: Test HTTP POST request with no data payload."""
     mock_response = Mock()
     mock_response.getcode.return_value = 200
     mock_response.read.return_value = b'{"success": true}'
@@ -47,7 +29,7 @@ def test_http_post_no_data(mock_urlopen):
 
 @patch("urllib.request.urlopen")
 def test_http_post_with_dict_data(mock_urlopen):
-    """Test case 5: Test HTTP POST request with dictionary data gets JSON encoded."""
+    """Test case 2: Test HTTP POST request with dictionary data gets JSON encoded."""
     mock_response = Mock()
     mock_response.getcode.return_value = 201
     mock_response.read.return_value = b'{"created": true}'
@@ -69,7 +51,7 @@ def test_http_post_with_dict_data(mock_urlopen):
 
 @patch("urllib.request.urlopen")
 def test_http_post_with_string_data(mock_urlopen):
-    """Test case 6: Test HTTP POST request with string data uses form encoding."""
+    """Test case 3: Test HTTP POST request with string data uses form encoding."""
     mock_response = Mock()
     mock_response.getcode.return_value = 200
     mock_response.read.return_value = b"OK"
@@ -91,7 +73,7 @@ def test_http_post_with_string_data(mock_urlopen):
 
 @patch("urllib.request.urlopen")
 def test_http_post_with_custom_headers(mock_urlopen):
-    """Test case 7: Test HTTP POST request with custom headers are properly set."""
+    """Test case 4: Test HTTP POST request with custom headers are properly set."""
     mock_response = Mock()
     mock_response.getcode.return_value = 200
     mock_response.read.return_value = b"test response"
@@ -112,7 +94,7 @@ def test_http_post_with_custom_headers(mock_urlopen):
 
 @patch("urllib.request.urlopen")
 def test_http_post_with_custom_timeout(mock_urlopen):
-    """Test case 8: Test HTTP POST request with custom timeout value."""
+    """Test case 5: Test HTTP POST request with custom timeout value."""
     mock_response = Mock()
     mock_response.getcode.return_value = 200
     mock_response.read.return_value = b"test"
@@ -129,7 +111,7 @@ def test_http_post_with_custom_timeout(mock_urlopen):
 
 @patch("urllib.request.urlopen")
 def test_http_post_default_timeout(mock_urlopen):
-    """Test case 9: Test that default timeout is 30 seconds when not specified."""
+    """Test case 6: Test that default timeout is 30 seconds when not specified."""
     mock_response = Mock()
     mock_response.getcode.return_value = 200
     mock_response.read.return_value = b"test"
@@ -145,7 +127,7 @@ def test_http_post_default_timeout(mock_urlopen):
 
 @patch("urllib.request.urlopen")
 def test_http_post_http_error_with_response_body(mock_urlopen):
-    """Test case 10: Test HTTP POST request with HTTP error that includes response body."""
+    """Test case 7: Test HTTP POST request with HTTP error that includes response body."""
     error = urllib.error.HTTPError(
         url="https://example.com",
         code=400,
@@ -166,7 +148,7 @@ def test_http_post_http_error_with_response_body(mock_urlopen):
 
 @patch("urllib.request.urlopen")
 def test_http_post_complex_nested_data(mock_urlopen):
-    """Test case 11: Test HTTP POST request with complex nested dictionary data."""
+    """Test case 8: Test HTTP POST request with complex nested dictionary data."""
     mock_response = Mock()
     mock_response.getcode.return_value = 200
     mock_response.read.return_value = b'{"received": true}'
@@ -188,3 +170,21 @@ def test_http_post_complex_nested_data(mock_urlopen):
     request = call_args[0]
     sent_data = json.loads(request.data.decode("utf-8"))
     assert sent_data == data
+def test_http_post_with_empty_url():
+    """Test case 9: Test http_post function with empty URL raises ValueError."""
+    with pytest.raises(ValueError, match="URL must be a non-empty string"):
+        http_post("")
+
+
+def test_http_post_with_whitespace_url():
+    """Test case 10: Test http_post function with whitespace-only URL raises ValueError."""
+    with pytest.raises(ValueError, match="URL must be a non-empty string"):
+        http_post("   ")
+
+
+def test_http_post_with_none_url():
+    """Test case 11: Test http_post function with None URL raises TypeError."""
+    with pytest.raises(TypeError):
+        http_post(None)
+
+

--- a/pytest/unit/http_functions/test_parse_url.py
+++ b/pytest/unit/http_functions/test_parse_url.py
@@ -2,26 +2,8 @@ import pytest
 from http_functions.parse_url import parse_url
 
 
-def test_parse_url_with_empty_string():
-    """Test case 1: Test parse_url function with empty string raises ValueError."""
-    with pytest.raises(ValueError, match="URL must be a non-empty string"):
-        parse_url("")
-
-
-def test_parse_url_with_whitespace_string():
-    """Test case 2: Test parse_url function with whitespace-only string raises ValueError."""
-    with pytest.raises(ValueError, match="URL must be a non-empty string"):
-        parse_url("   ")
-
-
-def test_parse_url_with_none():
-    """Test case 3: Test parse_url function with None raises TypeError."""
-    with pytest.raises(TypeError):
-        parse_url(None)
-
-
 def test_parse_simple_https_url():
-    """Test case 4: Test parsing a simple HTTPS URL returns correct components."""
+    """Test case 1: Test parsing a simple HTTPS URL returns correct components."""
     url = "https://example.com"
     result = parse_url(url)
 
@@ -38,7 +20,7 @@ def test_parse_simple_https_url():
 
 
 def test_parse_url_with_path():
-    """Test case 5: Test parsing URL with path component."""
+    """Test case 2: Test parsing URL with path component."""
     url = "https://example.com/api/v1/users"
     result = parse_url(url)
 
@@ -48,7 +30,7 @@ def test_parse_url_with_path():
 
 
 def test_parse_url_with_port():
-    """Test case 6: Test parsing URL with port number."""
+    """Test case 3: Test parsing URL with port number."""
     url = "https://example.com:8080/api"
     result = parse_url(url)
 
@@ -60,7 +42,7 @@ def test_parse_url_with_port():
 
 
 def test_parse_url_with_query_parameters():
-    """Test case 7: Test parsing URL with query parameters."""
+    """Test case 4: Test parsing URL with query parameters."""
     url = "https://example.com/search?q=python&page=1&sort=date"
     result = parse_url(url)
 
@@ -71,7 +53,7 @@ def test_parse_url_with_query_parameters():
 
 
 def test_parse_url_with_fragment():
-    """Test case 8: Test parsing URL with fragment component."""
+    """Test case 5: Test parsing URL with fragment component."""
     url = "https://example.com/docs#section1"
     result = parse_url(url)
 
@@ -82,7 +64,7 @@ def test_parse_url_with_fragment():
 
 
 def test_parse_url_with_username_and_password():
-    """Test case 9: Test parsing URL with authentication credentials."""
+    """Test case 6: Test parsing URL with authentication credentials."""
     url = "https://user:pass@example.com/secure"
     result = parse_url(url)
 
@@ -95,7 +77,7 @@ def test_parse_url_with_username_and_password():
 
 
 def test_parse_url_with_username_only():
-    """Test case 10: Test parsing URL with username but no password."""
+    """Test case 7: Test parsing URL with username but no password."""
     url = "https://user@example.com/api"
     result = parse_url(url)
 
@@ -108,7 +90,7 @@ def test_parse_url_with_username_only():
 
 
 def test_parse_complex_url_all_components():
-    """Test case 11: Test parsing a complex URL with all components present."""
+    """Test case 8: Test parsing a complex URL with all components present."""
     url = "https://user:pass@example.com:8080/api/v1/users?limit=10&offset=20#results"
     result = parse_url(url)
 
@@ -125,35 +107,35 @@ def test_parse_complex_url_all_components():
 
 
 def test_parse_url_http_scheme():
-    """Test case 12: Test parsing URL with HTTP scheme."""
+    """Test case 9: Test parsing URL with HTTP scheme."""
     url = "http://example.com"
     result = parse_url(url)
     assert result["scheme"] == "http"
 
 
 def test_parse_url_ftp_scheme():
-    """Test case 13: Test parsing URL with FTP scheme."""
+    """Test case 10: Test parsing URL with FTP scheme."""
     url = "ftp://ftp.example.com"
     result = parse_url(url)
     assert result["scheme"] == "ftp"
 
 
 def test_parse_url_file_scheme():
-    """Test case 14: Test parsing URL with file scheme."""
+    """Test case 11: Test parsing URL with file scheme."""
     url = "file:///path/to/file"
     result = parse_url(url)
     assert result["scheme"] == "file"
 
 
 def test_parse_url_mailto_scheme():
-    """Test case 15: Test parsing URL with mailto scheme."""
+    """Test case 12: Test parsing URL with mailto scheme."""
     url = "mailto:test@example.com"
     result = parse_url(url)
     assert result["scheme"] == "mailto"
 
 
 def test_parse_url_with_ip_address():
-    """Test case 16: Test parsing URL with IP address as hostname."""
+    """Test case 13: Test parsing URL with IP address as hostname."""
     url = "http://192.168.1.1:8000/api"
     result = parse_url(url)
 
@@ -164,7 +146,7 @@ def test_parse_url_with_ip_address():
 
 
 def test_parse_url_with_params():
-    """Test case 17: Test parsing URL with parameters (semicolon-separated)."""
+    """Test case 14: Test parsing URL with parameters (semicolon-separated)."""
     url = "http://example.com/path;param1=value1;param2=value2"
     result = parse_url(url)
 
@@ -175,7 +157,7 @@ def test_parse_url_with_params():
 
 
 def test_parse_url_with_trailing_slash():
-    """Test case 18: Test parsing URL with trailing slash in path."""
+    """Test case 15: Test parsing URL with trailing slash in path."""
     url = "https://example.com/"
     result = parse_url(url)
 
@@ -187,7 +169,7 @@ def test_parse_url_with_trailing_slash():
 
 
 def test_parse_url_empty_components():
-    """Test case 19: Test parsing URL handles empty components correctly."""
+    """Test case 16: Test parsing URL handles empty components correctly."""
     url = "https://example.com/"
     result = parse_url(url)
 
@@ -196,3 +178,21 @@ def test_parse_url_empty_components():
     assert result["path"] == "/"
     assert result["query"] == ""
     assert result["fragment"] == ""
+def test_parse_url_with_empty_string():
+    """Test case 17: Test parse_url function with empty string raises ValueError."""
+    with pytest.raises(ValueError, match="URL must be a non-empty string"):
+        parse_url("")
+
+
+def test_parse_url_with_whitespace_string():
+    """Test case 18: Test parse_url function with whitespace-only string raises ValueError."""
+    with pytest.raises(ValueError, match="URL must be a non-empty string"):
+        parse_url("   ")
+
+
+def test_parse_url_with_none():
+    """Test case 19: Test parse_url function with None raises TypeError."""
+    with pytest.raises(TypeError):
+        parse_url(None)
+
+

--- a/pytest/unit/http_functions/test_upload_file.py
+++ b/pytest/unit/http_functions/test_upload_file.py
@@ -6,57 +6,6 @@ from unittest.mock import MagicMock
 from http_functions.upload_file import upload_file
 
 
-def test_upload_file_with_empty_url() -> None:
-    """Test case 1: Test upload_file function with empty URL raises ValueError."""
-    with pytest.raises(ValueError, match="URL must be a non-empty string"):
-        upload_file("", "test.txt")
-
-
-def test_upload_file_with_whitespace_url() -> None:
-    """Test case 2: Test upload_file function with whitespace-only URL raises ValueError."""
-    with pytest.raises(ValueError, match="URL must be a non-empty string"):
-        upload_file("   ", "test.txt")
-
-
-def test_upload_file_with_none_url() -> None:
-    """Test case 3: Test upload_file function with None URL raises ValueError."""
-    with pytest.raises(ValueError, match="URL must be a non-empty string"):
-        upload_file(None, "test.txt")
-
-
-def test_upload_file_with_empty_file_path() -> None:
-    """Test case 4: Test upload_file function with empty file path raises ValueError."""
-    with pytest.raises(ValueError, match="file_path must be a non-empty string"):
-        upload_file("https://example.com/upload", "")
-
-
-def test_upload_file_with_whitespace_file_path() -> None:
-    """Test case 5: Test upload_file function with whitespace-only file path raises ValueError."""
-    with pytest.raises(ValueError, match="file_path must be a non-empty string"):
-        upload_file("https://example.com/upload", "   ")
-
-
-def test_upload_file_with_none_file_path() -> None:
-    """Test case 6: Test upload_file function with None file path raises ValueError."""
-    with pytest.raises(ValueError, match="file_path must be a non-empty string"):
-        upload_file("https://example.com/upload", None)
-
-
-@patch("pathlib.Path.exists", return_value=False)
-def test_upload_file_not_found(mock_exists: MagicMock) -> None:
-    """Test case 7: Test upload_file function when file doesn't exist raises FileNotFoundError."""
-    with pytest.raises(FileNotFoundError, match="File not found"):
-        upload_file("https://example.com/upload", "/tmp/nonexistent.txt")
-
-
-@patch("pathlib.Path.exists", return_value=True)
-@patch("pathlib.Path.is_file", return_value=False)
-def test_upload_file_not_a_file(mock_is_file: MagicMock, mock_exists: MagicMock) -> None:
-    """Test case 8: Test upload_file function when path is not a file raises ValueError."""
-    with pytest.raises(ValueError, match="Path is not a file"):
-        upload_file("https://example.com/upload", "/tmp/directory")
-
-
 @patch("pathlib.Path.exists", return_value=True)
 @patch("pathlib.Path.is_file", return_value=True)
 @patch("builtins.open", new_callable=mock_open, read_data=b"test file content")
@@ -69,7 +18,7 @@ def test_upload_file_successful(
     mock_is_file: MagicMock,
     mock_exists: MagicMock,
 ) -> None:
-    """Test case 9: Test successful file upload returns correct response structure."""
+    """Test case 1: Test successful file upload returns correct response structure."""
     # Mock response
     mock_response = Mock()
     mock_response.getcode.return_value = 200
@@ -104,7 +53,7 @@ def test_upload_file_unknown_content_type(
     mock_is_file: MagicMock,
     mock_exists: MagicMock,
 ) -> None:
-    """Test case 10: Test file upload when content type cannot be determined uses default."""
+    """Test case 2: Test file upload when content type cannot be determined uses default."""
     mock_response = Mock()
     mock_response.getcode.return_value = 200
     mock_response.read.return_value = b"OK"
@@ -133,7 +82,7 @@ def test_upload_file_with_custom_field_name(
     mock_is_file: MagicMock,
     mock_exists: MagicMock,
 ) -> None:
-    """Test case 11: Test file upload with custom field name parameter."""
+    """Test case 3: Test file upload with custom field name parameter."""
     mock_response = Mock()
     mock_response.getcode.return_value = 200
     mock_response.read.return_value = b"OK"
@@ -164,7 +113,7 @@ def test_upload_file_with_custom_headers(
     mock_is_file: MagicMock,
     mock_exists: MagicMock,
 ) -> None:
-    """Test case 12: Test file upload with additional custom headers."""
+    """Test case 4: Test file upload with additional custom headers."""
     mock_response = Mock()
     mock_response.getcode.return_value = 200
     mock_response.read.return_value = b"OK"
@@ -195,7 +144,7 @@ def test_upload_file_with_additional_data(
     mock_is_file: MagicMock,
     mock_exists: MagicMock,
 ) -> None:
-    """Test case 13: Test file upload with additional form data fields."""
+    """Test case 5: Test file upload with additional form data fields."""
     mock_response = Mock()
     mock_response.getcode.return_value = 200
     mock_response.read.return_value = b"OK"
@@ -233,7 +182,7 @@ def test_upload_file_with_custom_timeout(
     mock_is_file: MagicMock,
     mock_exists: MagicMock,
 ) -> None:
-    """Test case 14: Test file upload with custom timeout value."""
+    """Test case 6: Test file upload with custom timeout value."""
     mock_response = Mock()
     mock_response.getcode.return_value = 200
     mock_response.read.return_value = b"OK"
@@ -260,7 +209,7 @@ def test_upload_file_default_timeout(
     mock_is_file: MagicMock,
     mock_exists: MagicMock,
 ) -> None:
-    """Test case 15: Test that default timeout is 30 seconds when not specified."""
+    """Test case 7: Test that default timeout is 30 seconds when not specified."""
     mock_response = Mock()
     mock_response.getcode.return_value = 200
     mock_response.read.return_value = b"OK"
@@ -272,6 +221,57 @@ def test_upload_file_default_timeout(
 
         # Check that timeout=30 was passed
         assert mock_urlopen.call_args[1]["timeout"] == 30
+
+
+def test_upload_file_with_empty_url() -> None:
+    """Test case 8: Test upload_file function with empty URL raises ValueError."""
+    with pytest.raises(ValueError, match="URL must be a non-empty string"):
+        upload_file("", "test.txt")
+
+
+def test_upload_file_with_whitespace_url() -> None:
+    """Test case 9: Test upload_file function with whitespace-only URL raises ValueError."""
+    with pytest.raises(ValueError, match="URL must be a non-empty string"):
+        upload_file("   ", "test.txt")
+
+
+def test_upload_file_with_none_url() -> None:
+    """Test case 10: Test upload_file function with None URL raises ValueError."""
+    with pytest.raises(ValueError, match="URL must be a non-empty string"):
+        upload_file(None, "test.txt")
+
+
+def test_upload_file_with_empty_file_path() -> None:
+    """Test case 11: Test upload_file function with empty file path raises ValueError."""
+    with pytest.raises(ValueError, match="file_path must be a non-empty string"):
+        upload_file("https://example.com/upload", "")
+
+
+def test_upload_file_with_whitespace_file_path() -> None:
+    """Test case 12: Test upload_file function with whitespace-only file path raises ValueError."""
+    with pytest.raises(ValueError, match="file_path must be a non-empty string"):
+        upload_file("https://example.com/upload", "   ")
+
+
+def test_upload_file_with_none_file_path() -> None:
+    """Test case 13: Test upload_file function with None file path raises ValueError."""
+    with pytest.raises(ValueError, match="file_path must be a non-empty string"):
+        upload_file("https://example.com/upload", None)
+
+
+@patch("pathlib.Path.exists", return_value=False)
+def test_upload_file_not_found(mock_exists: MagicMock) -> None:
+    """Test case 14: Test upload_file function when file doesn't exist raises FileNotFoundError."""
+    with pytest.raises(FileNotFoundError, match="File not found"):
+        upload_file("https://example.com/upload", "/tmp/nonexistent.txt")
+
+
+@patch("pathlib.Path.exists", return_value=True)
+@patch("pathlib.Path.is_file", return_value=False)
+def test_upload_file_not_a_file(mock_is_file: MagicMock, mock_exists: MagicMock) -> None:
+    """Test case 15: Test upload_file function when path is not a file raises ValueError."""
+    with pytest.raises(ValueError, match="Path is not a file"):
+        upload_file("https://example.com/upload", "/tmp/directory")
 
 
 @patch("pathlib.Path.exists", return_value=True)


### PR DESCRIPTION
## Summary
- Reordered the HTTP-related unit tests so that happy-path coverage appears before error handling tests and grouped all exception checks at the end of each file.
- Renumbered every "Test case" docstring to match the new ordering and keep documentation consistent across the HTTP test suite.

## Testing
- pytest pytest/unit/http_functions

------
https://chatgpt.com/codex/tasks/task_e_68e7f17d029c8325b18b5fe8f2fd7eca