### PR TITLE
Reorder tests to group error cases last

### DIFF
--- a/pytest/unit/asyncio_functions/test_async_cleanup.py
+++ b/pytest/unit/asyncio_functions/test_async_cleanup.py
@@ -30,32 +30,9 @@ async def test_async_cleanup_successful_task_with_cleanup() -> None:
 
 
 @pytest.mark.asyncio
-async def test_async_cleanup_failing_task_with_cleanup() -> None:
-    """
-    Test case 2: Task fails but cleanup is still called.
-    """
-    # Arrange
-    cleanup_called = []
-
-    async def failing_task() -> str:
-        await asyncio.sleep(0.001)
-        raise ValueError("Task failed")
-
-    async def cleanup_function() -> None:
-        cleanup_called.append(True)
-
-    # Act & Assert
-    with pytest.raises(ValueError, match="Task failed"):
-        await async_cleanup(failing_task, cleanup_function)
-
-    # Cleanup should still have been called
-    assert len(cleanup_called) == 1
-
-
-@pytest.mark.asyncio
 async def test_async_cleanup_immediate_task_completion() -> None:
     """
-    Test case 3: Immediate task completion with cleanup.
+    Test case 2: Immediate task completion with cleanup.
     """
     # Arrange
     cleanup_called = []
@@ -77,7 +54,7 @@ async def test_async_cleanup_immediate_task_completion() -> None:
 @pytest.mark.asyncio
 async def test_async_cleanup_execution_order() -> None:
     """
-    Test case 4: Verify cleanup is called after task completes.
+    Test case 3: Verify cleanup is called after task completes.
     """
     # Arrange
     execution_order = []
@@ -100,30 +77,9 @@ async def test_async_cleanup_execution_order() -> None:
 
 
 @pytest.mark.asyncio
-async def test_async_cleanup_on_exception() -> None:
-    """
-    Test case 5: Cleanup is called even when task raises exception.
-    """
-    # Arrange
-    cleanup_called = []
-
-    async def task_with_exception() -> None:
-        raise RuntimeError("Critical error")
-
-    async def cleanup_function() -> None:
-        cleanup_called.append(True)
-
-    # Act & Assert
-    with pytest.raises(RuntimeError, match="Critical error"):
-        await async_cleanup(task_with_exception, cleanup_function)
-
-    assert len(cleanup_called) == 1
-
-
-@pytest.mark.asyncio
 async def test_async_cleanup_different_return_types() -> None:
     """
-    Test case 6: Different return value types are preserved.
+    Test case 4: Different return value types are preserved.
     """
     # Arrange
     cleanup_called = []
@@ -139,4 +95,46 @@ async def test_async_cleanup_different_return_types() -> None:
 
     # Assert
     assert result == [1, 2, 3]
+    assert len(cleanup_called) == 1
+@pytest.mark.asyncio
+async def test_async_cleanup_failing_task_with_cleanup() -> None:
+    """
+    Test case 5: Task fails but cleanup is still called.
+    """
+    # Arrange
+    cleanup_called = []
+
+    async def failing_task() -> str:
+        await asyncio.sleep(0.001)
+        raise ValueError("Task failed")
+
+    async def cleanup_function() -> None:
+        cleanup_called.append(True)
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="Task failed"):
+        await async_cleanup(failing_task, cleanup_function)
+
+    # Cleanup should still have been called
+    assert len(cleanup_called) == 1
+
+
+@pytest.mark.asyncio
+async def test_async_cleanup_on_exception() -> None:
+    """
+    Test case 6: Cleanup is called even when task raises exception.
+    """
+    # Arrange
+    cleanup_called = []
+
+    async def task_with_exception() -> None:
+        raise RuntimeError("Critical error")
+
+    async def cleanup_function() -> None:
+        cleanup_called.append(True)
+
+    # Act & Assert
+    with pytest.raises(RuntimeError, match="Critical error"):
+        await async_cleanup(task_with_exception, cleanup_function)
+
     assert len(cleanup_called) == 1

--- a/pytest/unit/asyncio_functions/test_async_connection_pool.py
+++ b/pytest/unit/asyncio_functions/test_async_connection_pool.py
@@ -64,23 +64,9 @@ async def test_async_connection_pool_multiple_connections() -> None:
 
 
 @pytest.mark.asyncio
-async def test_async_connection_pool_full_error() -> None:
-    """
-    Test case 4: RuntimeError when adding to a full pool.
-    """
-    # Arrange
-    pool: AsyncConnectionPool[str] = AsyncConnectionPool(max_connections=1)
-    await pool.add_connection("conn1")
-
-    # Act & Assert
-    with pytest.raises(RuntimeError, match="Connection pool is full"):
-        await pool.add_connection("conn2")
-
-
-@pytest.mark.asyncio
 async def test_use_connection_function() -> None:
     """
-    Test case 5: Use use_connection helper function.
+    Test case 4: Use use_connection helper function.
     """
     # Arrange
     pool: AsyncConnectionPool[str] = AsyncConnectionPool(max_connections=1)
@@ -99,7 +85,7 @@ async def test_use_connection_function() -> None:
 @pytest.mark.asyncio
 async def test_use_connection_reuse() -> None:
     """
-    Test case 6: Connection is properly reused after release.
+    Test case 5: Connection is properly reused after release.
     """
     # Arrange
     pool: AsyncConnectionPool[str] = AsyncConnectionPool(max_connections=1)
@@ -123,7 +109,7 @@ async def test_use_connection_reuse() -> None:
 @pytest.mark.asyncio
 async def test_use_connection_concurrent_access() -> None:
     """
-    Test case 7: Concurrent tasks use different connections.
+    Test case 6: Concurrent tasks use different connections.
     """
     # Arrange
     pool: AsyncConnectionPool[int] = AsyncConnectionPool(max_connections=2)
@@ -142,6 +128,20 @@ async def test_use_connection_concurrent_access() -> None:
 
     # Assert
     assert set(results) == {10, 20}
+
+
+@pytest.mark.asyncio
+async def test_async_connection_pool_full_error() -> None:
+    """
+    Test case 7: RuntimeError when adding to a full pool.
+    """
+    # Arrange
+    pool: AsyncConnectionPool[str] = AsyncConnectionPool(max_connections=1)
+    await pool.add_connection("conn1")
+
+    # Act & Assert
+    with pytest.raises(RuntimeError, match="Connection pool is full"):
+        await pool.add_connection("conn2")
 
 
 @pytest.mark.asyncio

--- a/pytest/unit/asyncio_functions/test_async_event_loop.py
+++ b/pytest/unit/asyncio_functions/test_async_event_loop.py
@@ -69,23 +69,9 @@ def test_async_event_loop_immediate_return() -> None:
     assert result == "immediate"
 
 
-def test_async_event_loop_exception_propagation() -> None:
-    """
-    Test case 5: Exceptions are properly propagated.
-    """
-    # Arrange
-    async def failing_task() -> None:
-        await asyncio.sleep(0.001)
-        raise ValueError("Task failed")
-
-    # Act & Assert
-    with pytest.raises(ValueError, match="Task failed"):
-        async_event_loop(failing_task)
-
-
 def test_async_event_loop_complex_computation() -> None:
     """
-    Test case 6: Complex computation with multiple awaits.
+    Test case 5: Complex computation with multiple awaits.
     """
     # Arrange
     async def complex_task() -> int:
@@ -101,3 +87,15 @@ def test_async_event_loop_complex_computation() -> None:
 
     # Assert
     assert result == 10  # 0+1+2+3+4
+def test_async_event_loop_exception_propagation() -> None:
+    """
+    Test case 6: Exceptions are properly propagated.
+    """
+    # Arrange
+    async def failing_task() -> None:
+        await asyncio.sleep(0.001)
+        raise ValueError("Task failed")
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="Task failed"):
+        async_event_loop(failing_task)

--- a/pytest/unit/asyncio_functions/test_async_stream_processor.py
+++ b/pytest/unit/asyncio_functions/test_async_stream_processor.py
@@ -94,9 +94,29 @@ async def test_async_stream_processor_transformation() -> None:
 
 
 @pytest.mark.asyncio
+async def test_async_stream_processor_large_stream() -> None:
+    """
+    Test case 5: Process a large stream efficiently.
+    """
+    # Arrange
+    count = []
+
+    async def generate_large_stream() -> AsyncIterator[str]:
+        for i in range(100):
+            yield f"data_{i}"
+
+    async def count_items(item: str) -> None:
+        count.append(1)
+
+    # Act
+    await async_stream_processor(generate_large_stream(), count_items)
+
+    # Assert
+    assert len(count) == 100
+@pytest.mark.asyncio
 async def test_async_stream_processor_exception_in_processor() -> None:
     """
-    Test case 5: Exception in processor stops processing.
+    Test case 6: Exception in processor stops processing.
     """
     # Arrange
     processed_items = []
@@ -115,25 +135,3 @@ async def test_async_stream_processor_exception_in_processor() -> None:
         await async_stream_processor(generate_data(), failing_processor)
 
     assert len(processed_items) == 3
-
-
-@pytest.mark.asyncio
-async def test_async_stream_processor_large_stream() -> None:
-    """
-    Test case 6: Process a large stream efficiently.
-    """
-    # Arrange
-    count = []
-
-    async def generate_large_stream() -> AsyncIterator[str]:
-        for i in range(100):
-            yield f"data_{i}"
-
-    async def count_items(item: str) -> None:
-        count.append(1)
-
-    # Act
-    await async_stream_processor(generate_large_stream(), count_items)
-
-    # Assert
-    assert len(count) == 100

--- a/pytest/unit/asyncio_functions/test_async_throttle.py
+++ b/pytest/unit/asyncio_functions/test_async_throttle.py
@@ -71,24 +71,9 @@ async def test_async_throttle_single_item() -> None:
 
 
 @pytest.mark.asyncio
-async def test_async_throttle_type_error_invalid_delay() -> None:
-    """
-    Test case 4: TypeError for non-numeric delay.
-    """
-    # Arrange
-    async def generate_items() -> AsyncGenerator[int, None]:
-        yield 1
-
-    # Act & Assert
-    with pytest.raises(TypeError, match="delay must be a float"):
-        async for _ in async_throttle(generate_items(), delay="invalid"):  # type: ignore
-            pass
-
-
-@pytest.mark.asyncio
 async def test_async_throttle_different_data_types() -> None:
     """
-    Test case 5: Throttle generators with different data types.
+    Test case 4: Throttle generators with different data types.
     """
     # Arrange
     async def string_generator() -> AsyncGenerator[str, None]:
@@ -108,7 +93,7 @@ async def test_async_throttle_different_data_types() -> None:
 @pytest.mark.asyncio
 async def test_async_throttle_verify_timing() -> None:
     """
-    Test case 6: Verify timing accuracy of throttling.
+    Test case 5: Verify timing accuracy of throttling.
     """
     # Arrange
     async def generate_items() -> AsyncGenerator[int, None]:
@@ -127,3 +112,16 @@ async def test_async_throttle_verify_timing() -> None:
     for i in range(1, len(timestamps)):
         delay = timestamps[i] - timestamps[i - 1]
         assert 0.015 <= delay <= 0.03  # Allow some tolerance
+@pytest.mark.asyncio
+async def test_async_throttle_type_error_invalid_delay() -> None:
+    """
+    Test case 6: TypeError for non-numeric delay.
+    """
+    # Arrange
+    async def generate_items() -> AsyncGenerator[int, None]:
+        yield 1
+
+    # Act & Assert
+    with pytest.raises(TypeError, match="delay must be a float"):
+        async for _ in async_throttle(generate_items(), delay="invalid"):  # type: ignore
+            pass

--- a/pytest/unit/asyncio_functions/test_gather_with_timeout.py
+++ b/pytest/unit/asyncio_functions/test_gather_with_timeout.py
@@ -32,28 +32,9 @@ async def test_gather_with_timeout_all_complete_before_timeout() -> None:
 
 
 @pytest.mark.asyncio
-async def test_gather_with_timeout_timeout_reached() -> None:
-    """
-    Test case 2: Timeout is reached before tasks complete.
-    """
-    # Arrange
-    async def slow_task() -> int:
-        await asyncio.sleep(1.0)
-        return 1
-
-    async def fast_task() -> int:
-        await asyncio.sleep(0.01)
-        return 2
-
-    # Act & Assert
-    with pytest.raises(asyncio.TimeoutError):
-        await gather_with_timeout([slow_task(), fast_task()], timeout=0.05)
-
-
-@pytest.mark.asyncio
 async def test_gather_with_timeout_empty_list() -> None:
     """
-    Test case 3: Empty list of awaitables.
+    Test case 2: Empty list of awaitables.
     """
     # Arrange
     awaitables: list[asyncio.Future[int]] = []
@@ -68,7 +49,7 @@ async def test_gather_with_timeout_empty_list() -> None:
 @pytest.mark.asyncio
 async def test_gather_with_timeout_single_awaitable() -> None:
     """
-    Test case 4: Single awaitable completes successfully.
+    Test case 3: Single awaitable completes successfully.
     """
     # Arrange
     async def single_task() -> str:
@@ -83,24 +64,9 @@ async def test_gather_with_timeout_single_awaitable() -> None:
 
 
 @pytest.mark.asyncio
-async def test_gather_with_timeout_very_short_timeout() -> None:
-    """
-    Test case 5: Very short timeout causes timeout error.
-    """
-    # Arrange
-    async def task() -> int:
-        await asyncio.sleep(0.1)
-        return 42
-
-    # Act & Assert
-    with pytest.raises(asyncio.TimeoutError):
-        await gather_with_timeout([task()], timeout=0.001)
-
-
-@pytest.mark.asyncio
 async def test_gather_with_timeout_mixed_completion_times() -> None:
     """
-    Test case 6: Mixed task completion times, all within timeout.
+    Test case 4: Mixed task completion times, all within timeout.
     """
     # Arrange
     async def instant_task() -> int:
@@ -121,3 +87,35 @@ async def test_gather_with_timeout_mixed_completion_times() -> None:
 
     # Assert
     assert results == [1, 2, 3]
+@pytest.mark.asyncio
+async def test_gather_with_timeout_timeout_reached() -> None:
+    """
+    Test case 5: Timeout is reached before tasks complete.
+    """
+    # Arrange
+    async def slow_task() -> int:
+        await asyncio.sleep(1.0)
+        return 1
+
+    async def fast_task() -> int:
+        await asyncio.sleep(0.01)
+        return 2
+
+    # Act & Assert
+    with pytest.raises(asyncio.TimeoutError):
+        await gather_with_timeout([slow_task(), fast_task()], timeout=0.05)
+
+
+@pytest.mark.asyncio
+async def test_gather_with_timeout_very_short_timeout() -> None:
+    """
+    Test case 6: Very short timeout causes timeout error.
+    """
+    # Arrange
+    async def task() -> int:
+        await asyncio.sleep(0.1)
+        return 42
+
+    # Act & Assert
+    with pytest.raises(asyncio.TimeoutError):
+        await gather_with_timeout([task()], timeout=0.001)

--- a/pytest/unit/asyncio_functions/test_retry_async.py
+++ b/pytest/unit/asyncio_functions/test_retry_async.py
@@ -49,28 +49,9 @@ async def test_retry_async_succeeds_after_failures() -> None:
 
 
 @pytest.mark.asyncio
-async def test_retry_async_fails_all_retries() -> None:
-    """
-    Test case 3: Function fails on all retry attempts.
-    """
-    # Arrange
-    call_count = []
-
-    async def always_failing_task() -> int:
-        call_count.append(1)
-        raise ValueError("Permanent failure")
-
-    # Act & Assert
-    with pytest.raises(ValueError, match="Permanent failure"):
-        await retry_async(always_failing_task, retries=3, delay=0.01)
-
-    assert len(call_count) == 3
-
-
-@pytest.mark.asyncio
 async def test_retry_async_single_retry() -> None:
     """
-    Test case 4: Single retry attempt.
+    Test case 3: Single retry attempt.
     """
     # Arrange
     call_count = []
@@ -90,33 +71,9 @@ async def test_retry_async_single_retry() -> None:
 
 
 @pytest.mark.asyncio
-async def test_retry_async_delay_between_retries() -> None:
-    """
-    Test case 5: Verify delay is applied between retries.
-    """
-    # Arrange
-    call_times = []
-
-    async def failing_task() -> None:
-        call_times.append(asyncio.get_event_loop().time())
-        raise ValueError("Fail")
-
-    # Act & Assert
-    with pytest.raises(ValueError):
-        await retry_async(failing_task, retries=3, delay=0.05)
-
-    # Verify timing
-    assert len(call_times) == 3
-    if len(call_times) >= 2:
-        # Check delay between first and second call
-        delay = call_times[1] - call_times[0]
-        assert 0.04 <= delay <= 0.07
-
-
-@pytest.mark.asyncio
 async def test_retry_async_different_exception_types() -> None:
     """
-    Test case 6: Different exception types are handled.
+    Test case 4: Different exception types are handled.
     """
     # Arrange
     call_count = []
@@ -135,3 +92,44 @@ async def test_retry_async_different_exception_types() -> None:
     # Assert
     assert result == "recovered"
     assert len(call_count) == 3
+@pytest.mark.asyncio
+async def test_retry_async_fails_all_retries() -> None:
+    """
+    Test case 5: Function fails on all retry attempts.
+    """
+    # Arrange
+    call_count = []
+
+    async def always_failing_task() -> int:
+        call_count.append(1)
+        raise ValueError("Permanent failure")
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="Permanent failure"):
+        await retry_async(always_failing_task, retries=3, delay=0.01)
+
+    assert len(call_count) == 3
+
+
+@pytest.mark.asyncio
+async def test_retry_async_delay_between_retries() -> None:
+    """
+    Test case 6: Verify delay is applied between retries.
+    """
+    # Arrange
+    call_times = []
+
+    async def failing_task() -> None:
+        call_times.append(asyncio.get_event_loop().time())
+        raise ValueError("Fail")
+
+    # Act & Assert
+    with pytest.raises(ValueError):
+        await retry_async(failing_task, retries=3, delay=0.05)
+
+    # Verify timing
+    assert len(call_times) == 3
+    if len(call_times) >= 2:
+        # Check delay between first and second call
+        delay = call_times[1] - call_times[0]
+        assert 0.04 <= delay <= 0.07

--- a/pytest/unit/bioinformatics_functions/annotation_functions/test_annotation_to_gtf.py
+++ b/pytest/unit/bioinformatics_functions/annotation_functions/test_annotation_to_gtf.py
@@ -30,9 +30,23 @@ def test_annotation_to_gtf_empty_input() -> None:
     """
     assert annotation_to_gtf([]) == []
 
+def test_annotation_to_gtf_boundary_values() -> None:
+    """
+    Test case 3: Conversion with minimal and maximal field values.
+    """
+    annotations = [
+        {
+            'seqid': '', 'source': '', 'feature': '',
+            'start': 0, 'end': 999999, 'score': '', 'strand': '.',
+            'frame': '', 'attribute': ''
+        }
+    ]
+    expected = ['\t\t\t0\t999999\t\t.\t\t']
+    result = annotation_to_gtf(annotations)
+    assert result == expected
 def test_annotation_to_gtf_missing_required_key() -> None:
     """
-    Test case 3: Error raised when a required key is missing.
+    Test case 4: Error raised when a required key is missing.
     """
     annotations = [
         {
@@ -46,14 +60,14 @@ def test_annotation_to_gtf_missing_required_key() -> None:
 
 def test_annotation_to_gtf_invalid_input_type() -> None:
     """
-    Test case 4: Error raised when input is not a list or tuple.
+    Test case 5: Error raised when input is not a list or tuple.
     """
     with pytest.raises(TypeError, match=r"annotations must be a list or tuple"):
         annotation_to_gtf('not_a_list')  # type: ignore[arg-type]
 
 def test_annotation_to_gtf_invalid_record_type() -> None:
     """
-    Test case 5: Error raised when a record is not a dict.
+    Test case 6: Error raised when a record is not a dict.
     """
     annotations = ['not_a_dict']
     with pytest.raises(TypeError, match=r"record must be a dict"):
@@ -64,18 +78,3 @@ def test_annotation_to_gtf_invalid_record_type() -> None:
         except KeyError as e:
             # If KeyError is raised, fail the test with a message
             pytest.fail(f"Expected TypeError for non-dict record, got KeyError: {e}")
-
-def test_annotation_to_gtf_boundary_values() -> None:
-    """
-    Test case 6: Conversion with minimal and maximal field values.
-    """
-    annotations = [
-        {
-            'seqid': '', 'source': '', 'feature': '',
-            'start': 0, 'end': 999999, 'score': '', 'strand': '.',
-            'frame': '', 'attribute': ''
-        }
-    ]
-    expected = ['\t\t\t0\t999999\t\t.\t\t']
-    result = annotation_to_gtf(annotations)
-    assert result == expected

--- a/pytest/unit/compression_functions/test_decompress_number.py
+++ b/pytest/unit/compression_functions/test_decompress_number.py
@@ -68,35 +68,9 @@ def test_decompress_number_multi_character() -> None:
     assert isinstance(result, int)
 
 
-def test_decompress_number_type_error_non_string_text() -> None:
-    """
-    Test case 5: TypeError when text is not a string.
-    """
-    # Arrange
-    invalid_text = 123
-    index = 0
-
-    # Act & Assert
-    with pytest.raises(TypeError, match="text must be a string"):
-        decompress_number(invalid_text, index)  # type: ignore
-
-
-def test_decompress_number_type_error_non_integer_index() -> None:
-    """
-    Test case 6: TypeError when index is not an integer.
-    """
-    # Arrange
-    text = "?"
-    invalid_index = "0"
-
-    # Act & Assert
-    with pytest.raises(TypeError, match="index must be an integer"):
-        decompress_number(text, invalid_index)  # type: ignore
-
-
 def test_decompress_number_start_at_different_index() -> None:
     """
-    Test case 7: Start decompressing from a different index.
+    Test case 5: Start decompressing from a different index.
     """
     # Arrange
     text = "??A"
@@ -112,7 +86,7 @@ def test_decompress_number_start_at_different_index() -> None:
 
 def test_decompress_number_complex_encoding() -> None:
     """
-    Test case 8: Decompress complex encoded number.
+    Test case 6: Decompress complex encoded number.
     """
     # Arrange
     text = "_ibE"
@@ -124,3 +98,27 @@ def test_decompress_number_complex_encoding() -> None:
     # Assert
     assert new_index <= len(text)
     assert isinstance(result, int)
+def test_decompress_number_type_error_non_string_text() -> None:
+    """
+    Test case 7: TypeError when text is not a string.
+    """
+    # Arrange
+    invalid_text = 123
+    index = 0
+
+    # Act & Assert
+    with pytest.raises(TypeError, match="text must be a string"):
+        decompress_number(invalid_text, index)  # type: ignore
+
+
+def test_decompress_number_type_error_non_integer_index() -> None:
+    """
+    Test case 8: TypeError when index is not an integer.
+    """
+    # Arrange
+    text = "?"
+    invalid_index = "0"
+
+    # Act & Assert
+    with pytest.raises(TypeError, match="index must be an integer"):
+        decompress_number(text, invalid_index)  # type: ignore

--- a/pytest/unit/compression_functions/test_polyline_decoding_list_of_ints.py
+++ b/pytest/unit/compression_functions/test_polyline_decoding_list_of_ints.py
@@ -37,21 +37,9 @@ def test_polyline_decoding_list_of_ints_single_value() -> None:
     assert len(result) >= 1
 
 
-def test_polyline_decoding_list_of_ints_empty_string_error() -> None:
-    """
-    Test case 3: ValueError when encoded text is empty.
-    """
-    # Arrange
-    empty_text = ""
-
-    # Act & Assert
-    with pytest.raises(ValueError, match="Encoded text cannot be empty"):
-        polyline_decoding_list_of_ints(empty_text)
-
-
 def test_polyline_decoding_list_of_ints_precision_handling() -> None:
     """
-    Test case 4: Verify precision is handled correctly.
+    Test case 3: Verify precision is handled correctly.
     """
     # Arrange
     encoded_text = "?AA"
@@ -66,7 +54,7 @@ def test_polyline_decoding_list_of_ints_precision_handling() -> None:
 
 def test_polyline_decoding_list_of_ints_multiple_values() -> None:
     """
-    Test case 5: Decode string with multiple values.
+    Test case 4: Decode string with multiple values.
     """
     # Arrange
     encoded_text = "AAAAA"
@@ -81,7 +69,7 @@ def test_polyline_decoding_list_of_ints_multiple_values() -> None:
 
 def test_polyline_decoding_list_of_ints_complex_encoding() -> None:
     """
-    Test case 6: Decode complex polyline encoded string.
+    Test case 5: Decode complex polyline encoded string.
     """
     # Arrange
     encoded_text = "B_ibE"
@@ -97,7 +85,7 @@ def test_polyline_decoding_list_of_ints_complex_encoding() -> None:
 
 def test_polyline_decoding_list_of_ints_returns_float_list() -> None:
     """
-    Test case 7: Verify return type is list of floats.
+    Test case 6: Verify return type is list of floats.
     """
     # Arrange
     encoded_text = "AAA"
@@ -113,7 +101,7 @@ def test_polyline_decoding_list_of_ints_returns_float_list() -> None:
 
 def test_polyline_decoding_list_of_ints_round_trip() -> None:
     """
-    Test case 8: Verify encoding and decoding are consistent.
+    Test case 7: Verify encoding and decoding are consistent.
     """
     # Arrange
     from compression_functions.polyline_encoding_list_of_ints import (
@@ -131,3 +119,13 @@ def test_polyline_decoding_list_of_ints_round_trip() -> None:
     # Values should be close after round-trip (accounting for precision)
     for i, orig in enumerate(original_values):
         assert abs(decoded[i] - orig) <= 1.0  # Allow some precision loss
+def test_polyline_decoding_list_of_ints_empty_string_error() -> None:
+    """
+    Test case 8: ValueError when encoded text is empty.
+    """
+    # Arrange
+    empty_text = ""
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="Encoded text cannot be empty"):
+        polyline_decoding_list_of_ints(empty_text)

--- a/pytest/unit/compression_functions/test_polyline_encoding_list_of_ints.py
+++ b/pytest/unit/compression_functions/test_polyline_encoding_list_of_ints.py
@@ -66,21 +66,9 @@ def test_polyline_encoding_list_of_ints_mixed_values() -> None:
     assert len(result) > 0
 
 
-def test_polyline_encoding_list_of_ints_empty_list_error() -> None:
-    """
-    Test case 5: ValueError when input list is empty.
-    """
-    # Arrange
-    empty_list: list[int] = []
-
-    # Act & Assert
-    with pytest.raises(ValueError, match="Input list cannot be empty"):
-        polyline_encoding_list_of_ints(empty_list)
-
-
 def test_polyline_encoding_list_of_ints_large_values() -> None:
     """
-    Test case 6: Encode list with large values.
+    Test case 5: Encode list with large values.
     """
     # Arrange
     list_of_ints = [1000, 2000, 3000]
@@ -95,7 +83,7 @@ def test_polyline_encoding_list_of_ints_large_values() -> None:
 
 def test_polyline_encoding_list_of_ints_sequential_values() -> None:
     """
-    Test case 7: Encode sequential values.
+    Test case 6: Encode sequential values.
     """
     # Arrange
     list_of_ints = list(range(0, 10))
@@ -110,7 +98,7 @@ def test_polyline_encoding_list_of_ints_sequential_values() -> None:
 
 def test_polyline_encoding_list_of_ints_zero_values() -> None:
     """
-    Test case 8: Encode list with zeros.
+    Test case 7: Encode list with zeros.
     """
     # Arrange
     list_of_ints = [0, 0, 0]
@@ -121,3 +109,13 @@ def test_polyline_encoding_list_of_ints_zero_values() -> None:
     # Assert
     assert isinstance(result, str)
     assert len(result) > 0
+def test_polyline_encoding_list_of_ints_empty_list_error() -> None:
+    """
+    Test case 8: ValueError when input list is empty.
+    """
+    # Arrange
+    empty_list: list[int] = []
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="Input list cannot be empty"):
+        polyline_encoding_list_of_ints(empty_list)

--- a/pytest/unit/data_types/test_avl_node.py
+++ b/pytest/unit/data_types/test_avl_node.py
@@ -123,22 +123,9 @@ def test_height_update_after_operations() -> None:
     assert tree.root.height == 2
 
 
-def test_delete_non_existing_key() -> None:
-    """
-    Test case 10: Test deleting a non-existing key from the AVL tree.
-    """
-    tree = AVLTree[int]()
-    tree.insert(10)
-    tree.insert(20)
-    with pytest.raises(ValueError):
-        tree.delete(30)
-    assert tree.root.key == 10
-    assert tree.root.right.key == 20
-
-
 def test_insert_duplicate_key() -> None:
     """
-    Test case 11: Test inserting a duplicate key into the AVL tree.
+    Test case 10: Test inserting a duplicate key into the AVL tree.
     """
     tree = AVLTree[int]()
     tree.insert(10)
@@ -151,7 +138,7 @@ def test_insert_duplicate_key() -> None:
 
 def test_delete_root_node() -> None:
     """
-    Test case 12: Test deleting the root node of the AVL tree.
+    Test case 11: Test deleting the root node of the AVL tree.
     """
     tree = AVLTree[int]()
     tree.insert(10)
@@ -164,7 +151,7 @@ def test_delete_root_node() -> None:
 
 def test_large_tree_balance() -> None:
     """
-    Test case 13: Test the balance of a large AVL tree after multiple insertions.
+    Test case 12: Test the balance of a large AVL tree after multiple insertions.
     """
     tree = AVLTree[int]()
     for i in range(1, 101):
@@ -175,7 +162,7 @@ def test_large_tree_balance() -> None:
 
 def test_delete_all_nodes() -> None:
     """
-    Test case 14: Test deleting all nodes from the AVL tree.
+    Test case 13: Test deleting all nodes from the AVL tree.
     """
     tree = AVLTree[int]()
     tree.insert(10)
@@ -189,7 +176,7 @@ def test_delete_all_nodes() -> None:
 
 def test_search_in_empty_tree() -> None:
     """
-    Test case 15: Test searching for a key in an empty AVL tree.
+    Test case 14: Test searching for a key in an empty AVL tree.
     """
     tree = AVLTree[int]()
     node = tree.search(10)
@@ -198,7 +185,7 @@ def test_search_in_empty_tree() -> None:
 
 def test_height_of_empty_tree() -> None:
     """
-    Test case 16: Test the height of an empty AVL tree.
+    Test case 15: Test the height of an empty AVL tree.
     """
     tree = AVLTree[int]()
     assert tree._get_height(tree.root) == 0
@@ -206,7 +193,18 @@ def test_height_of_empty_tree() -> None:
 
 def test_balance_of_empty_tree() -> None:
     """
-    Test case 17: Test the balance factor of an empty AVL tree.
+    Test case 16: Test the balance factor of an empty AVL tree.
     """
     tree = AVLTree[int]()
     assert tree._get_balance(tree.root) == 0
+def test_delete_non_existing_key() -> None:
+    """
+    Test case 17: Test deleting a non-existing key from the AVL tree.
+    """
+    tree = AVLTree[int]()
+    tree.insert(10)
+    tree.insert(20)
+    with pytest.raises(ValueError):
+        tree.delete(30)
+    assert tree.root.key == 10
+    assert tree.root.right.key == 20

--- a/pytest/unit/data_types/test_hash_table.py
+++ b/pytest/unit/data_types/test_hash_table.py
@@ -125,9 +125,17 @@ def test_custom_value_type() -> None:
     assert hash_table.get(2).value == 200
 
 
+def test_in_operator() -> None:
+    """
+    Test case 10: Test using the ``in`` operator with :class:`HashTable`.
+    """
+    hash_table = HashTable[int, str]()
+    hash_table.insert(1, "one")
+    assert (1 in hash_table) is True
+    assert (2 in hash_table) is False
 def test_empty_hash_table() -> None:
     """
-    Test case 10: Test operations on an empty hash table.
+    Test case 11: Test operations on an empty hash table.
     """
     hash_table = HashTable[int, str]()
     assert not hash_table.contains(1)
@@ -137,7 +145,7 @@ def test_empty_hash_table() -> None:
 
 def test_get_nonexistent_key() -> None:
     """
-    Test case 11: Test retrieving a value for a nonexistent key.
+    Test case 12: Test retrieving a value for a nonexistent key.
     """
     hash_table = HashTable[int, str]()
     with pytest.raises(KeyError, match="Key 1 not found in the hash table"):
@@ -146,18 +154,8 @@ def test_get_nonexistent_key() -> None:
 
 def test_remove_nonexistent_key() -> None:
     """
-    Test case 12: Test removing a nonexistent key.
+    Test case 13: Test removing a nonexistent key.
     """
     hash_table = HashTable[int, str]()
     with pytest.raises(KeyError, match="Key 1 not found in the hash table"):
         hash_table.remove(1)
-
-
-def test_in_operator() -> None:
-    """
-    Test case 13: Test using the ``in`` operator with :class:`HashTable`.
-    """
-    hash_table = HashTable[int, str]()
-    hash_table.insert(1, "one")
-    assert (1 in hash_table) is True
-    assert (2 in hash_table) is False

--- a/pytest/unit/data_validation/basic_validation/test_validate_collection.py
+++ b/pytest/unit/data_validation/basic_validation/test_validate_collection.py
@@ -124,9 +124,48 @@ def test_validate_collection_case_7_complex_validation_combinations() -> None:
     )
 
 
+def test_validate_collection_case_13_edge_cases() -> None:
+    """
+    Test case 8: Edge cases and boundary conditions.
+    """
+    # Test single element collections
+    validate_collection([1], list, min_length=1, max_length=1, element_type=int)
+    validate_collection({"a": 1}, dict, min_length=1, max_length=1, element_type=int)
+
+    # Test large collections
+    large_list = list(range(10000))
+    validate_collection(large_list, list, element_type=int)
+
+    # Test nested collections (without element type checking)
+    nested_list = [[1, 2], [3, 4], [5, 6]]
+    validate_collection(nested_list, list)
+
+    # Test collections with None elements
+    validate_collection([1, None, 3], list, element_type=(int, type(None)))
+
+
+def test_validate_collection_case_14_performance_large_collections() -> None:
+    """
+    Test case 9: Performance with large collections.
+    """
+    # Test large collection without element validation (should be fast)
+    large_list = list(range(100000))
+    import time
+
+    start_time = time.time()
+    validate_collection(large_list, list, min_length=1000, max_length=200000)
+    elapsed_time = time.time() - start_time
+    assert elapsed_time < 0.1  # Should be very fast without element checking
+
+    # Test smaller collection with element validation
+    medium_list = list(range(10000))
+    start_time = time.time()
+    validate_collection(medium_list, list, element_type=int)
+    elapsed_time = time.time() - start_time
+    assert elapsed_time < 1.0  # Should complete within 1 second
 def test_validate_collection_case_8_type_error_wrong_collection_type() -> None:
     """
-    Test case 8: TypeError for wrong collection type.
+    Test case 10: TypeError for wrong collection type.
     """
     with pytest.raises(TypeError, match="collection must be list, got tuple"):
         validate_collection((1, 2, 3), list)
@@ -144,7 +183,7 @@ def test_validate_collection_case_8_type_error_wrong_collection_type() -> None:
 
 def test_validate_collection_case_9_value_error_empty_not_allowed() -> None:
     """
-    Test case 9: ValueError when empty collections are not allowed.
+    Test case 11: ValueError when empty collections are not allowed.
     """
     with pytest.raises(ValueError, match="collection cannot be empty"):
         validate_collection([], list, allow_empty=False)
@@ -162,7 +201,7 @@ def test_validate_collection_case_9_value_error_empty_not_allowed() -> None:
 
 def test_validate_collection_case_10_value_error_length_bounds() -> None:
     """
-    Test case 10: ValueError for length constraint violations.
+    Test case 12: ValueError for length constraint violations.
     """
     # Test below minimum length
     with pytest.raises(
@@ -187,7 +226,7 @@ def test_validate_collection_case_10_value_error_length_bounds() -> None:
 
 def test_validate_collection_case_11_type_error_element_validation() -> None:
     """
-    Test case 11: TypeError for wrong element types.
+    Test case 13: TypeError for wrong element types.
     """
     # Test wrong single element type
     with pytest.raises(
@@ -216,7 +255,7 @@ def test_validate_collection_case_11_type_error_element_validation() -> None:
 
 def test_validate_collection_case_12_type_error_invalid_parameters() -> None:
     """
-    Test case 12: TypeError for invalid parameter types.
+    Test case 14: TypeError for invalid parameter types.
     """
     # Test invalid expected_type
     with pytest.raises(TypeError, match="expected_type must be a type"):
@@ -246,44 +285,3 @@ def test_validate_collection_case_12_type_error_invalid_parameters() -> None:
         ValueError, match="min_length \\(5\\) cannot be greater than max_length \\(3\\)"
     ):
         validate_collection([1, 2, 3], list, min_length=5, max_length=3)
-
-
-def test_validate_collection_case_13_edge_cases() -> None:
-    """
-    Test case 13: Edge cases and boundary conditions.
-    """
-    # Test single element collections
-    validate_collection([1], list, min_length=1, max_length=1, element_type=int)
-    validate_collection({"a": 1}, dict, min_length=1, max_length=1, element_type=int)
-
-    # Test large collections
-    large_list = list(range(10000))
-    validate_collection(large_list, list, element_type=int)
-
-    # Test nested collections (without element type checking)
-    nested_list = [[1, 2], [3, 4], [5, 6]]
-    validate_collection(nested_list, list)
-
-    # Test collections with None elements
-    validate_collection([1, None, 3], list, element_type=(int, type(None)))
-
-
-def test_validate_collection_case_14_performance_large_collections() -> None:
-    """
-    Test case 14: Performance with large collections.
-    """
-    # Test large collection without element validation (should be fast)
-    large_list = list(range(100000))
-    import time
-
-    start_time = time.time()
-    validate_collection(large_list, list, min_length=1000, max_length=200000)
-    elapsed_time = time.time() - start_time
-    assert elapsed_time < 0.1  # Should be very fast without element checking
-
-    # Test smaller collection with element validation
-    medium_list = list(range(10000))
-    start_time = time.time()
-    validate_collection(medium_list, list, element_type=int)
-    elapsed_time = time.time() - start_time
-    assert elapsed_time < 1.0  # Should complete within 1 second

--- a/pytest/unit/data_validation/basic_validation/test_validate_range.py
+++ b/pytest/unit/data_validation/basic_validation/test_validate_range.py
@@ -109,9 +109,44 @@ def test_validate_range_decimal_ranges() -> None:
     )
 
 
+def test_validate_range_case_11_boundary_conditions() -> None:
+    """
+    Test case 7: Edge cases and boundary conditions.
+    """
+    # Test zero boundaries
+    validate_range(0, min_value=0, max_value=0)
+
+    # Test very small ranges
+    validate_range(1, min_value=1, max_value=1)
+
+    # Test large numbers
+    large_num = 10**15
+    validate_range(large_num, min_value=0, max_value=10**16)
+
+    # Test very small floats
+    validate_range(1e-10, min_value=0.0, max_value=1e-9)
+
+
+def test_validate_range_case_12_performance_large_numbers() -> None:
+    """
+    Test case 8: Performance with large numbers and many validations.
+    """
+    # Test with very large numbers
+    large_value = 10**100
+    validate_range(large_value, min_value=0, max_value=10**101)
+
+    # Performance test
+    import time
+
+    start_time = time.time()
+    for i in range(10000):
+        validate_range(i, min_value=0, max_value=20000)
+    elapsed_time = time.time() - start_time
+
+    assert elapsed_time < 1.0  # Should complete within 1 second
 def test_validate_range_value_error_below_minimum() -> None:
     """
-    Test case 7: ValueError for values below minimum.
+    Test case 9: ValueError for values below minimum.
     """
     # Test inclusive minimum
     with pytest.raises(ValueError, match="value must be >= 0, got -1"):
@@ -131,7 +166,7 @@ def test_validate_range_value_error_below_minimum() -> None:
 
 def test_validate_range_value_error_above_maximum() -> None:
     """
-    Test case 8: ValueError for values above maximum.
+    Test case 10: ValueError for values above maximum.
     """
     # Test inclusive maximum
     with pytest.raises(ValueError, match="value must be <= 10, got 11"):
@@ -151,7 +186,7 @@ def test_validate_range_value_error_above_maximum() -> None:
 
 def test_validate_range_invalid_range_bounds() -> None:
     """
-    Test case 9: ValueError for invalid range bounds.
+    Test case 11: ValueError for invalid range bounds.
     """
     # Test min > max
     with pytest.raises(
@@ -175,7 +210,7 @@ def test_validate_range_invalid_range_bounds() -> None:
 
 def test_validate_range_case_10_type_errors() -> None:
     """
-    Test case 10: TypeError for invalid parameter types and incompatible comparisons.
+    Test case 12: TypeError for invalid parameter types and incompatible comparisons.
     """
     # Test invalid parameter types
     with pytest.raises(TypeError, match="min_inclusive must be bool, got str"):
@@ -197,40 +232,3 @@ def test_validate_range_case_10_type_errors() -> None:
         TypeError, match="Cannot compare value of type str with max_value of type int"
     ):
         validate_range("hello", max_value=10)
-
-
-def test_validate_range_case_11_boundary_conditions() -> None:
-    """
-    Test case 11: Edge cases and boundary conditions.
-    """
-    # Test zero boundaries
-    validate_range(0, min_value=0, max_value=0)
-
-    # Test very small ranges
-    validate_range(1, min_value=1, max_value=1)
-
-    # Test large numbers
-    large_num = 10**15
-    validate_range(large_num, min_value=0, max_value=10**16)
-
-    # Test very small floats
-    validate_range(1e-10, min_value=0.0, max_value=1e-9)
-
-
-def test_validate_range_case_12_performance_large_numbers() -> None:
-    """
-    Test case 12: Performance with large numbers and many validations.
-    """
-    # Test with very large numbers
-    large_value = 10**100
-    validate_range(large_value, min_value=0, max_value=10**101)
-
-    # Performance test
-    import time
-
-    start_time = time.time()
-    for i in range(10000):
-        validate_range(i, min_value=0, max_value=20000)
-    elapsed_time = time.time() - start_time
-
-    assert elapsed_time < 1.0  # Should complete within 1 second

--- a/pytest/unit/data_validation/basic_validation/test_validate_string.py
+++ b/pytest/unit/data_validation/basic_validation/test_validate_string.py
@@ -137,9 +137,29 @@ def test_validate_string_combined_validations() -> None:
     )
 
 
+def test_validate_string_performance_large_strings() -> None:
+    """
+    Test case 9: Performance with large strings and complex patterns.
+    """
+    # Test large string validation
+    large_string = "a" * 100000
+
+    import time
+
+    start_time = time.time()
+    validate_string(large_string, min_length=50000, max_length=200000)
+    elapsed_time = time.time() - start_time
+    assert elapsed_time < 0.1  # Should be fast for basic validation
+
+    # Test pattern matching performance
+    medium_string = "a" * 10000
+    start_time = time.time()
+    validate_string(medium_string, pattern=r"^a+$")
+    elapsed_time = time.time() - start_time
+    assert elapsed_time < 1.0  # Should complete within 1 second
 def test_validate_string_type_error_invalid_input() -> None:
     """
-    Test case 9: TypeError for non-string input.
+    Test case 10: TypeError for non-string input.
     """
     with pytest.raises(TypeError, match="value must be str, got int"):
         validate_string(123)
@@ -157,7 +177,7 @@ def test_validate_string_type_error_invalid_input() -> None:
 
 def test_validate_string_type_error_invalid_parameters() -> None:
     """
-    Test case 10: TypeError for invalid parameter types.
+    Test case 11: TypeError for invalid parameter types.
     """
     # Test invalid min_length
     with pytest.raises(TypeError, match="min_length must be int or None, got str"):
@@ -187,7 +207,7 @@ def test_validate_string_type_error_invalid_parameters() -> None:
 
 def test_validate_string_value_error_empty_not_allowed() -> None:
     """
-    Test case 11: ValueError when empty strings are not allowed.
+    Test case 12: ValueError when empty strings are not allowed.
     """
     with pytest.raises(ValueError, match="value cannot be empty"):
         validate_string("", allow_empty=False)
@@ -203,7 +223,7 @@ def test_validate_string_value_error_empty_not_allowed() -> None:
 
 def test_validate_string_value_error_length_violations() -> None:
     """
-    Test case 12: ValueError for length constraint violations.
+    Test case 13: ValueError for length constraint violations.
     """
     # Test below minimum length
     with pytest.raises(
@@ -227,7 +247,7 @@ def test_validate_string_value_error_length_violations() -> None:
 
 def test_validate_string_value_error_pattern_mismatch() -> None:
     """
-    Test case 13: ValueError for pattern matching failures.
+    Test case 14: ValueError for pattern matching failures.
     """
     # Test pattern mismatch
     with pytest.raises(
@@ -250,7 +270,7 @@ def test_validate_string_value_error_pattern_mismatch() -> None:
 
 def test_validate_string_value_error_character_violations() -> None:
     """
-    Test case 14: ValueError for character restriction violations.
+    Test case 15: ValueError for character restriction violations.
     """
     # Test disallowed characters
     with pytest.raises(ValueError, match="value contains disallowed character: x"):
@@ -266,7 +286,7 @@ def test_validate_string_value_error_character_violations() -> None:
 
 def test_validate_string_edge_cases() -> None:
     """
-    Test case 15: Edge cases and boundary conditions.
+    Test case 16: Edge cases and boundary conditions.
     """
     # Test single character strings
     validate_string("a", min_length=1, max_length=1)
@@ -288,25 +308,3 @@ def test_validate_string_edge_cases() -> None:
         match="min_length \\(10\\) cannot be greater than max_length \\(5\\)",
     ):
         validate_string("hello", min_length=10, max_length=5)
-
-
-def test_validate_string_performance_large_strings() -> None:
-    """
-    Test case 16: Performance with large strings and complex patterns.
-    """
-    # Test large string validation
-    large_string = "a" * 100000
-
-    import time
-
-    start_time = time.time()
-    validate_string(large_string, min_length=50000, max_length=200000)
-    elapsed_time = time.time() - start_time
-    assert elapsed_time < 0.1  # Should be fast for basic validation
-
-    # Test pattern matching performance
-    medium_string = "a" * 10000
-    start_time = time.time()
-    validate_string(medium_string, pattern=r"^a+$")
-    elapsed_time = time.time() - start_time
-    assert elapsed_time < 1.0  # Should complete within 1 second

--- a/pytest/unit/data_validation/basic_validation/test_validate_type.py
+++ b/pytest/unit/data_validation/basic_validation/test_validate_type.py
@@ -72,60 +72,9 @@ def test_validate_type_custom_param_name() -> None:
     validate_type("test", str, param_name="username")
 
 
-def test_validate_type_type_error_single_type() -> None:
-    """
-    Test case 5: TypeError for wrong type with single expected type.
-    """
-    with pytest.raises(TypeError, match="value must be str, got int"):
-        validate_type(42, str)
-
-    with pytest.raises(TypeError, match="value must be int, got str"):
-        validate_type("hello", int)
-
-    with pytest.raises(TypeError, match="value must be list, got dict"):
-        validate_type({"key": "value"}, list)
-
-    # Test with custom param name
-    with pytest.raises(TypeError, match="user_id must be int, got str"):
-        validate_type("123", int, param_name="user_id")
-
-
-def test_validate_type_type_error_union_types() -> None:
-    """
-    Test case 6: TypeError for wrong type with union types.
-    """
-    with pytest.raises(TypeError, match="value must be int \\| str, got float"):
-        validate_type(3.14, (int, str))
-
-    with pytest.raises(TypeError, match="value must be list \\| tuple, got set"):
-        validate_type({1, 2, 3}, (list, tuple))
-
-    # Test with custom param name
-    with pytest.raises(TypeError, match="data must be dict \\| list, got str"):
-        validate_type("invalid", (dict, list), param_name="data")
-
-
-def test_validate_type_none_not_allowed() -> None:
-    """
-    Test case 7: TypeError when None is not allowed.
-    """
-    with pytest.raises(TypeError, match="value cannot be None, expected str"):
-        validate_type(None, str)
-
-    with pytest.raises(TypeError, match="value cannot be None, expected int"):
-        validate_type(None, int, allow_none=False)
-
-    with pytest.raises(TypeError, match="value cannot be None, expected int \\| str"):
-        validate_type(None, (int, str))
-
-    # Test with custom param name
-    with pytest.raises(TypeError, match="user_id cannot be None, expected int"):
-        validate_type(None, int, param_name="user_id")
-
-
 def test_validate_type_complex_collections() -> None:
     """
-    Test case 8: Validation with complex collection types.
+    Test case 5: Validation with complex collection types.
     """
     # Test nested structures
     validate_type({"users": [1, 2, 3]}, dict)
@@ -141,7 +90,7 @@ def test_validate_type_complex_collections() -> None:
 
 def test_validate_type_edge_cases() -> None:
     """
-    Test case 9: Edge cases and boundary conditions.
+    Test case 6: Edge cases and boundary conditions.
     """
     # Test with zero values
     validate_type(0, int)
@@ -160,7 +109,7 @@ def test_validate_type_edge_cases() -> None:
 
 def test_validate_type_performance_large_unions() -> None:
     """
-    Test case 10: Performance with large union types.
+    Test case 7: Performance with large union types.
     """
     # Test with many union types
     many_types = (int, str, float, bool, list, dict, set, tuple, bytes, bytearray)
@@ -178,3 +127,52 @@ def test_validate_type_performance_large_unions() -> None:
     elapsed_time = time.time() - start_time
 
     assert elapsed_time < 1.0  # Should complete within 1 second
+def test_validate_type_type_error_single_type() -> None:
+    """
+    Test case 8: TypeError for wrong type with single expected type.
+    """
+    with pytest.raises(TypeError, match="value must be str, got int"):
+        validate_type(42, str)
+
+    with pytest.raises(TypeError, match="value must be int, got str"):
+        validate_type("hello", int)
+
+    with pytest.raises(TypeError, match="value must be list, got dict"):
+        validate_type({"key": "value"}, list)
+
+    # Test with custom param name
+    with pytest.raises(TypeError, match="user_id must be int, got str"):
+        validate_type("123", int, param_name="user_id")
+
+
+def test_validate_type_type_error_union_types() -> None:
+    """
+    Test case 9: TypeError for wrong type with union types.
+    """
+    with pytest.raises(TypeError, match="value must be int \\| str, got float"):
+        validate_type(3.14, (int, str))
+
+    with pytest.raises(TypeError, match="value must be list \\| tuple, got set"):
+        validate_type({1, 2, 3}, (list, tuple))
+
+    # Test with custom param name
+    with pytest.raises(TypeError, match="data must be dict \\| list, got str"):
+        validate_type("invalid", (dict, list), param_name="data")
+
+
+def test_validate_type_none_not_allowed() -> None:
+    """
+    Test case 10: TypeError when None is not allowed.
+    """
+    with pytest.raises(TypeError, match="value cannot be None, expected str"):
+        validate_type(None, str)
+
+    with pytest.raises(TypeError, match="value cannot be None, expected int"):
+        validate_type(None, int, allow_none=False)
+
+    with pytest.raises(TypeError, match="value cannot be None, expected int \\| str"):
+        validate_type(None, (int, str))
+
+    # Test with custom param name
+    with pytest.raises(TypeError, match="user_id cannot be None, expected int"):
+        validate_type(None, int, param_name="user_id")

--- a/pytest/unit/data_validation/schema_validation/test_validate_cerberus_schema.py
+++ b/pytest/unit/data_validation/schema_validation/test_validate_cerberus_schema.py
@@ -164,9 +164,59 @@ def test_validate_cerberus_schema_case_8_without_normalization() -> None:
     assert "count" not in result  # Default not applied without normalization
 
 
+def test_validate_cerberus_schema_case_17_edge_cases() -> None:
+    """
+    Test case 9: Edge cases and boundary conditions.
+    """
+    # Test empty schema
+    result = validate_cerberus_schema({}, {})
+    assert result == {}
+
+    # Test empty data with optional schema
+    schema = {"name": {"type": "string", "default": "Anonymous"}}
+    result = validate_cerberus_schema({}, schema, normalize=True)
+    assert result["name"] == "Anonymous"
+
+    # Test boundary values
+    schema = {"score": {"type": "integer", "min": 0, "max": 100}}
+
+    # Test minimum boundary
+    result = validate_cerberus_schema({"score": 0}, schema)
+    assert result["score"] == 0
+
+    # Test maximum boundary
+    result = validate_cerberus_schema({"score": 100}, schema)
+    assert result["score"] == 100
+
+
+def test_validate_cerberus_schema_case_19_performance_large_data() -> None:
+    """
+    Test case 10: Performance with large data structures.
+    """
+    schema = {
+        "items": {
+            "type": "list",
+            "schema": {
+                "type": "dict",
+                "schema": {"id": {"type": "integer"}, "name": {"type": "string"}},
+            },
+        }
+    }
+
+    # Create large dataset
+    large_data = {"items": [{"id": i, "name": f"item_{i}"} for i in range(1000)]}
+
+    import time
+
+    start_time = time.time()
+    result = validate_cerberus_schema(large_data, schema)
+    elapsed_time = time.time() - start_time
+
+    assert len(result["items"]) == 1000
+    assert elapsed_time < 2.0  # Should complete within 2 seconds
 def test_validate_cerberus_schema_case_9_type_error_invalid_data() -> None:
     """
-    Test case 9: TypeError for invalid data type.
+    Test case 11: TypeError for invalid data type.
     """
     schema = {"name": {"type": "string"}}
 
@@ -183,7 +233,7 @@ def test_validate_cerberus_schema_case_9_type_error_invalid_data() -> None:
 
 def test_validate_cerberus_schema_case_10_type_error_invalid_schema() -> None:
     """
-    Test case 10: TypeError for invalid schema type.
+    Test case 12: TypeError for invalid schema type.
     """
     data = {"name": "Test"}
 
@@ -196,7 +246,7 @@ def test_validate_cerberus_schema_case_10_type_error_invalid_schema() -> None:
 
 def test_validate_cerberus_schema_case_11_type_error_invalid_parameters() -> None:
     """
-    Test case 11: TypeError for invalid parameter types.
+    Test case 13: TypeError for invalid parameter types.
     """
     data = {"name": "Test"}
     schema = {"name": {"type": "string"}}
@@ -213,7 +263,7 @@ def test_validate_cerberus_schema_case_11_type_error_invalid_parameters() -> Non
 
 def test_validate_cerberus_schema_case_12_value_error_missing_required() -> None:
     """
-    Test case 12: ValueError for missing required fields.
+    Test case 14: ValueError for missing required fields.
     """
     schema = {
         "name": {"type": "string", "required": True},
@@ -228,7 +278,7 @@ def test_validate_cerberus_schema_case_12_value_error_missing_required() -> None
 
 def test_validate_cerberus_schema_case_13_value_error_type_mismatch() -> None:
     """
-    Test case 13: ValueError for type mismatches.
+    Test case 15: ValueError for type mismatches.
     """
     schema = {"age": {"type": "integer"}, "active": {"type": "boolean"}}
 
@@ -240,7 +290,7 @@ def test_validate_cerberus_schema_case_13_value_error_type_mismatch() -> None:
 
 def test_validate_cerberus_schema_case_14_value_error_constraint_violations() -> None:
     """
-    Test case 14: ValueError for constraint violations.
+    Test case 16: ValueError for constraint violations.
     """
     schema = {
         "age": {"type": "integer", "min": 0, "max": 150},
@@ -266,7 +316,7 @@ def test_validate_cerberus_schema_case_14_value_error_constraint_violations() ->
 
 def test_validate_cerberus_schema_case_15_value_error_unknown_fields() -> None:
     """
-    Test case 15: ValueError for unknown fields when not allowed.
+    Test case 17: ValueError for unknown fields when not allowed.
     """
     schema = {"name": {"type": "string", "required": True}}
 
@@ -278,7 +328,7 @@ def test_validate_cerberus_schema_case_15_value_error_unknown_fields() -> None:
 
 def test_validate_cerberus_schema_case_16_value_error_nested_validation() -> None:
     """
-    Test case 16: ValueError for nested validation failures.
+    Test case 18: ValueError for nested validation failures.
     """
     schema = {
         "user": {
@@ -301,64 +351,12 @@ def test_validate_cerberus_schema_case_16_value_error_nested_validation() -> Non
         validate_cerberus_schema(data, schema)
 
 
-def test_validate_cerberus_schema_case_17_edge_cases() -> None:
-    """
-    Test case 17: Edge cases and boundary conditions.
-    """
-    # Test empty schema
-    result = validate_cerberus_schema({}, {})
-    assert result == {}
-
-    # Test empty data with optional schema
-    schema = {"name": {"type": "string", "default": "Anonymous"}}
-    result = validate_cerberus_schema({}, schema, normalize=True)
-    assert result["name"] == "Anonymous"
-
-    # Test boundary values
-    schema = {"score": {"type": "integer", "min": 0, "max": 100}}
-
-    # Test minimum boundary
-    result = validate_cerberus_schema({"score": 0}, schema)
-    assert result["score"] == 0
-
-    # Test maximum boundary
-    result = validate_cerberus_schema({"score": 100}, schema)
-    assert result["score"] == 100
-
-
 def test_validate_cerberus_schema_case_18_custom_param_name() -> None:
     """
-    Test case 18: Custom parameter name in error messages.
+    Test case 19: Custom parameter name in error messages.
     """
     schema = {"name": {"type": "string", "required": True}}
     data = {}  # Missing required field
 
     with pytest.raises(ValueError, match="config_data validation failed"):
         validate_cerberus_schema(data, schema, param_name="config_data")
-
-
-def test_validate_cerberus_schema_case_19_performance_large_data() -> None:
-    """
-    Test case 19: Performance with large data structures.
-    """
-    schema = {
-        "items": {
-            "type": "list",
-            "schema": {
-                "type": "dict",
-                "schema": {"id": {"type": "integer"}, "name": {"type": "string"}},
-            },
-        }
-    }
-
-    # Create large dataset
-    large_data = {"items": [{"id": i, "name": f"item_{i}"} for i in range(1000)]}
-
-    import time
-
-    start_time = time.time()
-    result = validate_cerberus_schema(large_data, schema)
-    elapsed_time = time.time() - start_time
-
-    assert len(result["items"]) == 1000
-    assert elapsed_time < 2.0  # Should complete within 2 seconds

--- a/pytest/unit/data_validation/schema_validation/test_validate_pydantic_schema.py
+++ b/pytest/unit/data_validation/schema_validation/test_validate_pydantic_schema.py
@@ -151,104 +151,9 @@ def test_validate_pydantic_schema_allow_extra_fields() -> None:
     assert result.email == "eve@example.com"
 
 
-def test_validate_pydantic_schema_type_error_invalid_schema() -> None:
-    """
-    Test case 7: TypeError for invalid schema model.
-    """
-    data = {"name": "Test", "age": 25}
-
-    # Test with non-BaseModel class
-    class NotAModel:
-        pass
-
-    with pytest.raises(
-        TypeError, match="schema_model must be a Pydantic BaseModel class"
-    ):
-        validate_pydantic_schema(data, NotAModel)
-
-    # Test with non-class object
-    with pytest.raises(
-        TypeError, match="schema_model must be a Pydantic BaseModel class"
-    ):
-        validate_pydantic_schema(data, "not a class")
-
-
-def test_validate_pydantic_schema_type_error_invalid_parameters() -> None:
-    """
-    Test case 8: TypeError for invalid parameter types.
-    """
-    data = {"name": "Test", "age": 25, "email": "test@example.com"}
-
-    with pytest.raises(TypeError, match="strict must be bool, got str"):
-        validate_pydantic_schema(data, SimpleUserSchema, strict="true")
-
-    with pytest.raises(TypeError, match="allow_extra must be bool, got int"):
-        validate_pydantic_schema(data, SimpleUserSchema, allow_extra=1)
-
-    with pytest.raises(TypeError, match="param_name must be str, got int"):
-        validate_pydantic_schema(data, SimpleUserSchema, param_name=123)
-
-
-def test_validate_pydantic_schema_value_error_validation_failure() -> None:
-    """
-    Test case 9: ValueError for validation failures.
-    """
-    # Test missing required field
-    data = {"name": "Test", "age": 25}  # Missing email
-
-    with pytest.raises(ValueError, match="data validation failed"):
-        validate_pydantic_schema(data, SimpleUserSchema)
-
-    # Test wrong type
-    data = {"name": "Test", "age": "not a number", "email": "test@example.com"}
-
-    with pytest.raises(ValueError, match="data validation failed"):
-        validate_pydantic_schema(data, SimpleUserSchema)
-
-
-def test_validate_pydantic_schema_value_error_extra_fields_forbidden() -> None:
-    """
-    Test case 10: ValueError when extra fields are forbidden.
-    """
-    data = {
-        "name": "Test",
-        "age": 25,
-        "email": "test@example.com",
-        "extra_field": "not allowed",
-    }
-
-    with pytest.raises(ValueError, match="data validation failed"):
-        validate_pydantic_schema(data, SimpleUserSchema, allow_extra=False)
-
-
-def test_validate_pydantic_schema_value_error_strict_mode() -> None:
-    """
-    Test case 11: ValueError in strict mode with type coercion.
-    """
-    # Test strict mode rejecting type coercion
-    data = {"name": "Test", "age": "25", "email": "test@example.com"}  # age as string
-
-    with pytest.raises(ValueError, match="data validation failed"):
-        validate_pydantic_schema(data, SimpleUserSchema, strict=True)
-
-
-def test_validate_pydantic_schema_value_error_nested_validation() -> None:
-    """
-    Test case 12: ValueError for nested object validation failures.
-    """
-    # Test invalid nested object
-    data = {
-        "user": {"name": "Test", "age": "invalid"},  # Invalid age in nested object
-        "created_at": "2023-01-01",
-    }
-
-    with pytest.raises(ValueError, match="data validation failed"):
-        validate_pydantic_schema(data, NestedSchema)
-
-
 def test_validate_pydantic_schema_edge_cases() -> None:
     """
-    Test case 13: Edge cases and boundary conditions.
+    Test case 7: Edge cases and boundary conditions.
     """
     # Test with empty dict for schema with defaults
     data = {}
@@ -267,19 +172,9 @@ def test_validate_pydantic_schema_edge_cases() -> None:
     assert result.email is None
 
 
-def test_validate_pydantic_schema_custom_param_name() -> None:
-    """
-    Test case 14: Custom parameter name in error messages.
-    """
-    data = {"name": "Test", "age": "invalid"}  # Missing email, invalid age
-
-    with pytest.raises(ValueError, match="user_data validation failed"):
-        validate_pydantic_schema(data, SimpleUserSchema, param_name="user_data")
-
-
 def test_validate_pydantic_schema_complex_schemas() -> None:
     """
-    Test case 15: Complex schemas with various field types.
+    Test case 8: Complex schemas with various field types.
     """
 
     class ComplexSchema(BaseModel):
@@ -308,7 +203,7 @@ def test_validate_pydantic_schema_complex_schemas() -> None:
 
 def test_validate_pydantic_schema_performance_large_data() -> None:
     """
-    Test case 16: Performance with large data structures.
+    Test case 9: Performance with large data structures.
     """
     # Test with large list of objects
     large_data = {"name": "Performance Test", "age": 30, "email": "perf@example.com"}
@@ -327,6 +222,111 @@ def test_validate_pydantic_schema_performance_large_data() -> None:
     not PYDANTIC_AVAILABLE or not hasattr(__import__("pydantic"), "v1"),
     reason="Pydantic v1 compatibility layer not available",
 )
+def test_validate_pydantic_schema_type_error_invalid_schema() -> None:
+    """
+    Test case 10: TypeError for invalid schema model.
+    """
+    data = {"name": "Test", "age": 25}
+
+    # Test with non-BaseModel class
+    class NotAModel:
+        pass
+
+    with pytest.raises(
+        TypeError, match="schema_model must be a Pydantic BaseModel class"
+    ):
+        validate_pydantic_schema(data, NotAModel)
+
+    # Test with non-class object
+    with pytest.raises(
+        TypeError, match="schema_model must be a Pydantic BaseModel class"
+    ):
+        validate_pydantic_schema(data, "not a class")
+
+
+def test_validate_pydantic_schema_type_error_invalid_parameters() -> None:
+    """
+    Test case 11: TypeError for invalid parameter types.
+    """
+    data = {"name": "Test", "age": 25, "email": "test@example.com"}
+
+    with pytest.raises(TypeError, match="strict must be bool, got str"):
+        validate_pydantic_schema(data, SimpleUserSchema, strict="true")
+
+    with pytest.raises(TypeError, match="allow_extra must be bool, got int"):
+        validate_pydantic_schema(data, SimpleUserSchema, allow_extra=1)
+
+    with pytest.raises(TypeError, match="param_name must be str, got int"):
+        validate_pydantic_schema(data, SimpleUserSchema, param_name=123)
+
+
+def test_validate_pydantic_schema_value_error_validation_failure() -> None:
+    """
+    Test case 12: ValueError for validation failures.
+    """
+    # Test missing required field
+    data = {"name": "Test", "age": 25}  # Missing email
+
+    with pytest.raises(ValueError, match="data validation failed"):
+        validate_pydantic_schema(data, SimpleUserSchema)
+
+    # Test wrong type
+    data = {"name": "Test", "age": "not a number", "email": "test@example.com"}
+
+    with pytest.raises(ValueError, match="data validation failed"):
+        validate_pydantic_schema(data, SimpleUserSchema)
+
+
+def test_validate_pydantic_schema_value_error_extra_fields_forbidden() -> None:
+    """
+    Test case 13: ValueError when extra fields are forbidden.
+    """
+    data = {
+        "name": "Test",
+        "age": 25,
+        "email": "test@example.com",
+        "extra_field": "not allowed",
+    }
+
+    with pytest.raises(ValueError, match="data validation failed"):
+        validate_pydantic_schema(data, SimpleUserSchema, allow_extra=False)
+
+
+def test_validate_pydantic_schema_value_error_strict_mode() -> None:
+    """
+    Test case 14: ValueError in strict mode with type coercion.
+    """
+    # Test strict mode rejecting type coercion
+    data = {"name": "Test", "age": "25", "email": "test@example.com"}  # age as string
+
+    with pytest.raises(ValueError, match="data validation failed"):
+        validate_pydantic_schema(data, SimpleUserSchema, strict=True)
+
+
+def test_validate_pydantic_schema_value_error_nested_validation() -> None:
+    """
+    Test case 15: ValueError for nested object validation failures.
+    """
+    # Test invalid nested object
+    data = {
+        "user": {"name": "Test", "age": "invalid"},  # Invalid age in nested object
+        "created_at": "2023-01-01",
+    }
+
+    with pytest.raises(ValueError, match="data validation failed"):
+        validate_pydantic_schema(data, NestedSchema)
+
+
+def test_validate_pydantic_schema_custom_param_name() -> None:
+    """
+    Test case 16: Custom parameter name in error messages.
+    """
+    data = {"name": "Test", "age": "invalid"}  # Missing email, invalid age
+
+    with pytest.raises(ValueError, match="user_data validation failed"):
+        validate_pydantic_schema(data, SimpleUserSchema, param_name="user_data")
+
+
 def test_validate_pydantic_schema_pydantic_v1_branch(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test case 17: Ensure the legacy branch configures Config.extra and Config.allow_mutation."""
 

--- a/pytest/unit/datetime_functions/test_calculate_age.py
+++ b/pytest/unit/datetime_functions/test_calculate_age.py
@@ -59,22 +59,9 @@ def test_calculate_age_with_datetime_objects() -> None:
     assert result == 33
 
 
-def test_calculate_age_type_error_on_non_datetime() -> None:
-    """
-    Test case 6: calculate_age raises TypeError if either argument is not datetime.
-    """
-    reference_date = datetime(2023, 1, 15, 12, 0, 0)
-    with pytest.raises(TypeError):
-        calculate_age("1990-01-15", reference_date)
-    with pytest.raises(TypeError):
-        calculate_age(123, reference_date)
-    with pytest.raises(TypeError):
-        calculate_age(None, reference_date)
-
-
 def test_calculate_age_default_reference() -> None:
     """
-    Test case 7: calculate_age uses current date as default reference.
+    Test case 6: calculate_age uses current date as default reference.
     """
     birth_date = datetime(2020, 1, 1, 0, 0, 0)
     result = calculate_age(birth_date)
@@ -83,6 +70,19 @@ def test_calculate_age_default_reference() -> None:
 
 
     # Removed: covered by test_calculate_age_type_error_on_non_datetime
+
+
+def test_calculate_age_type_error_on_non_datetime() -> None:
+    """
+    Test case 7: calculate_age raises TypeError if either argument is not datetime.
+    """
+    reference_date = datetime(2023, 1, 15, 12, 0, 0)
+    with pytest.raises(TypeError):
+        calculate_age("1990-01-15", reference_date)
+    with pytest.raises(TypeError):
+        calculate_age(123, reference_date)
+    with pytest.raises(TypeError):
+        calculate_age(None, reference_date)
 
 
 def test_calculate_age_future_birth_date() -> None:

--- a/pytest/unit/datetime_functions/test_days_between.py
+++ b/pytest/unit/datetime_functions/test_days_between.py
@@ -48,9 +48,21 @@ def test_days_between_with_datetime_objects() -> None:
     assert result == 3
 
 
+def test_days_between_cross_month() -> None:
+    """
+    Test case 5: days_between across month boundaries.
+    """
+    dt1 = datetime(2023, 1, 30, 0, 0, 0)
+    dt2 = datetime(2023, 2, 2, 0, 0, 0)
+    result = days_between(dt1, dt2)
+    assert isinstance(result, int)
+    assert result == 3
+
+
+    # Removed: covered by test_days_between_type_error_on_non_datetime
 def test_days_between_type_error_on_non_datetime() -> None:
     """
-    Test case 5: days_between raises TypeError if either argument is not datetime.
+    Test case 6: days_between raises TypeError if either argument is not datetime.
     """
     dt2 = datetime(2023, 1, 20, 12, 0, 0)
     with pytest.raises(TypeError):
@@ -61,17 +73,3 @@ def test_days_between_type_error_on_non_datetime() -> None:
         days_between(123, dt2)
     with pytest.raises(TypeError):
         days_between(dt2, None)
-
-
-def test_days_between_cross_month() -> None:
-    """
-    Test case 6: days_between across month boundaries.
-    """
-    dt1 = datetime(2023, 1, 30, 0, 0, 0)
-    dt2 = datetime(2023, 2, 2, 0, 0, 0)
-    result = days_between(dt1, dt2)
-    assert isinstance(result, int)
-    assert result == 3
-
-
-    # Removed: covered by test_days_between_type_error_on_non_datetime

--- a/pytest/unit/datetime_functions/test_get_end_of_month.py
+++ b/pytest/unit/datetime_functions/test_get_end_of_month.py
@@ -42,19 +42,18 @@ def test_get_end_of_month_december() -> None:
     result = get_end_of_month(dt)
     assert result == datetime(2023, 12, 31, 15, 45)
 
+def test_get_end_of_month_first_day() -> None:
+    """
+    Test case 6: get_end_of_month returns last day for a date on the first of the month.
+    """
+    dt = datetime(2023, 5, 1, 6, 0)
+    result = get_end_of_month(dt)
+    assert result == datetime(2023, 5, 31, 6, 0)
 def test_get_end_of_month_type_error() -> None:
     """
-    Test case 6: get_end_of_month raises TypeError for invalid input types.
+    Test case 7: get_end_of_month raises TypeError for invalid input types.
     """
     with pytest.raises(TypeError, match="date_obj must be a datetime"):
         get_end_of_month("2023-02-15")
     with pytest.raises(TypeError, match="date_obj must be a datetime"):
         get_end_of_month(123)
-
-def test_get_end_of_month_first_day() -> None:
-    """
-    Test case 7: get_end_of_month returns last day for a date on the first of the month.
-    """
-    dt = datetime(2023, 5, 1, 6, 0)
-    result = get_end_of_month(dt)
-    assert result == datetime(2023, 5, 31, 6, 0)

--- a/pytest/unit/datetime_functions/test_get_end_of_year.py
+++ b/pytest/unit/datetime_functions/test_get_end_of_year.py
@@ -95,30 +95,9 @@ def test_get_end_of_year_preserves_time() -> None:
     assert result.second == 36
 
 
-def test_get_end_of_year_type_error_non_datetime() -> None:
-    """
-    Test case 6: TypeError when input is not a datetime object.
-    """
-    # Arrange
-    invalid_input = "2023-12-31"
-
-    # Act & Assert
-    with pytest.raises(TypeError, match="date_obj must be a datetime object"):
-        get_end_of_year(invalid_input)  # type: ignore
-
-
-def test_get_end_of_year_type_error_none() -> None:
-    """
-    Test case 7: TypeError when input is None.
-    """
-    # Act & Assert
-    with pytest.raises(TypeError, match="date_obj must be a datetime object"):
-        get_end_of_year(None)  # type: ignore
-
-
 def test_get_end_of_year_different_years() -> None:
     """
-    Test case 8: Get end of year for different years.
+    Test case 6: Get end of year for different years.
     """
     # Arrange
     dates = [
@@ -133,3 +112,22 @@ def test_get_end_of_year_different_years() -> None:
         assert result.year == date.year
         assert result.month == 12
         assert result.day == 31
+def test_get_end_of_year_type_error_non_datetime() -> None:
+    """
+    Test case 7: TypeError when input is not a datetime object.
+    """
+    # Arrange
+    invalid_input = "2023-12-31"
+
+    # Act & Assert
+    with pytest.raises(TypeError, match="date_obj must be a datetime object"):
+        get_end_of_year(invalid_input)  # type: ignore
+
+
+def test_get_end_of_year_type_error_none() -> None:
+    """
+    Test case 8: TypeError when input is None.
+    """
+    # Act & Assert
+    with pytest.raises(TypeError, match="date_obj must be a datetime object"):
+        get_end_of_year(None)  # type: ignore

--- a/pytest/unit/datetime_functions/test_get_start_of_year.py
+++ b/pytest/unit/datetime_functions/test_get_start_of_year.py
@@ -95,30 +95,9 @@ def test_get_start_of_year_preserves_time() -> None:
     assert result.second == 36
 
 
-def test_get_start_of_year_type_error_non_datetime() -> None:
-    """
-    Test case 6: TypeError when input is not a datetime object.
-    """
-    # Arrange
-    invalid_input = "2023-01-01"
-
-    # Act & Assert
-    with pytest.raises(TypeError, match="date_obj must be a datetime object"):
-        get_start_of_year(invalid_input)  # type: ignore
-
-
-def test_get_start_of_year_type_error_none() -> None:
-    """
-    Test case 7: TypeError when input is None.
-    """
-    # Act & Assert
-    with pytest.raises(TypeError, match="date_obj must be a datetime object"):
-        get_start_of_year(None)  # type: ignore
-
-
 def test_get_start_of_year_different_years() -> None:
     """
-    Test case 8: Get start of year for different years.
+    Test case 6: Get start of year for different years.
     """
     # Arrange
     dates = [
@@ -133,3 +112,22 @@ def test_get_start_of_year_different_years() -> None:
         assert result.year == date.year
         assert result.month == 1
         assert result.day == 1
+def test_get_start_of_year_type_error_non_datetime() -> None:
+    """
+    Test case 7: TypeError when input is not a datetime object.
+    """
+    # Arrange
+    invalid_input = "2023-01-01"
+
+    # Act & Assert
+    with pytest.raises(TypeError, match="date_obj must be a datetime object"):
+        get_start_of_year(invalid_input)  # type: ignore
+
+
+def test_get_start_of_year_type_error_none() -> None:
+    """
+    Test case 8: TypeError when input is None.
+    """
+    # Act & Assert
+    with pytest.raises(TypeError, match="date_obj must be a datetime object"):
+        get_start_of_year(None)  # type: ignore

--- a/pytest/unit/decorators/test_async_handle_error.py
+++ b/pytest/unit/decorators/test_async_handle_error.py
@@ -95,38 +95,9 @@ async def test_sync_function_with_no_args():
     assert result == "success"
 
 
-def test_non_async_function():
-    """
-    Test case 6: Synchronous function that raises an error.
-    """
-    with pytest.raises(
-        TypeError, match="The function to be wrapped must be asynchronous"
-    ):
-
-        @async_handle_error()
-        def sample_function(x: int, y: int) -> int:
-            return x + y
-
-
-@pytest.mark.asyncio
-async def test_async_function_exception(caplog, capsys):
-    """
-    Test case 7: Asynchronous function that raises an exception. The error
-    should be logged via the default logger and no output should be printed.
-    """
-    with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError, match="Test exception"):
-            await sample_function_exception(1, 2)
-    assert (
-        "An error occurred in sample_function_exception: Test exception" in caplog.text
-    )
-    captured = capsys.readouterr()
-    assert captured.out == ""
-
-
 def test_non_async_function_with_logger(caplog):
     """
-    Test case 8: Synchronous function that logs an error with logging enabled.
+    Test case 6: Synchronous function that logs an error with logging enabled.
     """
     with caplog.at_level(logging.ERROR):
 
@@ -143,7 +114,7 @@ def test_non_async_function_with_logger(caplog):
 @pytest.mark.asyncio
 async def test_async_function_with_logger(caplog):
     """
-    Test case 9: Asynchronous function that logs an exception with logging enabled.
+    Test case 7: Asynchronous function that logs an exception with logging enabled.
     """
     with caplog.at_level(logging.ERROR):
         result = await sample_function_with_logger(1, 2)
@@ -152,6 +123,35 @@ async def test_async_function_with_logger(caplog):
             "An error occurred in sample_function_with_logger: Test exception"
             in caplog.text
         )
+
+
+def test_non_async_function():
+    """
+    Test case 8: Synchronous function that raises an error.
+    """
+    with pytest.raises(
+        TypeError, match="The function to be wrapped must be asynchronous"
+    ):
+
+        @async_handle_error()
+        def sample_function(x: int, y: int) -> int:
+            return x + y
+
+
+@pytest.mark.asyncio
+async def test_async_function_exception(caplog, capsys):
+    """
+    Test case 9: Asynchronous function that raises an exception. The error
+    should be logged via the default logger and no output should be printed.
+    """
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(ValueError, match="Test exception"):
+            await sample_function_exception(1, 2)
+    assert (
+        "An error occurred in sample_function_exception: Test exception" in caplog.text
+    )
+    captured = capsys.readouterr()
+    assert captured.out == ""
 
 
 @pytest.mark.asyncio

--- a/pytest/unit/decorators/test_async_wrapper.py
+++ b/pytest/unit/decorators/test_async_wrapper.py
@@ -95,9 +95,23 @@ async def test_sync_function_with_no_args():
     assert result == "success"
 
 
+@pytest.mark.asyncio
+async def test_sync_function_with_logger(caplog):
+    """
+    Test case 6: Synchronous function that logs an exception with logging enabled.
+    """
+    with caplog.at_level(logging.ERROR):
+        result = await sample_function_with_logger(1, 2)
+        assert result is None
+        assert (
+            "An error occurred in sample_function_with_logger: Test exception"
+            in caplog.text
+        )
+
+
 def test_async_function():
     """
-    Test case 6: Asynchronous function that raises an TypeError.
+    Test case 7: Asynchronous function that raises an TypeError.
     """
     with pytest.raises(
         TypeError, match="The function to be wrapped must be synchronous"
@@ -111,7 +125,7 @@ def test_async_function():
 @pytest.mark.asyncio
 async def test_sync_function_with_logger_raises_value_error():
     """
-    Test case 7: Synchronous function that raises a ValueError.
+    Test case 8: Synchronous function that raises a ValueError.
     """
     with pytest.raises(ValueError, match="Test exception"):
         await sample_function_exception(1, 2)
@@ -119,7 +133,7 @@ async def test_sync_function_with_logger_raises_value_error():
 
 def test_async_function_with_logger(caplog):
     """
-    Test case 8: Asynchronous function that logs an TypeError with logging enabled.
+    Test case 9: Asynchronous function that logs an TypeError with logging enabled.
     """
     with pytest.raises(
         TypeError, match="The function to be wrapped must be synchronous"
@@ -134,20 +148,6 @@ def test_async_function_with_logger(caplog):
                 "An error occurred in sample_function: The function to be wrapped must be synchronous"
                 in caplog.text
             )
-
-
-@pytest.mark.asyncio
-async def test_sync_function_with_logger(caplog):
-    """
-    Test case 9: Synchronous function that logs an exception with logging enabled.
-    """
-    with caplog.at_level(logging.ERROR):
-        result = await sample_function_with_logger(1, 2)
-        assert result is None
-        assert (
-            "An error occurred in sample_function_with_logger: Test exception"
-            in caplog.text
-        )
 
 
 @pytest.mark.asyncio

--- a/pytest/unit/decorators/test_handle_error.py
+++ b/pytest/unit/decorators/test_handle_error.py
@@ -139,20 +139,9 @@ def test_handle_error_with_custom_exception(capfd):
     assert "An error occurred: This is a CustomException" in out
 
 
-def test_handle_invalid_logger():
-    """
-    Test case 9: Invalid logger.
-    """
-    with pytest.raises(TypeError):
-
-        @handle_error("An error occurred", logger="test_logger")
-        def raise_value_error_invalid_logger():
-            raise ValueError("This is a ValueError")
-
-
 def test_handle_error_value_error_with_logging(caplog):
     """
-    Test case 10: Handling ValueError with logging.
+    Test case 9: Handling ValueError with logging.
     """
     with caplog.at_level(logging.ERROR):
         result = raise_value_error_with_logging()
@@ -162,9 +151,18 @@ def test_handle_error_value_error_with_logging(caplog):
 
 def test_handle_error_type_error_with_logging(caplog):
     """
-    Test case 11: Handling TypeError with logging.
+    Test case 10: Handling TypeError with logging.
     """
     with caplog.at_level(logging.ERROR):
         result = raise_type_error_with_logging()
         assert result is None
         assert "An error occurred: This is a TypeError" in caplog.text
+def test_handle_invalid_logger():
+    """
+    Test case 11: Invalid logger.
+    """
+    with pytest.raises(TypeError):
+
+        @handle_error("An error occurred", logger="test_logger")
+        def raise_value_error_invalid_logger():
+            raise ValueError("This is a ValueError")

--- a/pytest/unit/decorators/test_log_signature.py
+++ b/pytest/unit/decorators/test_log_signature.py
@@ -54,21 +54,9 @@ def test_log_signature_greet(caplog):
         )
 
 
-def test_log_signature_raise_value_error(caplog):
-    """
-    Test case 3: Logging function signature for function that raises ValueError.
-    """
-    with caplog.at_level(logging.DEBUG):
-        with pytest.raises(ValueError, match="This is a ValueError"):
-            raise_value_error()
-        assert (
-            "Executing raise_value_error() with args: () and kwargs: {}" in caplog.text
-        )
-
-
 def test_log_signature_return_value(caplog):
     """
-    Test case 4: Logging function signature for return_value function.
+    Test case 3: Logging function signature for return_value function.
     """
     with caplog.at_level(logging.DEBUG):
         result = return_value(5)
@@ -81,7 +69,7 @@ def test_log_signature_return_value(caplog):
 
 def test_log_signature_with_kwargs(caplog):
     """
-    Test case 5: Logging function signature with keyword arguments.
+    Test case 4: Logging function signature with keyword arguments.
     """
 
     @log_signature(logger=test_logger)
@@ -99,7 +87,7 @@ def test_log_signature_with_kwargs(caplog):
 
 def test_log_signature_with_multiple_args(caplog):
     """
-    Test case 6: Logging function signature with multiple arguments.
+    Test case 5: Logging function signature with multiple arguments.
     """
 
     @log_signature(logger=test_logger)
@@ -112,6 +100,18 @@ def test_log_signature_with_multiple_args(caplog):
         assert (
             "Executing multiple_args(a, b, c) with args: (1, 2, 3) and kwargs: {}"
             in caplog.text
+        )
+
+
+def test_log_signature_raise_value_error(caplog):
+    """
+    Test case 6: Logging function signature for function that raises ValueError.
+    """
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(ValueError, match="This is a ValueError"):
+            raise_value_error()
+        assert (
+            "Executing raise_value_error() with args: () and kwargs: {}" in caplog.text
         )
 
 

--- a/pytest/unit/decorators/test_multi_decorator.py
+++ b/pytest/unit/decorators/test_multi_decorator.py
@@ -96,11 +96,24 @@ def test_multi_decorator_with_variable_length_arguments(
     )
 
 
+def test_multi_decorator_no_logger() -> None:
+    """
+    Test case 5: Multi decorator without logger
+    """
+
+    @multi_decorator([decorator1, decorator2])
+    def sample_function_no_logger(a: int, b: int) -> int:
+        return a + b
+
+    result = sample_function_no_logger(1, 2)
+    assert result == "decorator1(decorator2(3))"
+
+
 def test_multi_decorator_function_raises_error(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """
-    Test case 5: Multi decorator when the wrapped function raises an error
+    Test case 6: Multi decorator when the wrapped function raises an error
     """
     with caplog.at_level(logging.ERROR):
         with pytest.raises(ValueError, match="An error occurred"):
@@ -109,7 +122,7 @@ def test_multi_decorator_function_raises_error(
 
 def test_multi_decorator_invalid_decorator(caplog: pytest.LogCaptureFixture) -> None:
     """
-    Test case 6: Invalid decorator type
+    Test case 7: Invalid decorator type
     """
     with caplog.at_level(logging.ERROR):
         with pytest.raises(TypeError, match="Decorator 123 is not callable"):
@@ -121,7 +134,7 @@ def test_multi_decorator_invalid_decorator(caplog: pytest.LogCaptureFixture) -> 
 
 def test_multi_decorator_invalid_logger() -> None:
     """
-    Test case 7: Invalid logger type
+    Test case 8: Invalid logger type
     """
     with pytest.raises(
         TypeError, match="logger must be an instance of logging.Logger or None"
@@ -130,19 +143,6 @@ def test_multi_decorator_invalid_logger() -> None:
         @multi_decorator([decorator1, decorator2], logger="invalid_logger")
         def sample_function_invalid_logger(a: int, b: int) -> int:
             return a + b
-
-
-def test_multi_decorator_no_logger() -> None:
-    """
-    Test case 8: Multi decorator without logger
-    """
-
-    @multi_decorator([decorator1, decorator2])
-    def sample_function_no_logger(a: int, b: int) -> int:
-        return a + b
-
-    result = sample_function_no_logger(1, 2)
-    assert result == "decorator1(decorator2(3))"
 
 
 def test_multi_decorator_invalid_decorator_no_logger() -> None:

--- a/pytest/unit/decorators/test_rate_limit.py
+++ b/pytest/unit/decorators/test_rate_limit.py
@@ -18,9 +18,21 @@ def sample_function() -> str:
     return "Function executed"
 
 
+def test_rate_limit_single_call():
+    """
+    Test case 1: Single call within the rate limit period
+    """
+
+    @rate_limit(max_calls=1, period=5)
+    def single_call_function() -> str:
+        return "Function executed"
+
+    assert single_call_function() == "Function executed"
+
+
 def test_rate_limit_basic():
     """
-    Test case 1: Basic functionality of rate limiting
+    Test case 2: Basic functionality of rate limiting
     """
     assert sample_function() == "Function executed"
     assert sample_function() == "Function executed"
@@ -30,7 +42,7 @@ def test_rate_limit_basic():
 
 def test_rate_limit_custom_message():
     """
-    Test case 2: Custom exception message when rate limit is exceeded
+    Test case 3: Custom exception message when rate limit is exceeded
     """
 
     @rate_limit(max_calls=1, period=5, exception_message="Custom rate limit message")
@@ -44,7 +56,7 @@ def test_rate_limit_custom_message():
 
 def test_rate_limit_with_logger(caplog):
     """
-    Test case 3: Logger functionality when rate limit is exceeded
+    Test case 4: Logger functionality when rate limit is exceeded
     """
     logger = logging.getLogger("rate_limit_logger")
     logger.setLevel(logging.WARNING)
@@ -64,7 +76,7 @@ def test_rate_limit_with_logger(caplog):
 
 def test_rate_limit_with_args():
     """
-    Test case 4: Function with positional arguments
+    Test case 5: Function with positional arguments
     """
 
     @rate_limit(max_calls=2, period=5)
@@ -79,7 +91,7 @@ def test_rate_limit_with_args():
 
 def test_rate_limit_with_kwargs():
     """
-    Test case 5: Function with keyword arguments
+    Test case 6: Function with keyword arguments
     """
 
     @rate_limit(max_calls=2, period=5)
@@ -94,7 +106,7 @@ def test_rate_limit_with_kwargs():
 
 def test_rate_limit_with_variable_length_args():
     """
-    Test case 6: Function with variable length arguments (*args and **kwargs)
+    Test case 7: Function with variable length arguments (*args and **kwargs)
     """
 
     @rate_limit(max_calls=2, period=5)
@@ -115,7 +127,7 @@ def test_rate_limit_with_variable_length_args():
 
 def test_rate_limit_exceeding_calls():
     """
-    Test case 7: Exceeding function call within the rate limit period
+    Test case 8: Exceeding function call within the rate limit period
     """
 
     @rate_limit(max_calls=1, period=5)
@@ -125,18 +137,6 @@ def test_rate_limit_exceeding_calls():
     assert exceeding_function_call() == "Function executed"
     with pytest.raises(RateLimitExceededException):
         exceeding_function_call()
-
-
-def test_rate_limit_single_call():
-    """
-    Test case 8: Single call within the rate limit period
-    """
-
-    @rate_limit(max_calls=1, period=5)
-    def single_call_function() -> str:
-        return "Function executed"
-
-    assert single_call_function() == "Function executed"
 
 
 def test_rate_limit_with_multiple_calls():

--- a/pytest/unit/decorators/test_retry.py
+++ b/pytest/unit/decorators/test_retry.py
@@ -30,34 +30,9 @@ def test_retry_success():
     assert sample_function_success() == "Function executed"
 
 
-def test_retry_failure():
-    """
-    Test case 2: Function fails after retries
-    """
-    with pytest.raises(Exception, match="Function failed"):
-        sample_function_failure()
-
-
-def test_retry_with_logger(caplog):
-    """
-    Test case 3: Logger functionality when function fails
-    """
-
-    @retry(3, logger=test_logger)
-    def logged_function() -> str:
-        raise Exception("Function failed")
-
-    with caplog.at_level(logging.WARNING):
-        with pytest.raises(Exception, match="Function failed"):
-            logged_function()
-        assert "Attempt 1 failed for logged_function: Function failed" in caplog.text
-        assert "Attempt 2 failed for logged_function: Function failed" in caplog.text
-        assert "Attempt 3 failed for logged_function: Function failed" in caplog.text
-
-
 def test_retry_with_args():
     """
-    Test case 4: Function with positional arguments
+    Test case 2: Function with positional arguments
     """
 
     @retry(3)
@@ -69,7 +44,7 @@ def test_retry_with_args():
 
 def test_retry_with_kwargs():
     """
-    Test case 5: Function with keyword arguments
+    Test case 3: Function with keyword arguments
     """
 
     @retry(3)
@@ -81,7 +56,7 @@ def test_retry_with_kwargs():
 
 def test_retry_with_var_args():
     """
-    Test case 6: Function with variable length arguments (*args and **kwargs)
+    Test case 4: Function with variable length arguments (*args and **kwargs)
     """
 
     @retry(3)
@@ -96,7 +71,7 @@ def test_retry_with_var_args():
 
 def test_retry_with_0_max_retries():
     """
-    Test case 7: Function with 0 max_retries
+    Test case 5: Function with 0 max_retries
     """
 
     @retry(0)
@@ -106,9 +81,46 @@ def test_retry_with_0_max_retries():
     assert function_with_0_max_retries() == "Function executed"
 
 
+def test_retry_with_0_delay():
+    """
+    Test case 6: Function with 0 delay
+    """
+
+    @retry(3, delay=0)
+    def function_with_0_delay() -> str:
+        return "Function executed"
+
+    assert function_with_0_delay() == "Function executed"
+
+
+def test_retry_failure():
+    """
+    Test case 7: Function fails after retries
+    """
+    with pytest.raises(Exception, match="Function failed"):
+        sample_function_failure()
+
+
+def test_retry_with_logger(caplog):
+    """
+    Test case 8: Logger functionality when function fails
+    """
+
+    @retry(3, logger=test_logger)
+    def logged_function() -> str:
+        raise Exception("Function failed")
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(Exception, match="Function failed"):
+            logged_function()
+        assert "Attempt 1 failed for logged_function: Function failed" in caplog.text
+        assert "Attempt 2 failed for logged_function: Function failed" in caplog.text
+        assert "Attempt 3 failed for logged_function: Function failed" in caplog.text
+
+
 def test_retry_with_negative_retries():
     """
-    Test case 8: Function with negative max_retries
+    Test case 9: Function with negative max_retries
     """
     with pytest.raises(Exception, match="max_retries must be an positive integer or 0"):
 
@@ -117,18 +129,6 @@ def test_retry_with_negative_retries():
             raise Exception("Function failed")
 
         function_with_negative_retries()
-
-
-def test_retry_with_0_delay():
-    """
-    Test case 9: Function with 0 delay
-    """
-
-    @retry(3, delay=0)
-    def function_with_0_delay() -> str:
-        return "Function executed"
-
-    assert function_with_0_delay() == "Function executed"
 
 
 def test_retry_with_negative_delay():

--- a/pytest/unit/decorators/test_serialize_output.py
+++ b/pytest/unit/decorators/test_serialize_output.py
@@ -66,9 +66,19 @@ def test_serialize_output_with_var_args():
     )
 
 
+def test_serialize_invalid_logger():
+    """
+    Test case 5: Invalid logger
+    """
+
+    @serialize_output("json", logger="invalid_logger")
+    def invalid_logger_function() -> None:
+        pass
+
+
 def test_serialize_output_with_logger(caplog):
     """
-    Test case 5: Logger functionality when an error occurs
+    Test case 6: Logger functionality when an error occurs
     """
     logger = logging.getLogger("serialize_output_logger")
     logger.setLevel(logging.ERROR)
@@ -81,16 +91,6 @@ def test_serialize_output_with_logger(caplog):
         with pytest.raises(ValueError):
             error_function()
         assert "Error serializing output in error_function: Sample error" in caplog.text
-
-
-def test_serialize_invalid_logger():
-    """
-    Test case 6: Invalid logger
-    """
-
-    @serialize_output("json", logger="invalid_logger")
-    def invalid_logger_function() -> None:
-        pass
 
 
 def test_invalid_format_type():

--- a/pytest/unit/decorators/test_timeout.py
+++ b/pytest/unit/decorators/test_timeout.py
@@ -28,9 +28,51 @@ def test_timeout_success():
     assert result == "Function executed"
 
 
+def test_timeout_with_args():
+    """
+    Test case 2: Function with positional arguments
+    """
+
+    @timeout(seconds=2)
+    def function_with_args(a: int, b: int) -> int:
+        time.sleep(1)
+        return a + b
+
+    result = function_with_args(1, 2)
+    assert result == 3
+
+
+def test_timeout_with_kwargs():
+    """
+    Test case 3: Function with keyword arguments
+    """
+
+    @timeout(seconds=2)
+    def function_with_kwargs(a: int, b: int = 0) -> int:
+        time.sleep(1)
+        return a + b
+
+    result = function_with_kwargs(1, b=2)
+    assert result == 3
+
+
+def test_timeout_with_var_args():
+    """
+    Test case 4: Function with variable length arguments (*args and **kwargs)
+    """
+
+    @timeout(seconds=2)
+    def function_with_var_args(a: int, *args: str, **kwargs: float) -> str:
+        time.sleep(1)
+        return f"{a} - {args} - {kwargs}"
+
+    result = function_with_var_args(1, "arg1", "arg2", kwarg1=1.0, kwarg2=2.0)
+    assert result == "1 - ('arg1', 'arg2') - {'kwarg1': 1.0, 'kwarg2': 2.0}"
+
+
 def test_timeout_exceeded():
     """
-    Test case 2: Function exceeds the timeout period and raises TimeoutException
+    Test case 5: Function exceeds the timeout period and raises TimeoutException
     """
 
     @timeout(seconds=1)
@@ -46,7 +88,7 @@ def test_timeout_exceeded():
 
 def test_timeout_with_logger(caplog):
     """
-    Test case 3: Function exceeds the timeout period and logs the timeout message
+    Test case 6: Function exceeds the timeout period and logs the timeout message
     """
 
     @timeout(seconds=1, logger=test_logger)
@@ -60,48 +102,6 @@ def test_timeout_with_logger(caplog):
             "Function long_running_function_with_logger timed out after 1 seconds"
             in caplog.text
         )
-
-
-def test_timeout_with_args():
-    """
-    Test case 4: Function with positional arguments
-    """
-
-    @timeout(seconds=2)
-    def function_with_args(a: int, b: int) -> int:
-        time.sleep(1)
-        return a + b
-
-    result = function_with_args(1, 2)
-    assert result == 3
-
-
-def test_timeout_with_kwargs():
-    """
-    Test case 5: Function with keyword arguments
-    """
-
-    @timeout(seconds=2)
-    def function_with_kwargs(a: int, b: int = 0) -> int:
-        time.sleep(1)
-        return a + b
-
-    result = function_with_kwargs(1, b=2)
-    assert result == 3
-
-
-def test_timeout_with_var_args():
-    """
-    Test case 6: Function with variable length arguments (*args and **kwargs)
-    """
-
-    @timeout(seconds=2)
-    def function_with_var_args(a: int, *args: str, **kwargs: float) -> str:
-        time.sleep(1)
-        return f"{a} - {args} - {kwargs}"
-
-    result = function_with_var_args(1, "arg1", "arg2", kwarg1=1.0, kwarg2=2.0)
-    assert result == "1 - ('arg1', 'arg2') - {'kwarg1': 1.0, 'kwarg2': 2.0}"
 
 
 def test_invalid_logger_type():

--- a/pytest/unit/decorators/test_validate_args.py
+++ b/pytest/unit/decorators/test_validate_args.py
@@ -31,9 +31,35 @@ def test_validate_args_success():
     assert result == 3
 
 
+def test_validate_args_with_kwargs():
+    """
+    Test case 2: Function with keyword arguments
+    """
+
+    @validate_args(is_positive)
+    def function_with_kwargs(a: int, b: int = 0) -> int:
+        return a + b
+
+    result = function_with_kwargs(1, b=2)
+    assert result == 3
+
+
+def test_validate_args_with_var_args():
+    """
+    Test case 3: Function with variable length arguments (*args and **kwargs)
+    """
+
+    @validate_args(is_positive)
+    def function_with_var_args(a: int, *args: int, **kwargs: int) -> str:
+        return f"{a} - {args} - {kwargs}"
+
+    result = function_with_var_args(1, 2, 3, kwarg1=4, kwarg2=5)
+    assert result == "1 - (2, 3) - {'kwarg1': 4, 'kwarg2': 5}"
+
+
 def test_validate_args_failure():
     """
-    Test case 2: Function raises ValueError with invalid arguments
+    Test case 4: Function raises ValueError with invalid arguments
     """
     with pytest.raises(
         ValueError, match="Function sample_function arguments did not pass validation."
@@ -43,7 +69,7 @@ def test_validate_args_failure():
 
 def test_validate_args_with_logger(caplog):
     """
-    Test case 3: Function raises ValueError and logs the validation failure message
+    Test case 5: Function raises ValueError and logs the validation failure message
     """
 
     @validate_args(is_positive, logger=test_logger)
@@ -57,32 +83,6 @@ def test_validate_args_with_logger(caplog):
             "Function function_with_logger arguments did not pass validation."
             in caplog.text
         )
-
-
-def test_validate_args_with_kwargs():
-    """
-    Test case 4: Function with keyword arguments
-    """
-
-    @validate_args(is_positive)
-    def function_with_kwargs(a: int, b: int = 0) -> int:
-        return a + b
-
-    result = function_with_kwargs(1, b=2)
-    assert result == 3
-
-
-def test_validate_args_with_var_args():
-    """
-    Test case 5: Function with variable length arguments (*args and **kwargs)
-    """
-
-    @validate_args(is_positive)
-    def function_with_var_args(a: int, *args: int, **kwargs: int) -> str:
-        return f"{a} - {args} - {kwargs}"
-
-    result = function_with_var_args(1, 2, 3, kwarg1=4, kwarg2=5)
-    assert result == "1 - (2, 3) - {'kwarg1': 4, 'kwarg2': 5}"
 
 
 def test_invalid_validation_func():

--- a/pytest/unit/file_functions/file_operations/test_copy_file.py
+++ b/pytest/unit/file_functions/file_operations/test_copy_file.py
@@ -62,71 +62,9 @@ def test_copy_file_creates_destination_directory() -> None:
         assert destination.read_text() == "content"
 
 
-def test_copy_file_type_error_non_string_source() -> None:
-    """
-    Test case 4: TypeError when source is not a string.
-    """
-    # Act & Assert
-    with pytest.raises(TypeError, match="source must be a string"):
-        copy_file(123, "destination.txt")  # type: ignore
-
-
-def test_copy_file_type_error_non_string_destination() -> None:
-    """
-    Test case 5: TypeError when destination is not a string.
-    """
-    # Act & Assert
-    with pytest.raises(TypeError, match="destination must be a string"):
-        copy_file("source.txt", 456)  # type: ignore
-
-
-def test_copy_file_value_error_empty_source() -> None:
-    """
-    Test case 6: ValueError when source path is empty.
-    """
-    # Act & Assert
-    with pytest.raises(ValueError, match="source path cannot be empty"):
-        copy_file("", "destination.txt")
-
-
-def test_copy_file_value_error_empty_destination() -> None:
-    """
-    Test case 7: ValueError when destination path is empty.
-    """
-    # Act & Assert
-    with pytest.raises(ValueError, match="destination path cannot be empty"):
-        copy_file("source.txt", "")
-
-
-def test_copy_file_file_not_found_error() -> None:
-    """
-    Test case 8: FileNotFoundError when source doesn't exist.
-    """
-    # Arrange
-    non_existent = "/path/that/does/not/exist/file.txt"
-
-    # Act & Assert
-    with pytest.raises(FileNotFoundError, match="Source file not found"):
-        copy_file(non_existent, "destination.txt")
-
-
-def test_copy_file_value_error_source_is_directory() -> None:
-    """
-    Test case 9: ValueError when source is a directory.
-    """
-    # Arrange
-    with tempfile.TemporaryDirectory() as temp_dir:
-        source_dir = Path(temp_dir) / "source_dir"
-        source_dir.mkdir()
-
-        # Act & Assert
-        with pytest.raises(ValueError, match="Source is not a file"):
-            copy_file(str(source_dir), "destination.txt")
-
-
 def test_copy_file_large_file() -> None:
     """
-    Test case 10: Copy large file successfully.
+    Test case 4: Copy large file successfully.
     """
     # Arrange
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -145,7 +83,7 @@ def test_copy_file_large_file() -> None:
 
 def test_copy_file_preserves_content() -> None:
     """
-    Test case 11: Verify file content is preserved exactly.
+    Test case 5: Verify file content is preserved exactly.
     """
     # Arrange
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -163,7 +101,7 @@ def test_copy_file_preserves_content() -> None:
 
 def test_copy_file_different_extension() -> None:
     """
-    Test case 12: Copy file with different extension.
+    Test case 6: Copy file with different extension.
     """
     # Arrange
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -177,3 +115,63 @@ def test_copy_file_different_extension() -> None:
         # Assert
         assert destination.exists()
         assert destination.read_text() == "content"
+def test_copy_file_type_error_non_string_source() -> None:
+    """
+    Test case 7: TypeError when source is not a string.
+    """
+    # Act & Assert
+    with pytest.raises(TypeError, match="source must be a string"):
+        copy_file(123, "destination.txt")  # type: ignore
+
+
+def test_copy_file_type_error_non_string_destination() -> None:
+    """
+    Test case 8: TypeError when destination is not a string.
+    """
+    # Act & Assert
+    with pytest.raises(TypeError, match="destination must be a string"):
+        copy_file("source.txt", 456)  # type: ignore
+
+
+def test_copy_file_value_error_empty_source() -> None:
+    """
+    Test case 9: ValueError when source path is empty.
+    """
+    # Act & Assert
+    with pytest.raises(ValueError, match="source path cannot be empty"):
+        copy_file("", "destination.txt")
+
+
+def test_copy_file_value_error_empty_destination() -> None:
+    """
+    Test case 10: ValueError when destination path is empty.
+    """
+    # Act & Assert
+    with pytest.raises(ValueError, match="destination path cannot be empty"):
+        copy_file("source.txt", "")
+
+
+def test_copy_file_file_not_found_error() -> None:
+    """
+    Test case 11: FileNotFoundError when source doesn't exist.
+    """
+    # Arrange
+    non_existent = "/path/that/does/not/exist/file.txt"
+
+    # Act & Assert
+    with pytest.raises(FileNotFoundError, match="Source file not found"):
+        copy_file(non_existent, "destination.txt")
+
+
+def test_copy_file_value_error_source_is_directory() -> None:
+    """
+    Test case 12: ValueError when source is a directory.
+    """
+    # Arrange
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_dir = Path(temp_dir) / "source_dir"
+        source_dir.mkdir()
+
+        # Act & Assert
+        with pytest.raises(ValueError, match="Source is not a file"):
+            copy_file(str(source_dir), "destination.txt")

--- a/pytest/unit/file_functions/file_operations/test_write_lines.py
+++ b/pytest/unit/file_functions/file_operations/test_write_lines.py
@@ -64,43 +64,9 @@ def test_write_lines_case_3_append_mode() -> None:
         assert content == "initial\nappended1\nappended2\n"
 
 
-def test_write_lines_case_4_type_validation() -> None:
-    """
-    Test case 4: Type validation for parameters.
-    """
-    # Test invalid lines type
-    with pytest.raises(TypeError, match="lines must be a list"):
-        write_lines("not_a_list", "output.txt")
-
-    # Test invalid file_path type
-    with pytest.raises(TypeError, match="file_path must be a string"):
-        write_lines(["line1"], 123)
-
-    # Test invalid joiner type
-    with pytest.raises(TypeError, match="joiner must be a string"):
-        write_lines(["line1"], "output.txt", joiner=123)
-
-    # Test invalid write_mode type
-    with pytest.raises(TypeError, match="write_mode must be a string"):
-        write_lines(["line1"], "output.txt", write_mode=123)
-
-
-def test_write_lines_case_5_value_validation() -> None:
-    """
-    Test case 5: Value validation for parameters.
-    """
-    # Test empty file_path
-    with pytest.raises(ValueError, match="file_path cannot be empty"):
-        write_lines(["line1"], "")
-
-    # Test invalid write_mode
-    with pytest.raises(ValueError, match="write_mode must be 'w' or 'a'"):
-        write_lines(["line1"], "output.txt", write_mode="invalid")
-
-
 def test_write_lines_case_6_empty_list() -> None:
     """
-    Test case 6: Write empty list of lines.
+    Test case 4: Write empty list of lines.
     """
     # Arrange
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -118,7 +84,7 @@ def test_write_lines_case_6_empty_list() -> None:
 
 def test_write_lines_case_7_lines_with_non_strings() -> None:
     """
-    Test case 7: Handle non-string items in lines list.
+    Test case 5: Handle non-string items in lines list.
     """
     # Arrange
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -136,7 +102,7 @@ def test_write_lines_case_7_lines_with_non_strings() -> None:
 
 def test_write_lines_case_8_unicode_content() -> None:
     """
-    Test case 8: Handle Unicode characters in lines.
+    Test case 6: Handle Unicode characters in lines.
     """
     # Arrange
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -154,7 +120,7 @@ def test_write_lines_case_8_unicode_content() -> None:
 
 def test_write_lines_case_9_overwrite_mode() -> None:
     """
-    Test case 9: Write lines in overwrite mode (default).
+    Test case 7: Write lines in overwrite mode (default).
     """
     # Arrange
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -177,7 +143,7 @@ def test_write_lines_case_9_overwrite_mode() -> None:
 
 def test_write_lines_case_10_custom_joiner_no_spaces() -> None:
     """
-    Test case 10: Write lines with custom joiner without spaces.
+    Test case 8: Write lines with custom joiner without spaces.
     """
     # Arrange
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -191,3 +157,35 @@ def test_write_lines_case_10_custom_joiner_no_spaces() -> None:
         with open(output_file) as f:
             content = f.read()
         assert content == "a|b|c|d\n"
+def test_write_lines_case_4_type_validation() -> None:
+    """
+    Test case 9: Type validation for parameters.
+    """
+    # Test invalid lines type
+    with pytest.raises(TypeError, match="lines must be a list"):
+        write_lines("not_a_list", "output.txt")
+
+    # Test invalid file_path type
+    with pytest.raises(TypeError, match="file_path must be a string"):
+        write_lines(["line1"], 123)
+
+    # Test invalid joiner type
+    with pytest.raises(TypeError, match="joiner must be a string"):
+        write_lines(["line1"], "output.txt", joiner=123)
+
+    # Test invalid write_mode type
+    with pytest.raises(TypeError, match="write_mode must be a string"):
+        write_lines(["line1"], "output.txt", write_mode=123)
+
+
+def test_write_lines_case_5_value_validation() -> None:
+    """
+    Test case 10: Value validation for parameters.
+    """
+    # Test empty file_path
+    with pytest.raises(ValueError, match="file_path cannot be empty"):
+        write_lines(["line1"], "")
+
+    # Test invalid write_mode
+    with pytest.raises(ValueError, match="write_mode must be 'w' or 'a'"):
+        write_lines(["line1"], "output.txt", write_mode="invalid")

--- a/pytest/unit/file_functions/file_operations/test_write_to_file.py
+++ b/pytest/unit/file_functions/file_operations/test_write_to_file.py
@@ -80,9 +80,92 @@ def test_write_to_file_case_4_custom_end_char() -> None:
             assert f.read() == content + end_char
 
 
+def test_write_to_file_case_7_unicode_content() -> None:
+    """
+    Test case 5: Handle Unicode characters in content.
+    """
+    # Arrange
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        output_file = os.path.join(tmp_dir, "output.txt")
+        content = "Hello 世界! ümläuts émojis 🎉"
+
+        # Act
+        write_to_file(content, output_file)
+
+        # Assert
+        with open(output_file, encoding="utf-8") as f:
+            assert f.read() == content
+
+
+def test_write_to_file_case_8_empty_content() -> None:
+    """
+    Test case 6: Write empty content.
+    """
+    # Arrange
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        output_file = os.path.join(tmp_dir, "output.txt")
+        content = ""
+
+        # Act
+        write_to_file(content, output_file)
+
+        # Assert
+        with open(output_file) as f:
+            assert f.read() == content
+
+
+def test_write_to_file_case_9_exclusive_mode() -> None:
+    """
+    Test case 7: Write in exclusive mode (file must not exist).
+    """
+    # Arrange
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        new_file = os.path.join(tmp_dir, "new_file.txt")
+        content = "New file content"
+
+        # Act
+        write_to_file(content, new_file, mode="x")
+
+        # Assert
+        with open(new_file) as f:
+            assert f.read() == content
+
+
+def test_write_to_file_case_11_multiline_content() -> None:
+    """
+    Test case 8: Handle multiline content.
+    """
+    # Arrange
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        output_file = os.path.join(tmp_dir, "output.txt")
+        content = "Line 1\nLine 2\nLine 3"
+
+        # Act
+        write_to_file(content, output_file)
+
+        # Assert
+        with open(output_file) as f:
+            assert f.read() == content
+
+
+def test_write_to_file_case_12_special_characters() -> None:
+    """
+    Test case 9: Handle special characters in content.
+    """
+    # Arrange
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        output_file = os.path.join(tmp_dir, "output.txt")
+        content = "Special chars: !@#$%^&*()_+-=[]{}|;':\",./<>?`~"
+
+        # Act
+        write_to_file(content, output_file)
+
+        # Assert
+        with open(output_file) as f:
+            assert f.read() == content
 def test_write_to_file_case_5_type_validation() -> None:
     """
-    Test case 5: Type validation for parameters.
+    Test case 10: Type validation for parameters.
     """
     # Test invalid data type
     with pytest.raises(TypeError, match="data must be a string"):
@@ -103,7 +186,7 @@ def test_write_to_file_case_5_type_validation() -> None:
 
 def test_write_to_file_case_6_value_validation() -> None:
     """
-    Test case 6: Value validation for parameters.
+    Test case 11: Value validation for parameters.
     """
     # Test empty file_path
     with pytest.raises(ValueError, match="file_path cannot be empty"):
@@ -114,60 +197,9 @@ def test_write_to_file_case_6_value_validation() -> None:
         write_to_file("content", "output.txt", mode="invalid")
 
 
-def test_write_to_file_case_7_unicode_content() -> None:
-    """
-    Test case 7: Handle Unicode characters in content.
-    """
-    # Arrange
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        output_file = os.path.join(tmp_dir, "output.txt")
-        content = "Hello 世界! ümläuts émojis 🎉"
-
-        # Act
-        write_to_file(content, output_file)
-
-        # Assert
-        with open(output_file, encoding="utf-8") as f:
-            assert f.read() == content
-
-
-def test_write_to_file_case_8_empty_content() -> None:
-    """
-    Test case 8: Write empty content.
-    """
-    # Arrange
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        output_file = os.path.join(tmp_dir, "output.txt")
-        content = ""
-
-        # Act
-        write_to_file(content, output_file)
-
-        # Assert
-        with open(output_file) as f:
-            assert f.read() == content
-
-
-def test_write_to_file_case_9_exclusive_mode() -> None:
-    """
-    Test case 9: Write in exclusive mode (file must not exist).
-    """
-    # Arrange
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        new_file = os.path.join(tmp_dir, "new_file.txt")
-        content = "New file content"
-
-        # Act
-        write_to_file(content, new_file, mode="x")
-
-        # Assert
-        with open(new_file) as f:
-            assert f.read() == content
-
-
 def test_write_to_file_case_10_exclusive_mode_file_exists() -> None:
     """
-    Test case 10: Exclusive mode should raise error if file exists.
+    Test case 12: Exclusive mode should raise error if file exists.
     """
     # Arrange
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -180,37 +212,3 @@ def test_write_to_file_case_10_exclusive_mode_file_exists() -> None:
         # Act & Assert
         with pytest.raises(FileExistsError):
             write_to_file("new content", existing_file, mode="x")
-
-
-def test_write_to_file_case_11_multiline_content() -> None:
-    """
-    Test case 11: Handle multiline content.
-    """
-    # Arrange
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        output_file = os.path.join(tmp_dir, "output.txt")
-        content = "Line 1\nLine 2\nLine 3"
-
-        # Act
-        write_to_file(content, output_file)
-
-        # Assert
-        with open(output_file) as f:
-            assert f.read() == content
-
-
-def test_write_to_file_case_12_special_characters() -> None:
-    """
-    Test case 12: Handle special characters in content.
-    """
-    # Arrange
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        output_file = os.path.join(tmp_dir, "output.txt")
-        content = "Special chars: !@#$%^&*()_+-=[]{}|;':\",./<>?`~"
-
-        # Act
-        write_to_file(content, output_file)
-
-        # Assert
-        with open(output_file) as f:
-            assert f.read() == content

--- a/pytest/unit/file_functions/recursive_search/test_find_files_by_extension.py
+++ b/pytest/unit/file_functions/recursive_search/test_find_files_by_extension.py
@@ -87,9 +87,26 @@ def test_find_files_by_extension_case_4_empty_directory() -> None:
         assert result == []
 
 
+def test_find_files_by_extension_case_8_path_object_input() -> None:
+    """
+    Test case 5: Function works with Path object input.
+    """
+    # Arrange
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        (temp_path / "test.py").touch()
+
+        # Act
+        result = find_files_by_extension(temp_path, ".py")
+
+        # Assert
+        assert len(result) == 1
+        assert Path(result[0]).name == "test.py"
+
+
 def test_find_files_by_extension_case_5_invalid_directory_error() -> None:
     """
-    Test case 5: ValueError for non-existent directory.
+    Test case 6: ValueError for non-existent directory.
     """
     # Arrange
     non_existent_dir = "/path/that/does/not/exist"
@@ -101,7 +118,7 @@ def test_find_files_by_extension_case_5_invalid_directory_error() -> None:
 
 def test_find_files_by_extension_case_6_invalid_type_errors() -> None:
     """
-    Test case 6: TypeError for invalid parameter types.
+    Test case 7: TypeError for invalid parameter types.
     """
     # Test invalid directory type
     with pytest.raises(TypeError, match="directory must be a string or Path"):
@@ -118,30 +135,13 @@ def test_find_files_by_extension_case_6_invalid_type_errors() -> None:
 
 def test_find_files_by_extension_case_7_empty_extension_error() -> None:
     """
-    Test case 7: ValueError for empty extension.
+    Test case 8: ValueError for empty extension.
     """
     # Arrange
     with tempfile.TemporaryDirectory() as temp_dir:
         # Act & Assert
         with pytest.raises(ValueError, match="Extension cannot be empty"):
             find_files_by_extension(temp_dir, "")
-
-
-def test_find_files_by_extension_case_8_path_object_input() -> None:
-    """
-    Test case 8: Function works with Path object input.
-    """
-    # Arrange
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_path = Path(temp_dir)
-        (temp_path / "test.py").touch()
-
-        # Act
-        result = find_files_by_extension(temp_path, ".py")
-
-        # Assert
-        assert len(result) == 1
-        assert Path(result[0]).name == "test.py"
 
 
 def test_find_files_by_extension_case_9_file_path_not_directory_error() -> None:

--- a/pytest/unit/file_functions/recursive_search/test_find_files_by_mtime.py
+++ b/pytest/unit/file_functions/recursive_search/test_find_files_by_mtime.py
@@ -130,83 +130,9 @@ def test_find_files_by_mtime_case_4_combined_filters() -> None:
         assert Path(file_path).name == "middle.txt"
 
 
-def test_find_files_by_mtime_case_5_no_criteria_error() -> None:
-    """
-    Test case 5: ValueError when no time criteria specified.
-    """
-    # Arrange
-    with tempfile.TemporaryDirectory() as temp_dir:
-        # Act & Assert
-        with pytest.raises(
-            ValueError, match="At least one time criterion must be specified"
-        ):
-            find_files_by_mtime(temp_dir)
-
-
-def test_find_files_by_mtime_case_6_invalid_directory_error() -> None:
-    """
-    Test case 6: ValueError for non-existent directory.
-    """
-    # Arrange
-    non_existent_dir = "/path/that/does/not/exist"
-    cutoff = datetime.now()
-
-    # Act & Assert
-    with pytest.raises(ValueError, match="Directory does not exist"):
-        find_files_by_mtime(non_existent_dir, newer_than=cutoff)
-
-
-def test_find_files_by_mtime_case_7_invalid_type_errors() -> None:
-    """
-    Test case 7: TypeError for invalid parameter types.
-    """
-    cutoff = datetime.now()
-
-    # Test invalid directory type
-    with pytest.raises(TypeError, match="directory must be a string or Path"):
-        find_files_by_mtime(123, newer_than=cutoff)
-
-    # Test invalid days_old type
-    with pytest.raises(TypeError, match="days_old must be an integer or None"):
-        find_files_by_mtime("/tmp", days_old="not_int")
-
-    # Test invalid newer_than type
-    with pytest.raises(TypeError, match="newer_than must be a datetime or None"):
-        find_files_by_mtime("/tmp", newer_than="not_datetime")
-
-    # Test invalid older_than type
-    with pytest.raises(TypeError, match="older_than must be a datetime or None"):
-        find_files_by_mtime("/tmp", older_than="not_datetime")
-
-
-def test_find_files_by_mtime_case_8_invalid_time_range() -> None:
-    """
-    Test case 8: ValueError for invalid time range.
-    """
-    # Arrange
-    with tempfile.TemporaryDirectory() as temp_dir:
-        newer_than = datetime.now() - timedelta(days=1)
-        older_than = datetime.now() - timedelta(days=2)  # older than newer_than
-
-        # Act & Assert
-        with pytest.raises(ValueError, match="newer_than must be before older_than"):
-            find_files_by_mtime(temp_dir, newer_than=newer_than, older_than=older_than)
-
-
-def test_find_files_by_mtime_case_9_negative_days_old_error() -> None:
-    """
-    Test case 9: ValueError for negative days_old.
-    """
-    # Arrange
-    with tempfile.TemporaryDirectory() as temp_dir:
-        # Act & Assert
-        with pytest.raises(ValueError, match="days_old must be non-negative"):
-            find_files_by_mtime(temp_dir, days_old=-1)
-
-
 def test_find_files_by_mtime_case_10_file_access_error_handling() -> None:
     """
-    Test case 10: Graceful handling of file access errors.
+    Test case 5: Graceful handling of file access errors.
     """
     # Arrange
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -229,3 +155,75 @@ def test_find_files_by_mtime_case_10_file_access_error_handling() -> None:
 
             # Assert - should skip the problematic file
             assert result == []
+def test_find_files_by_mtime_case_5_no_criteria_error() -> None:
+    """
+    Test case 6: ValueError when no time criteria specified.
+    """
+    # Arrange
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Act & Assert
+        with pytest.raises(
+            ValueError, match="At least one time criterion must be specified"
+        ):
+            find_files_by_mtime(temp_dir)
+
+
+def test_find_files_by_mtime_case_6_invalid_directory_error() -> None:
+    """
+    Test case 7: ValueError for non-existent directory.
+    """
+    # Arrange
+    non_existent_dir = "/path/that/does/not/exist"
+    cutoff = datetime.now()
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="Directory does not exist"):
+        find_files_by_mtime(non_existent_dir, newer_than=cutoff)
+
+
+def test_find_files_by_mtime_case_7_invalid_type_errors() -> None:
+    """
+    Test case 8: TypeError for invalid parameter types.
+    """
+    cutoff = datetime.now()
+
+    # Test invalid directory type
+    with pytest.raises(TypeError, match="directory must be a string or Path"):
+        find_files_by_mtime(123, newer_than=cutoff)
+
+    # Test invalid days_old type
+    with pytest.raises(TypeError, match="days_old must be an integer or None"):
+        find_files_by_mtime("/tmp", days_old="not_int")
+
+    # Test invalid newer_than type
+    with pytest.raises(TypeError, match="newer_than must be a datetime or None"):
+        find_files_by_mtime("/tmp", newer_than="not_datetime")
+
+    # Test invalid older_than type
+    with pytest.raises(TypeError, match="older_than must be a datetime or None"):
+        find_files_by_mtime("/tmp", older_than="not_datetime")
+
+
+def test_find_files_by_mtime_case_8_invalid_time_range() -> None:
+    """
+    Test case 9: ValueError for invalid time range.
+    """
+    # Arrange
+    with tempfile.TemporaryDirectory() as temp_dir:
+        newer_than = datetime.now() - timedelta(days=1)
+        older_than = datetime.now() - timedelta(days=2)  # older than newer_than
+
+        # Act & Assert
+        with pytest.raises(ValueError, match="newer_than must be before older_than"):
+            find_files_by_mtime(temp_dir, newer_than=newer_than, older_than=older_than)
+
+
+def test_find_files_by_mtime_case_9_negative_days_old_error() -> None:
+    """
+    Test case 10: ValueError for negative days_old.
+    """
+    # Arrange
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Act & Assert
+        with pytest.raises(ValueError, match="days_old must be non-negative"):
+            find_files_by_mtime(temp_dir, days_old=-1)

--- a/pytest/unit/file_functions/recursive_search/test_find_files_by_pattern.py
+++ b/pytest/unit/file_functions/recursive_search/test_find_files_by_pattern.py
@@ -109,9 +109,26 @@ def test_find_files_by_pattern_case_5_empty_directory() -> None:
         assert result == []
 
 
+def test_find_files_by_pattern_case_9_path_object_input() -> None:
+    """
+    Test case 6: Function works with Path object input.
+    """
+    # Arrange
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        (temp_path / "test.py").touch()
+
+        # Act
+        result = find_files_by_pattern(temp_path, "*.py")
+
+        # Assert
+        assert len(result) == 1
+        assert Path(result[0]).name == "test.py"
+
+
 def test_find_files_by_pattern_case_6_invalid_directory_error() -> None:
     """
-    Test case 6: ValueError for non-existent directory.
+    Test case 7: ValueError for non-existent directory.
     """
     # Arrange
     non_existent_dir = "/path/that/does/not/exist"
@@ -123,7 +140,7 @@ def test_find_files_by_pattern_case_6_invalid_directory_error() -> None:
 
 def test_find_files_by_pattern_case_7_invalid_type_errors() -> None:
     """
-    Test case 7: TypeError for invalid parameter types.
+    Test case 8: TypeError for invalid parameter types.
     """
     # Test invalid directory type
     with pytest.raises(TypeError, match="directory must be a string or Path"):
@@ -140,30 +157,13 @@ def test_find_files_by_pattern_case_7_invalid_type_errors() -> None:
 
 def test_find_files_by_pattern_case_8_empty_pattern_error() -> None:
     """
-    Test case 8: ValueError for empty pattern.
+    Test case 9: ValueError for empty pattern.
     """
     # Arrange
     with tempfile.TemporaryDirectory() as temp_dir:
         # Act & Assert
         with pytest.raises(ValueError, match="Pattern cannot be empty"):
             find_files_by_pattern(temp_dir, "")
-
-
-def test_find_files_by_pattern_case_9_path_object_input() -> None:
-    """
-    Test case 9: Function works with Path object input.
-    """
-    # Arrange
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_path = Path(temp_dir)
-        (temp_path / "test.py").touch()
-
-        # Act
-        result = find_files_by_pattern(temp_path, "*.py")
-
-        # Assert
-        assert len(result) == 1
-        assert Path(result[0]).name == "test.py"
 
 
 def test_find_files_by_pattern_case_10_os_error_handling() -> None:

--- a/pytest/unit/file_functions/recursive_search/test_find_files_by_size.py
+++ b/pytest/unit/file_functions/recursive_search/test_find_files_by_size.py
@@ -115,57 +115,9 @@ def test_find_files_by_size_case_5_recursive_search() -> None:
         assert "file2.txt" in file_names
 
 
-def test_find_files_by_size_case_6_invalid_directory_error() -> None:
-    """
-    Test case 6: ValueError for non-existent directory.
-    """
-    # Arrange
-    non_existent_dir = "/path/that/does/not/exist"
-
-    # Act & Assert
-    with pytest.raises(ValueError, match="Directory does not exist"):
-        find_files_by_size(non_existent_dir)
-
-
-def test_find_files_by_size_case_7_invalid_type_errors() -> None:
-    """
-    Test case 7: TypeError for invalid parameter types.
-    """
-    # Test invalid directory type
-    with pytest.raises(TypeError, match="directory must be a string or Path"):
-        find_files_by_size(123)
-
-    # Test invalid min_size type
-    with pytest.raises(TypeError, match="min_size must be an integer"):
-        find_files_by_size("/tmp", min_size="not_int")
-
-    # Test invalid max_size type
-    with pytest.raises(TypeError, match="max_size must be an integer or None"):
-        find_files_by_size("/tmp", max_size="not_int")
-
-
-def test_find_files_by_size_case_8_invalid_size_values() -> None:
-    """
-    Test case 8: ValueError for invalid size values.
-    """
-    # Arrange
-    with tempfile.TemporaryDirectory() as temp_dir:
-        # Test negative min_size
-        with pytest.raises(ValueError, match="min_size must be non-negative"):
-            find_files_by_size(temp_dir, min_size=-1)
-
-        # Test negative max_size
-        with pytest.raises(ValueError, match="max_size must be non-negative"):
-            find_files_by_size(temp_dir, max_size=-1)
-
-        # Test max_size < min_size
-        with pytest.raises(ValueError, match="max_size .* must be >= min_size"):
-            find_files_by_size(temp_dir, min_size=100, max_size=50)
-
-
 def test_find_files_by_size_case_9_path_object_input() -> None:
     """
-    Test case 9: Function works with Path object input.
+    Test case 6: Function works with Path object input.
     """
     # Arrange
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -184,7 +136,7 @@ def test_find_files_by_size_case_9_path_object_input() -> None:
 
 def test_find_files_by_size_case_10_file_access_error_handling() -> None:
     """
-    Test case 10: Graceful handling of file access errors.
+    Test case 7: Graceful handling of file access errors.
     """
     # Arrange
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -206,3 +158,49 @@ def test_find_files_by_size_case_10_file_access_error_handling() -> None:
 
             # Assert - should skip the problematic file
             assert result == []
+def test_find_files_by_size_case_6_invalid_directory_error() -> None:
+    """
+    Test case 8: ValueError for non-existent directory.
+    """
+    # Arrange
+    non_existent_dir = "/path/that/does/not/exist"
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="Directory does not exist"):
+        find_files_by_size(non_existent_dir)
+
+
+def test_find_files_by_size_case_7_invalid_type_errors() -> None:
+    """
+    Test case 9: TypeError for invalid parameter types.
+    """
+    # Test invalid directory type
+    with pytest.raises(TypeError, match="directory must be a string or Path"):
+        find_files_by_size(123)
+
+    # Test invalid min_size type
+    with pytest.raises(TypeError, match="min_size must be an integer"):
+        find_files_by_size("/tmp", min_size="not_int")
+
+    # Test invalid max_size type
+    with pytest.raises(TypeError, match="max_size must be an integer or None"):
+        find_files_by_size("/tmp", max_size="not_int")
+
+
+def test_find_files_by_size_case_8_invalid_size_values() -> None:
+    """
+    Test case 10: ValueError for invalid size values.
+    """
+    # Arrange
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Test negative min_size
+        with pytest.raises(ValueError, match="min_size must be non-negative"):
+            find_files_by_size(temp_dir, min_size=-1)
+
+        # Test negative max_size
+        with pytest.raises(ValueError, match="max_size must be non-negative"):
+            find_files_by_size(temp_dir, max_size=-1)
+
+        # Test max_size < min_size
+        with pytest.raises(ValueError, match="max_size .* must be >= min_size"):
+            find_files_by_size(temp_dir, min_size=100, max_size=50)

--- a/pytest/unit/file_functions/temp_management/test_create_temp_directory.py
+++ b/pytest/unit/file_functions/temp_management/test_create_temp_directory.py
@@ -125,9 +125,25 @@ def test_create_temp_directory_case_7_path_object_directory() -> None:
             assert Path(temp_dir).exists()
 
 
+def test_create_temp_directory_case_10_cleanup_error_handling() -> None:
+    """
+    Test case 8: Graceful handling of cleanup errors.
+    """
+    temp_dir_holder = []
+
+    # Act
+    with create_temp_directory() as temp_dir:
+        temp_dir_holder.append(temp_dir)
+        assert Path(temp_dir).exists()
+
+        # Manually delete the directory to simulate cleanup error
+        shutil.rmtree(temp_dir)
+
+    # Assert - should not raise error even if directory was already deleted
+    assert not Path(temp_dir_holder[0]).exists()
 def test_create_temp_directory_case_8_invalid_type_errors() -> None:
     """
-    Test case 8: TypeError for invalid parameter types.
+    Test case 9: TypeError for invalid parameter types.
     """
     # Test invalid suffix type
     with pytest.raises(TypeError, match="suffix must be a string"):
@@ -152,7 +168,7 @@ def test_create_temp_directory_case_8_invalid_type_errors() -> None:
 
 def test_create_temp_directory_case_9_directory_creation_error() -> None:
     """
-    Test case 9: OSError handling during directory creation.
+    Test case 10: OSError handling during directory creation.
     """
     # Mock mkdtemp to raise OSError
     with patch("tempfile.mkdtemp", side_effect=OSError("Permission denied")):
@@ -160,21 +176,3 @@ def test_create_temp_directory_case_9_directory_creation_error() -> None:
         with pytest.raises(OSError, match="Error creating temporary directory"):
             with create_temp_directory():
                 pass
-
-
-def test_create_temp_directory_case_10_cleanup_error_handling() -> None:
-    """
-    Test case 10: Graceful handling of cleanup errors.
-    """
-    temp_dir_holder = []
-
-    # Act
-    with create_temp_directory() as temp_dir:
-        temp_dir_holder.append(temp_dir)
-        assert Path(temp_dir).exists()
-
-        # Manually delete the directory to simulate cleanup error
-        shutil.rmtree(temp_dir)
-
-    # Assert - should not raise error even if directory was already deleted
-    assert not Path(temp_dir_holder[0]).exists()

--- a/pytest/unit/file_functions/temp_management/test_create_temp_file.py
+++ b/pytest/unit/file_functions/temp_management/test_create_temp_file.py
@@ -123,9 +123,25 @@ def test_create_temp_file_case_7_path_object_directory() -> None:
             assert Path(temp_path).exists()
 
 
+def test_create_temp_file_case_10_cleanup_error_handling() -> None:
+    """
+    Test case 8: Graceful handling of cleanup errors.
+    """
+    temp_path_holder = []
+
+    # Act
+    with create_temp_file() as temp_path:
+        temp_path_holder.append(temp_path)
+        assert Path(temp_path).exists()
+
+        # Manually delete the file to simulate cleanup error
+        Path(temp_path).unlink()
+
+    # Assert - should not raise error even if file was already deleted
+    assert not Path(temp_path_holder[0]).exists()
 def test_create_temp_file_case_8_invalid_type_errors() -> None:
     """
-    Test case 8: TypeError for invalid parameter types.
+    Test case 9: TypeError for invalid parameter types.
     """
     # Test invalid suffix type
     with pytest.raises(TypeError, match="suffix must be a string"):
@@ -155,7 +171,7 @@ def test_create_temp_file_case_8_invalid_type_errors() -> None:
 
 def test_create_temp_file_case_9_file_creation_error() -> None:
     """
-    Test case 9: OSError handling during file creation.
+    Test case 10: OSError handling during file creation.
     """
     # Mock NamedTemporaryFile to raise OSError
     with patch("tempfile.NamedTemporaryFile", side_effect=OSError("Disk full")):
@@ -163,21 +179,3 @@ def test_create_temp_file_case_9_file_creation_error() -> None:
         with pytest.raises(OSError, match="Error creating temporary file"):
             with create_temp_file():
                 pass
-
-
-def test_create_temp_file_case_10_cleanup_error_handling() -> None:
-    """
-    Test case 10: Graceful handling of cleanup errors.
-    """
-    temp_path_holder = []
-
-    # Act
-    with create_temp_file() as temp_path:
-        temp_path_holder.append(temp_path)
-        assert Path(temp_path).exists()
-
-        # Manually delete the file to simulate cleanup error
-        Path(temp_path).unlink()
-
-    # Assert - should not raise error even if file was already deleted
-    assert not Path(temp_path_holder[0]).exists()

--- a/pytest/unit/file_functions/temp_management/test_get_temp_dir_info.py
+++ b/pytest/unit/file_functions/temp_management/test_get_temp_dir_info.py
@@ -138,9 +138,24 @@ def test_get_temp_dir_info_case_7_non_existent_directory() -> None:
         assert info["total_size_bytes"] == 0
 
 
+def test_get_temp_dir_info_case_9_statvfs_not_available() -> None:
+    """
+    Test case 8: Handle systems where statvfs is not available.
+    """
+    # Arrange
+    with tempfile.TemporaryDirectory() as controlled_temp:
+        with patch("os.statvfs", side_effect=AttributeError("statvfs not available")):
+            with patch("tempfile.gettempdir", return_value=controlled_temp):
+                # Act
+                info = get_temp_dir_info()
+
+                # Assert
+                assert info["available_space_bytes"] == 0
+
+
 def test_get_temp_dir_info_case_8_file_access_error_handling() -> None:
     """
-    Test case 8: Graceful handling of file access errors.
+    Test case 9: Graceful handling of file access errors.
     """
     # Arrange
     with tempfile.TemporaryDirectory() as controlled_temp:
@@ -161,21 +176,6 @@ def test_get_temp_dir_info_case_8_file_access_error_handling() -> None:
                 # Act & Assert
                 with pytest.raises(OSError, match="Error accessing temporary directory: Permission denied"):
                     get_temp_dir_info()
-
-
-def test_get_temp_dir_info_case_9_statvfs_not_available() -> None:
-    """
-    Test case 9: Handle systems where statvfs is not available.
-    """
-    # Arrange
-    with tempfile.TemporaryDirectory() as controlled_temp:
-        with patch("os.statvfs", side_effect=AttributeError("statvfs not available")):
-            with patch("tempfile.gettempdir", return_value=controlled_temp):
-                # Act
-                info = get_temp_dir_info()
-
-                # Assert
-                assert info["available_space_bytes"] == 0
 
 
 def test_get_temp_dir_info_case_10_directory_access_error() -> None:

--- a/pytest/unit/iterable_functions/dictionary_operations/test_deep_get.py
+++ b/pytest/unit/iterable_functions/dictionary_operations/test_deep_get.py
@@ -117,23 +117,9 @@ def test_deep_get_root_level_key() -> None:
     assert result == expected_output
 
 
-def test_deep_get_invalid_type_error() -> None:
-    """
-    Test case 8: TypeError for invalid input type.
-    """
-    # Arrange
-    invalid_input: str = "not a dict"
-    key_path: str = "key"
-    expected_message: str = "d must be a dictionary, got str"
-
-    # Act & Assert
-    with pytest.raises(TypeError, match=expected_message):
-        deep_get(invalid_input, key_path)
-
-
 def test_deep_get_deeply_nested_structure() -> None:
     """
-    Test case 9: Normal operation with deeply nested structure.
+    Test case 8: Normal operation with deeply nested structure.
     """
     # Arrange
     input_data: dict[str, Any] = {"level1": {"level2": {"level3": {"level4": "value"}}}}
@@ -149,7 +135,7 @@ def test_deep_get_deeply_nested_structure() -> None:
 
 def test_deep_get_mixed_data_types() -> None:
     """
-    Test case 10: Normal operation with mixed data types.
+    Test case 9: Normal operation with mixed data types.
     """
     # Arrange
     input_data: dict[str, Any] = {
@@ -173,7 +159,7 @@ def test_deep_get_mixed_data_types() -> None:
 
 def test_deep_get_empty_string_in_path() -> None:
     """
-    Test case 11: Edge case with empty string in path.
+    Test case 10: Edge case with empty string in path.
     """
     # Arrange
     input_data: dict[str, Any] = {"": {"nested": "value"}}
@@ -185,3 +171,15 @@ def test_deep_get_empty_string_in_path() -> None:
 
     # Assert
     assert result == expected_output
+def test_deep_get_invalid_type_error() -> None:
+    """
+    Test case 11: TypeError for invalid input type.
+    """
+    # Arrange
+    invalid_input: str = "not a dict"
+    key_path: str = "key"
+    expected_message: str = "d must be a dictionary, got str"
+
+    # Act & Assert
+    with pytest.raises(TypeError, match=expected_message):
+        deep_get(invalid_input, key_path)

--- a/pytest/unit/iterable_functions/dictionary_operations/test_deep_set.py
+++ b/pytest/unit/iterable_functions/dictionary_operations/test_deep_set.py
@@ -129,24 +129,9 @@ def test_deep_set_mixed_data_types() -> None:
     assert input_data == expected_output
 
 
-def test_deep_set_invalid_type_error() -> None:
-    """
-    Test case 8: TypeError for invalid input type.
-    """
-    # Arrange
-    invalid_input: str = "not a dict"
-    key_path: str = "key"
-    value: str = "value"
-    expected_message: str = "d must be a dictionary, got str"
-
-    # Act & Assert
-    with pytest.raises(TypeError, match=expected_message):
-        deep_set(invalid_input, key_path, value)
-
-
 def test_deep_set_empty_string_in_path() -> None:
     """
-    Test case 9: Edge case with empty string in path.
+    Test case 8: Edge case with empty string in path.
     """
     # Arrange
     input_data: dict[str, Any] = {}
@@ -163,7 +148,7 @@ def test_deep_set_empty_string_in_path() -> None:
 
 def test_deep_set_single_key() -> None:
     """
-    Test case 10: Edge case with single key.
+    Test case 9: Edge case with single key.
     """
     # Arrange
     input_data: dict[str, Any] = {}
@@ -180,7 +165,7 @@ def test_deep_set_single_key() -> None:
 
 def test_deep_set_numeric_keys_in_path() -> None:
     """
-    Test case 11: Normal operation with numeric keys in path.
+    Test case 10: Normal operation with numeric keys in path.
     """
     # Arrange
     input_data: dict[str, Any] = {}
@@ -193,3 +178,16 @@ def test_deep_set_numeric_keys_in_path() -> None:
 
     # Assert
     assert input_data == expected_output
+def test_deep_set_invalid_type_error() -> None:
+    """
+    Test case 11: TypeError for invalid input type.
+    """
+    # Arrange
+    invalid_input: str = "not a dict"
+    key_path: str = "key"
+    value: str = "value"
+    expected_message: str = "d must be a dictionary, got str"
+
+    # Act & Assert
+    with pytest.raises(TypeError, match=expected_message):
+        deep_set(invalid_input, key_path, value)

--- a/pytest/unit/iterable_functions/dictionary_operations/test_dict_structural_difference.py
+++ b/pytest/unit/iterable_functions/dictionary_operations/test_dict_structural_difference.py
@@ -194,23 +194,9 @@ def test_dict_structural_difference_one_empty_dict() -> None:
     assert result == expected_output
 
 
-def test_dict_structural_difference_type_error_invalid_input() -> None:
-    """
-    Test case 10: TypeError for invalid input types.
-    """
-    # Arrange
-    dict1: dict[str, Any] = {"a": 1}
-    invalid_dict2: str = "not a dict"
-    expected_message: str = "Both dict1 and dict2 must be dictionaries"
-
-    # Act & Assert
-    with pytest.raises(TypeError, match=expected_message):
-        dict_structural_difference(dict1, invalid_dict2)
-
-
 def test_dict_structural_difference_complex_nested_structure() -> None:
     """
-    Test case 11: Normal operation with complex nested structure.
+    Test case 10: Normal operation with complex nested structure.
     """
     # Arrange
     dict1: dict[str, Any] = {
@@ -241,7 +227,7 @@ def test_dict_structural_difference_complex_nested_structure() -> None:
 
 def test_dict_structural_difference_no_changes_deeply_nested() -> None:
     """
-    Test case 12: Edge case with no changes in deeply nested structure.
+    Test case 11: Edge case with no changes in deeply nested structure.
     """
     # Arrange
     dict1: dict[str, Any] = {"a": {"b": {"c": 1}}}
@@ -258,3 +244,15 @@ def test_dict_structural_difference_no_changes_deeply_nested() -> None:
 
     # Assert
     assert result == expected_output
+def test_dict_structural_difference_type_error_invalid_input() -> None:
+    """
+    Test case 12: TypeError for invalid input types.
+    """
+    # Arrange
+    dict1: dict[str, Any] = {"a": 1}
+    invalid_dict2: str = "not a dict"
+    expected_message: str = "Both dict1 and dict2 must be dictionaries"
+
+    # Act & Assert
+    with pytest.raises(TypeError, match=expected_message):
+        dict_structural_difference(dict1, invalid_dict2)

--- a/pytest/unit/iterable_functions/dictionary_operations/test_dict_value_difference.py
+++ b/pytest/unit/iterable_functions/dictionary_operations/test_dict_value_difference.py
@@ -111,49 +111,9 @@ def test_dict_value_difference_nested_values() -> None:
     assert result == {"b": {"x": 2}}
 
 
-def test_dict_value_difference_type_error_non_dict_dict1() -> None:
-    """
-    Test case 8: TypeError when dict1 is not a dictionary.
-    """
-    # Arrange
-    invalid_dict1 = "not a dict"
-    dict2 = {"a": 1}
-
-    # Act & Assert
-    with pytest.raises(TypeError, match="dict1 must be a dictionary"):
-        dict_value_difference(invalid_dict1, dict2)  # type: ignore
-
-
-def test_dict_value_difference_type_error_non_dict_dict2() -> None:
-    """
-    Test case 9: TypeError when dict2 is not a dictionary.
-    """
-    # Arrange
-    dict1 = {"a": 1}
-    invalid_dict2 = [1, 2, 3]
-
-    # Act & Assert
-    with pytest.raises(TypeError, match="dict2 must be a dictionary"):
-        dict_value_difference(dict1, invalid_dict2)  # type: ignore
-
-
-def test_dict_value_difference_type_error_non_bool_ignore_missing() -> None:
-    """
-    Test case 10: TypeError when ignore_missing is not a boolean.
-    """
-    # Arrange
-    dict1 = {"a": 1}
-    dict2 = {"b": 2}
-    invalid_ignore = "yes"
-
-    # Act & Assert
-    with pytest.raises(TypeError, match="ignore_missing must be a boolean"):
-        dict_value_difference(dict1, dict2, ignore_missing=invalid_ignore)  # type: ignore
-
-
 def test_dict_value_difference_different_value_types() -> None:
     """
-    Test case 11: Values change types between dictionaries.
+    Test case 8: Values change types between dictionaries.
     """
     # Arrange
     dict1 = {"a": 1, "b": "text", "c": True}
@@ -168,7 +128,7 @@ def test_dict_value_difference_different_value_types() -> None:
 
 def test_dict_value_difference_none_values() -> None:
     """
-    Test case 12: Dictionaries with None values.
+    Test case 9: Dictionaries with None values.
     """
     # Arrange
     dict1 = {"a": 1, "b": None}
@@ -179,3 +139,41 @@ def test_dict_value_difference_none_values() -> None:
 
     # Assert
     assert result == {"a": None}
+def test_dict_value_difference_type_error_non_dict_dict1() -> None:
+    """
+    Test case 10: TypeError when dict1 is not a dictionary.
+    """
+    # Arrange
+    invalid_dict1 = "not a dict"
+    dict2 = {"a": 1}
+
+    # Act & Assert
+    with pytest.raises(TypeError, match="dict1 must be a dictionary"):
+        dict_value_difference(invalid_dict1, dict2)  # type: ignore
+
+
+def test_dict_value_difference_type_error_non_dict_dict2() -> None:
+    """
+    Test case 11: TypeError when dict2 is not a dictionary.
+    """
+    # Arrange
+    dict1 = {"a": 1}
+    invalid_dict2 = [1, 2, 3]
+
+    # Act & Assert
+    with pytest.raises(TypeError, match="dict2 must be a dictionary"):
+        dict_value_difference(dict1, invalid_dict2)  # type: ignore
+
+
+def test_dict_value_difference_type_error_non_bool_ignore_missing() -> None:
+    """
+    Test case 12: TypeError when ignore_missing is not a boolean.
+    """
+    # Arrange
+    dict1 = {"a": 1}
+    dict2 = {"b": 2}
+    invalid_ignore = "yes"
+
+    # Act & Assert
+    with pytest.raises(TypeError, match="ignore_missing must be a boolean"):
+        dict_value_difference(dict1, dict2, ignore_missing=invalid_ignore)  # type: ignore

--- a/pytest/unit/iterable_functions/dictionary_operations/test_filter_dict_by_keys.py
+++ b/pytest/unit/iterable_functions/dictionary_operations/test_filter_dict_by_keys.py
@@ -143,9 +143,23 @@ def test_filter_dict_by_keys_no_keys_no_pattern() -> None:
     assert result == expected_output
 
 
+def test_filter_dict_by_keys_no_modification_original() -> None:
+    """
+    Test case 9: Verify original dictionary is not modified.
+    """
+    # Arrange
+    input_data: dict[str, Any] = {"a": 1, "b": 2, "c": 3}
+    original_data: dict[str, Any] = input_data.copy()
+    filter_keys: list[str] = ["a"]
+
+    # Act
+    filter_dict_by_keys(input_data, filter_keys)
+
+    # Assert
+    assert input_data == original_data
 def test_filter_dict_by_keys_invalid_dict_type_error() -> None:
     """
-    Test case 9: TypeError for invalid dictionary input.
+    Test case 10: TypeError for invalid dictionary input.
     """
     # Arrange
     invalid_input: str = "not a dict"
@@ -159,7 +173,7 @@ def test_filter_dict_by_keys_invalid_dict_type_error() -> None:
 
 def test_filter_dict_by_keys_invalid_keys_type_error() -> None:
     """
-    Test case 10: TypeError for invalid keys type.
+    Test case 11: TypeError for invalid keys type.
     """
     # Arrange
     input_data: dict[str, Any] = {"a": 1, "b": 2}
@@ -169,19 +183,3 @@ def test_filter_dict_by_keys_invalid_keys_type_error() -> None:
     # Act & Assert
     with pytest.raises(TypeError, match=expected_message):
         filter_dict_by_keys(input_data, invalid_keys)
-
-
-def test_filter_dict_by_keys_no_modification_original() -> None:
-    """
-    Test case 11: Verify original dictionary is not modified.
-    """
-    # Arrange
-    input_data: dict[str, Any] = {"a": 1, "b": 2, "c": 3}
-    original_data: dict[str, Any] = input_data.copy()
-    filter_keys: list[str] = ["a"]
-
-    # Act
-    filter_dict_by_keys(input_data, filter_keys)
-
-    # Assert
-    assert input_data == original_data

--- a/pytest/unit/iterable_functions/dictionary_operations/test_flatten_dict.py
+++ b/pytest/unit/iterable_functions/dictionary_operations/test_flatten_dict.py
@@ -119,22 +119,9 @@ def test_flatten_dict_empty_dictionary() -> None:
     assert result == expected_output
 
 
-def test_flatten_dict_invalid_type_error() -> None:
-    """
-    Test case 8: TypeError for invalid input type.
-    """
-    # Arrange
-    invalid_input: str = "not a dict"
-    expected_message: str = "d must be a dictionary, got str"
-
-    # Act & Assert
-    with pytest.raises(TypeError, match=expected_message):
-        flatten_dict(invalid_input)
-
-
 def test_flatten_dict_no_modification_original() -> None:
     """
-    Test case 9: Verify original dictionary is not modified.
+    Test case 8: Verify original dictionary is not modified.
     """
     # Arrange
     input_data: dict[str, Any] = {"a": {"b": 1}}
@@ -149,7 +136,7 @@ def test_flatten_dict_no_modification_original() -> None:
 
 def test_flatten_dict_complex_separator() -> None:
     """
-    Test case 10: Normal operation with complex separator.
+    Test case 9: Normal operation with complex separator.
     """
     # Arrange
     input_data: dict[str, Any] = {"a": {"b": {"c": 1}}}
@@ -160,3 +147,14 @@ def test_flatten_dict_complex_separator() -> None:
 
     # Assert
     assert result == expected_output
+def test_flatten_dict_invalid_type_error() -> None:
+    """
+    Test case 10: TypeError for invalid input type.
+    """
+    # Arrange
+    invalid_input: str = "not a dict"
+    expected_message: str = "d must be a dictionary, got str"
+
+    # Act & Assert
+    with pytest.raises(TypeError, match=expected_message):
+        flatten_dict(invalid_input)

--- a/pytest/unit/iterable_functions/dictionary_operations/test_invert_dict.py
+++ b/pytest/unit/iterable_functions/dictionary_operations/test_invert_dict.py
@@ -34,22 +34,9 @@ def test_invert_dict_allow_duplicates() -> None:
     assert result == expected_output
 
 
-def test_invert_dict_duplicates_not_allowed_error() -> None:
-    """
-    Test case 3: ValueError for duplicate values when not allowed.
-    """
-    # Arrange
-    input_data: dict[str, Any] = {"a": 1, "b": 1}
-    expected_message: str = "Duplicate values found: \\[1\\]"
-
-    # Act & Assert
-    with pytest.raises(ValueError, match=expected_message):
-        invert_dict(input_data, allow_duplicates=False)
-
-
 def test_invert_dict_empty_dictionary() -> None:
     """
-    Test case 4: Edge case with empty dictionary.
+    Test case 3: Edge case with empty dictionary.
     """
     # Arrange
     input_data: dict[str, Any] = {}
@@ -64,7 +51,7 @@ def test_invert_dict_empty_dictionary() -> None:
 
 def test_invert_dict_mixed_value_types() -> None:
     """
-    Test case 5: Normal operation with mixed value types.
+    Test case 4: Normal operation with mixed value types.
     """
     # Arrange
     input_data: dict[str, Any] = {"a": 1, "b": "hello", "c": (1, 2)}
@@ -77,22 +64,9 @@ def test_invert_dict_mixed_value_types() -> None:
     assert result == expected_output
 
 
-def test_invert_dict_invalid_type_error() -> None:
-    """
-    Test case 6: TypeError for invalid input type.
-    """
-    # Arrange
-    invalid_input: str = "not a dict"
-    expected_message: str = "d must be a dictionary, got str"
-
-    # Act & Assert
-    with pytest.raises(TypeError, match=expected_message):
-        invert_dict(invalid_input)
-
-
 def test_invert_dict_multiple_duplicates() -> None:
     """
-    Test case 7: Normal operation with multiple duplicates.
+    Test case 5: Normal operation with multiple duplicates.
     """
     # Arrange
     input_data: dict[str, Any] = {"a": 1, "b": 1, "c": 2, "d": 1}
@@ -107,7 +81,7 @@ def test_invert_dict_multiple_duplicates() -> None:
 
 def test_invert_dict_single_item() -> None:
     """
-    Test case 8: Edge case with single item dictionary.
+    Test case 6: Edge case with single item dictionary.
     """
     # Arrange
     input_data: dict[str, Any] = {"a": 1}
@@ -122,7 +96,7 @@ def test_invert_dict_single_item() -> None:
 
 def test_invert_dict_no_modification_original() -> None:
     """
-    Test case 9: Verify original dictionary is not modified.
+    Test case 7: Verify original dictionary is not modified.
     """
     # Arrange
     input_data: dict[str, Any] = {"a": 1, "b": 2}
@@ -137,7 +111,7 @@ def test_invert_dict_no_modification_original() -> None:
 
 def test_invert_dict_no_duplicates_with_allow_true() -> None:
     """
-    Test case 10: Normal operation with no duplicates but allow_duplicates=True.
+    Test case 8: Normal operation with no duplicates but allow_duplicates=True.
     """
     # Arrange
     input_data: dict[str, Any] = {"a": 1, "b": 2}
@@ -148,3 +122,27 @@ def test_invert_dict_no_duplicates_with_allow_true() -> None:
 
     # Assert
     assert result == expected_output
+def test_invert_dict_duplicates_not_allowed_error() -> None:
+    """
+    Test case 9: ValueError for duplicate values when not allowed.
+    """
+    # Arrange
+    input_data: dict[str, Any] = {"a": 1, "b": 1}
+    expected_message: str = "Duplicate values found: \\[1\\]"
+
+    # Act & Assert
+    with pytest.raises(ValueError, match=expected_message):
+        invert_dict(input_data, allow_duplicates=False)
+
+
+def test_invert_dict_invalid_type_error() -> None:
+    """
+    Test case 10: TypeError for invalid input type.
+    """
+    # Arrange
+    invalid_input: str = "not a dict"
+    expected_message: str = "d must be a dictionary, got str"
+
+    # Act & Assert
+    with pytest.raises(TypeError, match=expected_message):
+        invert_dict(invalid_input)

--- a/pytest/unit/iterable_functions/list_operations/test_chunk_by_size.py
+++ b/pytest/unit/iterable_functions/list_operations/test_chunk_by_size.py
@@ -109,9 +109,22 @@ def test_chunk_by_size_large_chunk_size() -> None:
     assert result == [[1, 2, 3]]
 
 
+def test_chunk_by_size_mixed_types() -> None:
+    """
+    Test case 8: Chunk list with mixed types.
+    """
+    # Arrange
+    items = [1, "two", 3.0, True, None]
+    chunk_size = 2
+
+    # Act
+    result = chunk_by_size(items, chunk_size)
+
+    # Assert
+    assert result == [[1, "two"], [3.0, True], [None]]
 def test_chunk_by_size_type_error_non_list() -> None:
     """
-    Test case 8: TypeError when items is not a list.
+    Test case 9: TypeError when items is not a list.
     """
     # Arrange
     invalid_items = "not a list"
@@ -124,7 +137,7 @@ def test_chunk_by_size_type_error_non_list() -> None:
 
 def test_chunk_by_size_type_error_non_integer_chunk_size() -> None:
     """
-    Test case 9: TypeError when chunk_size is not an integer.
+    Test case 10: TypeError when chunk_size is not an integer.
     """
     # Arrange
     items = [1, 2, 3]
@@ -137,7 +150,7 @@ def test_chunk_by_size_type_error_non_integer_chunk_size() -> None:
 
 def test_chunk_by_size_value_error_zero_chunk_size() -> None:
     """
-    Test case 10: ValueError when chunk_size is 0.
+    Test case 11: ValueError when chunk_size is 0.
     """
     # Arrange
     items = [1, 2, 3]
@@ -150,7 +163,7 @@ def test_chunk_by_size_value_error_zero_chunk_size() -> None:
 
 def test_chunk_by_size_value_error_negative_chunk_size() -> None:
     """
-    Test case 11: ValueError when chunk_size is negative.
+    Test case 12: ValueError when chunk_size is negative.
     """
     # Arrange
     items = [1, 2, 3]
@@ -159,18 +172,3 @@ def test_chunk_by_size_value_error_negative_chunk_size() -> None:
     # Act & Assert
     with pytest.raises(ValueError, match="chunk_size must be positive"):
         chunk_by_size(items, chunk_size)
-
-
-def test_chunk_by_size_mixed_types() -> None:
-    """
-    Test case 12: Chunk list with mixed types.
-    """
-    # Arrange
-    items = [1, "two", 3.0, True, None]
-    chunk_size = 2
-
-    # Act
-    result = chunk_by_size(items, chunk_size)
-
-    # Assert
-    assert result == [[1, "two"], [3.0, True], [None]]

--- a/pytest/unit/iterable_functions/list_operations/test_find_duplicates.py
+++ b/pytest/unit/iterable_functions/list_operations/test_find_duplicates.py
@@ -42,17 +42,9 @@ def test_find_duplicates_strings() -> None:
     assert result == expected
 
 
-def test_find_duplicates_type_error() -> None:
-    """
-    Test case 5: TypeError for non-list input.
-    """
-    with pytest.raises(TypeError, match="items must be a list"):
-        find_duplicates("not a list")
-
-
 def test_find_duplicates_boundary_single_element() -> None:
     """
-    Test case 6: Single element (no duplicates).
+    Test case 5: Single element (no duplicates).
     """
     items = [42]
     expected = {}
@@ -62,7 +54,7 @@ def test_find_duplicates_boundary_single_element() -> None:
 
 def test_find_duplicates_boundary_all_duplicates() -> None:
     """
-    Test case 7: All elements are duplicates.
+    Test case 6: All elements are duplicates.
     """
     items = [1, 1, 1, 1]
     expected = {1: 4}
@@ -72,9 +64,15 @@ def test_find_duplicates_boundary_all_duplicates() -> None:
 
 def test_find_duplicates_large_list() -> None:
     """
-    Test case 8: Performance test with large list.
+    Test case 7: Performance test with large list.
     """
     items = list(range(1000)) + [999] * 5  # 999 appears 6 times total
     result = find_duplicates(items)
     assert 999 in result
     assert result[999] == 6
+def test_find_duplicates_type_error() -> None:
+    """
+    Test case 8: TypeError for non-list input.
+    """
+    with pytest.raises(TypeError, match="items must be a list"):
+        find_duplicates("not a list")

--- a/pytest/unit/iterable_functions/list_operations/test_group_by.py
+++ b/pytest/unit/iterable_functions/list_operations/test_group_by.py
@@ -166,40 +166,9 @@ def test_group_by_complex_objects() -> None:
     assert all(p.age == 30 for p in result[30])
 
 
-def test_group_by_invalid_items_type_error() -> None:
-    """
-    Test case 9: TypeError for invalid items type.
-    """
-    # Arrange
-    invalid_items: str = "not a list"
-
-    def key_function(x):
-        return x
-
-    expected_message: str = "items must be a list, got str"
-
-    # Act & Assert
-    with pytest.raises(TypeError, match=expected_message):
-        group_by(invalid_items, key_function)  # type: ignore
-
-
-def test_group_by_invalid_key_func_type_error() -> None:
-    """
-    Test case 10: TypeError for invalid key_func type.
-    """
-    # Arrange
-    input_items: list[str] = ["a", "b", "c"]
-    invalid_key_func: str = "not callable"
-    expected_message: str = "key_func must be callable or None, got str"
-
-    # Act & Assert
-    with pytest.raises(TypeError, match=expected_message):
-        group_by(input_items, invalid_key_func)  # type: ignore
-
-
 def test_group_by_preserves_order() -> None:
     """
-    Test case 11: Preserve original order within groups.
+    Test case 9: Preserve original order within groups.
     """
     # Arrange
     input_items: list[str] = ["first", "second", "third", "fourth", "fifth"]
@@ -221,7 +190,7 @@ def test_group_by_preserves_order() -> None:
 
 def test_group_by_none_values() -> None:
     """
-    Test case 12: Group None values.
+    Test case 10: Group None values.
     """
     # Arrange
     input_items: list[Any] = [None, "a", None, "b"]
@@ -236,3 +205,32 @@ def test_group_by_none_values() -> None:
 
     # Assert
     assert result == expected_output
+def test_group_by_invalid_items_type_error() -> None:
+    """
+    Test case 11: TypeError for invalid items type.
+    """
+    # Arrange
+    invalid_items: str = "not a list"
+
+    def key_function(x):
+        return x
+
+    expected_message: str = "items must be a list, got str"
+
+    # Act & Assert
+    with pytest.raises(TypeError, match=expected_message):
+        group_by(invalid_items, key_function)  # type: ignore
+
+
+def test_group_by_invalid_key_func_type_error() -> None:
+    """
+    Test case 12: TypeError for invalid key_func type.
+    """
+    # Arrange
+    input_items: list[str] = ["a", "b", "c"]
+    invalid_key_func: str = "not callable"
+    expected_message: str = "key_func must be callable or None, got str"
+
+    # Act & Assert
+    with pytest.raises(TypeError, match=expected_message):
+        group_by(input_items, invalid_key_func)  # type: ignore

--- a/pytest/unit/iterable_functions/list_operations/test_sliding_window.py
+++ b/pytest/unit/iterable_functions/list_operations/test_sliding_window.py
@@ -42,41 +42,9 @@ def test_sliding_window_empty_list() -> None:
     assert result == expected
 
 
-def test_sliding_window_type_error_items() -> None:
-    """
-    Test case 5: TypeError for non-list items.
-    """
-    with pytest.raises(TypeError, match="items must be a list"):
-        list(sliding_window("not a list", 2))
-
-
-def test_sliding_window_type_error_window_size() -> None:
-    """
-    Test case 6: TypeError for non-int window_size.
-    """
-    with pytest.raises(TypeError, match="window_size must be an int"):
-        list(sliding_window([1, 2, 3], "not an int"))
-
-
-def test_sliding_window_value_error_window_size_zero() -> None:
-    """
-    Test case 7: ValueError for window_size 0.
-    """
-    with pytest.raises(ValueError, match="window_size must be at least 1"):
-        list(sliding_window([1, 2, 3], 0))
-
-
-def test_sliding_window_value_error_negative_window_size() -> None:
-    """
-    Test case 8: ValueError for negative window_size.
-    """
-    with pytest.raises(ValueError, match="window_size must be at least 1"):
-        list(sliding_window([1, 2, 3], -1))
-
-
 def test_sliding_window_boundary_window_larger_than_list() -> None:
     """
-    Test case 9: Window size larger than list.
+    Test case 5: Window size larger than list.
     """
     items = [1, 2]
     result = list(sliding_window(items, 5))
@@ -86,10 +54,40 @@ def test_sliding_window_boundary_window_larger_than_list() -> None:
 
 def test_sliding_window_large_list() -> None:
     """
-    Test case 10: Performance test with large list.
+    Test case 6: Performance test with large list.
     """
     items = list(range(1000))
     result = list(sliding_window(items, 10))
     assert len(result) == 991  # 1000 - 10 + 1
     assert result[0] == list(range(10))
     assert result[-1] == list(range(990, 1000))
+def test_sliding_window_type_error_items() -> None:
+    """
+    Test case 7: TypeError for non-list items.
+    """
+    with pytest.raises(TypeError, match="items must be a list"):
+        list(sliding_window("not a list", 2))
+
+
+def test_sliding_window_type_error_window_size() -> None:
+    """
+    Test case 8: TypeError for non-int window_size.
+    """
+    with pytest.raises(TypeError, match="window_size must be an int"):
+        list(sliding_window([1, 2, 3], "not an int"))
+
+
+def test_sliding_window_value_error_window_size_zero() -> None:
+    """
+    Test case 9: ValueError for window_size 0.
+    """
+    with pytest.raises(ValueError, match="window_size must be at least 1"):
+        list(sliding_window([1, 2, 3], 0))
+
+
+def test_sliding_window_value_error_negative_window_size() -> None:
+    """
+    Test case 10: ValueError for negative window_size.
+    """
+    with pytest.raises(ValueError, match="window_size must be at least 1"):
+        list(sliding_window([1, 2, 3], -1))

--- a/pytest/unit/iterable_functions/set_operations/test_count_combinations.py
+++ b/pytest/unit/iterable_functions/set_operations/test_count_combinations.py
@@ -79,9 +79,19 @@ def test_count_combinations_large_set() -> None:
     assert result == expected
 
 
+def test_count_combinations_boundary_values() -> None:
+    """
+    Test case 8: Test boundary values.
+    """
+    # Test C(4,1) = 4
+    assert count_combinations({1, 2, 3, 4}, 1) == 4
+    # Test C(4,4) = 1
+    assert count_combinations({1, 2, 3, 4}, 4) == 1
+    # Test C(4,0) = 1
+    assert count_combinations({1, 2, 3, 4}, 0) == 1
 def test_count_combinations_type_error_input_set() -> None:
     """
-    Test case 8: TypeError for invalid input_set type.
+    Test case 9: TypeError for invalid input_set type.
     """
     with pytest.raises(TypeError, match="input_set must be a set"):
         count_combinations("not a set", 2)
@@ -89,7 +99,7 @@ def test_count_combinations_type_error_input_set() -> None:
 
 def test_count_combinations_type_error_r() -> None:
     """
-    Test case 9: TypeError for invalid r type.
+    Test case 10: TypeError for invalid r type.
     """
     input_set = {1, 2, 3}
     with pytest.raises(TypeError, match="r must be an int"):
@@ -98,7 +108,7 @@ def test_count_combinations_type_error_r() -> None:
 
 def test_count_combinations_value_error_negative_r() -> None:
     """
-    Test case 10: ValueError for negative r.
+    Test case 11: ValueError for negative r.
     """
     input_set = {1, 2, 3}
     with pytest.raises(ValueError, match="r must be non-negative"):
@@ -107,20 +117,8 @@ def test_count_combinations_value_error_negative_r() -> None:
 
 def test_count_combinations_value_error_r_too_large() -> None:
     """
-    Test case 11: ValueError for r larger than set size.
+    Test case 12: ValueError for r larger than set size.
     """
     input_set = {1, 2, 3}
     with pytest.raises(ValueError, match="r cannot be larger than set size 3"):
         count_combinations(input_set, 4)
-
-
-def test_count_combinations_boundary_values() -> None:
-    """
-    Test case 12: Test boundary values.
-    """
-    # Test C(4,1) = 4
-    assert count_combinations({1, 2, 3, 4}, 1) == 4
-    # Test C(4,4) = 1
-    assert count_combinations({1, 2, 3, 4}, 4) == 1
-    # Test C(4,0) = 1
-    assert count_combinations({1, 2, 3, 4}, 0) == 1

--- a/pytest/unit/iterable_functions/set_operations/test_get_combinations.py
+++ b/pytest/unit/iterable_functions/set_operations/test_get_combinations.py
@@ -46,19 +46,9 @@ def test_get_combinations_r_equals_n() -> None:
     assert result == expected
 
 
-def test_get_combinations_empty_set() -> None:
-    """
-    Test case 5: Test with empty set.
-    """
-    input_set = set()
-    r = 2
-    with pytest.raises(ValueError, match="r cannot be larger than set size 0"):
-        get_combinations(input_set, r)
-
-
 def test_get_combinations_single_element() -> None:
     """
-    Test case 6: Test with single element set.
+    Test case 5: Test with single element set.
     """
     input_set = {1}
     r = 1
@@ -69,7 +59,7 @@ def test_get_combinations_single_element() -> None:
 
 def test_get_combinations_strings() -> None:
     """
-    Test case 7: Test with string elements.
+    Test case 6: Test with string elements.
     """
     input_set = {"a", "b", "c"}
     r = 2
@@ -78,44 +68,9 @@ def test_get_combinations_strings() -> None:
     assert result == expected
 
 
-def test_get_combinations_type_error_input_set() -> None:
-    """
-    Test case 8: TypeError for invalid input_set type.
-    """
-    with pytest.raises(TypeError, match="input_set must be a set"):
-        get_combinations("not a set", 2)
-
-
-def test_get_combinations_type_error_r() -> None:
-    """
-    Test case 9: TypeError for invalid r type.
-    """
-    input_set = {1, 2, 3}
-    with pytest.raises(TypeError, match="r must be an int"):
-        get_combinations(input_set, "not an int")
-
-
-def test_get_combinations_value_error_negative_r() -> None:
-    """
-    Test case 10: ValueError for negative r.
-    """
-    input_set = {1, 2, 3}
-    with pytest.raises(ValueError, match="r must be non-negative"):
-        get_combinations(input_set, -1)
-
-
-def test_get_combinations_value_error_r_too_large() -> None:
-    """
-    Test case 11: ValueError for r larger than set size.
-    """
-    input_set = {1, 2, 3}
-    with pytest.raises(ValueError, match="r cannot be larger than set size 3"):
-        get_combinations(input_set, 4)
-
-
 def test_get_combinations_boundary_r_equals_1() -> None:
     """
-    Test case 12: Boundary test with r=1.
+    Test case 7: Boundary test with r=1.
     """
     input_set = {1, 2, 3}
     r = 1
@@ -126,7 +81,7 @@ def test_get_combinations_boundary_r_equals_1() -> None:
 
 def test_get_combinations_large_set() -> None:
     """
-    Test case 13: Performance test with larger set.
+    Test case 8: Performance test with larger set.
     """
     input_set = set(range(10))
     r = 3
@@ -135,3 +90,46 @@ def test_get_combinations_large_set() -> None:
     assert len(result) == 120
     # Each combination should have exactly 3 elements
     assert all(len(comb) == 3 for comb in result)
+def test_get_combinations_empty_set() -> None:
+    """
+    Test case 9: Test with empty set.
+    """
+    input_set = set()
+    r = 2
+    with pytest.raises(ValueError, match="r cannot be larger than set size 0"):
+        get_combinations(input_set, r)
+
+
+def test_get_combinations_type_error_input_set() -> None:
+    """
+    Test case 10: TypeError for invalid input_set type.
+    """
+    with pytest.raises(TypeError, match="input_set must be a set"):
+        get_combinations("not a set", 2)
+
+
+def test_get_combinations_type_error_r() -> None:
+    """
+    Test case 11: TypeError for invalid r type.
+    """
+    input_set = {1, 2, 3}
+    with pytest.raises(TypeError, match="r must be an int"):
+        get_combinations(input_set, "not an int")
+
+
+def test_get_combinations_value_error_negative_r() -> None:
+    """
+    Test case 12: ValueError for negative r.
+    """
+    input_set = {1, 2, 3}
+    with pytest.raises(ValueError, match="r must be non-negative"):
+        get_combinations(input_set, -1)
+
+
+def test_get_combinations_value_error_r_too_large() -> None:
+    """
+    Test case 13: ValueError for r larger than set size.
+    """
+    input_set = {1, 2, 3}
+    with pytest.raises(ValueError, match="r cannot be larger than set size 3"):
+        get_combinations(input_set, 4)

--- a/pytest/unit/iterable_functions/set_operations/test_get_combinations_with_replacement.py
+++ b/pytest/unit/iterable_functions/set_operations/test_get_combinations_with_replacement.py
@@ -70,35 +70,9 @@ def test_get_combinations_with_replacement_strings() -> None:
     assert result == expected
 
 
-def test_get_combinations_with_replacement_type_error_input_set() -> None:
-    """
-    Test case 7: TypeError for invalid input_set type.
-    """
-    with pytest.raises(TypeError, match="input_set must be a set"):
-        get_combinations_with_replacement("not a set", 2)
-
-
-def test_get_combinations_with_replacement_type_error_r() -> None:
-    """
-    Test case 8: TypeError for invalid r type.
-    """
-    input_set = {1, 2, 3}
-    with pytest.raises(TypeError, match="r must be an int"):
-        get_combinations_with_replacement(input_set, "not an int")
-
-
-def test_get_combinations_with_replacement_value_error_negative_r() -> None:
-    """
-    Test case 9: ValueError for negative r.
-    """
-    input_set = {1, 2, 3}
-    with pytest.raises(ValueError, match="r must be non-negative"):
-        get_combinations_with_replacement(input_set, -1)
-
-
 def test_get_combinations_with_replacement_boundary_r_equals_1() -> None:
     """
-    Test case 10: Boundary test with r=1.
+    Test case 7: Boundary test with r=1.
     """
     input_set = {1, 2, 3}
     r = 1
@@ -109,7 +83,7 @@ def test_get_combinations_with_replacement_boundary_r_equals_1() -> None:
 
 def test_get_combinations_with_replacement_large_set() -> None:
     """
-    Test case 11: Test with larger set.
+    Test case 8: Test with larger set.
     """
     input_set = {1, 2, 3, 4}
     r = 2
@@ -118,3 +92,27 @@ def test_get_combinations_with_replacement_large_set() -> None:
     assert len(result) == 10
     # Each combination should have exactly 2 elements
     assert all(len(comb) == 2 for comb in result)
+def test_get_combinations_with_replacement_type_error_input_set() -> None:
+    """
+    Test case 9: TypeError for invalid input_set type.
+    """
+    with pytest.raises(TypeError, match="input_set must be a set"):
+        get_combinations_with_replacement("not a set", 2)
+
+
+def test_get_combinations_with_replacement_type_error_r() -> None:
+    """
+    Test case 10: TypeError for invalid r type.
+    """
+    input_set = {1, 2, 3}
+    with pytest.raises(TypeError, match="r must be an int"):
+        get_combinations_with_replacement(input_set, "not an int")
+
+
+def test_get_combinations_with_replacement_value_error_negative_r() -> None:
+    """
+    Test case 11: ValueError for negative r.
+    """
+    input_set = {1, 2, 3}
+    with pytest.raises(ValueError, match="r must be non-negative"):
+        get_combinations_with_replacement(input_set, -1)

--- a/pytest/unit/iterable_functions/set_operations/test_get_permutations.py
+++ b/pytest/unit/iterable_functions/set_operations/test_get_permutations.py
@@ -34,19 +34,9 @@ def test_get_permutations_r_equals_0() -> None:
     assert result == expected
 
 
-def test_get_permutations_empty_set() -> None:
-    """
-    Test case 4: Test with empty set.
-    """
-    input_set = set()
-    r = 2
-    with pytest.raises(ValueError, match="r cannot be larger than set size"):
-        get_permutations(input_set, r)
-
-
 def test_get_permutations_single_element() -> None:
     """
-    Test case 5: Test with single element set.
+    Test case 4: Test with single element set.
     """
     input_set = {1}
     r = 1
@@ -57,7 +47,7 @@ def test_get_permutations_single_element() -> None:
 
 def test_get_permutations_strings() -> None:
     """
-    Test case 6: Test with string elements.
+    Test case 5: Test with string elements.
     """
     input_set = {"a", "b"}
     r = 2
@@ -66,44 +56,9 @@ def test_get_permutations_strings() -> None:
     assert result == expected
 
 
-def test_get_permutations_type_error_input_set() -> None:
-    """
-    Test case 7: TypeError for invalid input_set type.
-    """
-    with pytest.raises(TypeError, match="input_set must be a set"):
-        get_permutations("not a set", 2)
-
-
-def test_get_permutations_type_error_r() -> None:
-    """
-    Test case 8: TypeError for invalid r type.
-    """
-    input_set = {1, 2, 3}
-    with pytest.raises(TypeError, match="r must be an int or None"):
-        get_permutations(input_set, "not an int")
-
-
-def test_get_permutations_value_error_negative_r() -> None:
-    """
-    Test case 9: ValueError for negative r.
-    """
-    input_set = {1, 2, 3}
-    with pytest.raises(ValueError, match="r must be non-negative"):
-        get_permutations(input_set, -1)
-
-
-def test_get_permutations_value_error_r_too_large() -> None:
-    """
-    Test case 10: ValueError for r larger than set size.
-    """
-    input_set = {1, 2, 3}
-    with pytest.raises(ValueError, match="r cannot be larger than set size 3"):
-        get_permutations(input_set, 4)
-
-
 def test_get_permutations_boundary_r_equals_1() -> None:
     """
-    Test case 11: Boundary test with r=1.
+    Test case 6: Boundary test with r=1.
     """
     input_set = {1, 2, 3}
     r = 1
@@ -114,7 +69,7 @@ def test_get_permutations_boundary_r_equals_1() -> None:
 
 def test_get_permutations_large_set() -> None:
     """
-    Test case 12: Test with larger set.
+    Test case 7: Test with larger set.
     """
     input_set = {1, 2, 3, 4}
     r = 2
@@ -123,3 +78,46 @@ def test_get_permutations_large_set() -> None:
     assert len(result) == 12
     # Each permutation should have exactly 2 elements
     assert all(len(perm) == 2 for perm in result)
+def test_get_permutations_empty_set() -> None:
+    """
+    Test case 8: Test with empty set.
+    """
+    input_set = set()
+    r = 2
+    with pytest.raises(ValueError, match="r cannot be larger than set size"):
+        get_permutations(input_set, r)
+
+
+def test_get_permutations_type_error_input_set() -> None:
+    """
+    Test case 9: TypeError for invalid input_set type.
+    """
+    with pytest.raises(TypeError, match="input_set must be a set"):
+        get_permutations("not a set", 2)
+
+
+def test_get_permutations_type_error_r() -> None:
+    """
+    Test case 10: TypeError for invalid r type.
+    """
+    input_set = {1, 2, 3}
+    with pytest.raises(TypeError, match="r must be an int or None"):
+        get_permutations(input_set, "not an int")
+
+
+def test_get_permutations_value_error_negative_r() -> None:
+    """
+    Test case 11: ValueError for negative r.
+    """
+    input_set = {1, 2, 3}
+    with pytest.raises(ValueError, match="r must be non-negative"):
+        get_permutations(input_set, -1)
+
+
+def test_get_permutations_value_error_r_too_large() -> None:
+    """
+    Test case 12: ValueError for r larger than set size.
+    """
+    input_set = {1, 2, 3}
+    with pytest.raises(ValueError, match="r cannot be larger than set size 3"):
+        get_permutations(input_set, 4)

--- a/pytest/unit/iterable_functions/set_operations/test_get_set_partitions.py
+++ b/pytest/unit/iterable_functions/set_operations/test_get_set_partitions.py
@@ -67,19 +67,9 @@ def test_get_set_partitions_single_element() -> None:
     assert result[0] == [{1}]
 
 
-def test_get_set_partitions_empty_set() -> None:
-    """
-    Test case 5: Partition empty set.
-    """
-    input_set = set()
-    k = 1
-    with pytest.raises(ValueError, match="k cannot be greater than set size 0"):
-        get_set_partitions(input_set, k)
-
-
 def test_get_set_partitions_strings() -> None:
     """
-    Test case 6: Partition set with string elements.
+    Test case 5: Partition set with string elements.
     """
     input_set = {"a", "b"}
     k = 2
@@ -94,53 +84,9 @@ def test_get_set_partitions_strings() -> None:
         assert union == input_set
 
 
-def test_get_set_partitions_type_error_input_set() -> None:
-    """
-    Test case 7: TypeError for invalid input_set type.
-    """
-    with pytest.raises(TypeError, match="input_set must be a set"):
-        get_set_partitions("not a set", 2)
-
-
-def test_get_set_partitions_type_error_k() -> None:
-    """
-    Test case 8: TypeError for invalid k type.
-    """
-    input_set = {1, 2, 3}
-    with pytest.raises(TypeError, match="k must be an int"):
-        get_set_partitions(input_set, "not an int")
-
-
-def test_get_set_partitions_value_error_k_zero() -> None:
-    """
-    Test case 9: ValueError for k=0.
-    """
-    input_set = {1, 2, 3}
-    with pytest.raises(ValueError, match="k must be at least 1"):
-        get_set_partitions(input_set, 0)
-
-
-def test_get_set_partitions_value_error_k_negative() -> None:
-    """
-    Test case 10: ValueError for negative k.
-    """
-    input_set = {1, 2, 3}
-    with pytest.raises(ValueError, match="k must be at least 1"):
-        get_set_partitions(input_set, -1)
-
-
-def test_get_set_partitions_value_error_k_too_large() -> None:
-    """
-    Test case 11: ValueError for k larger than set size.
-    """
-    input_set = {1, 2, 3}
-    with pytest.raises(ValueError, match="k cannot be greater than set size 3"):
-        get_set_partitions(input_set, 4)
-
-
 def test_get_set_partitions_no_duplicates() -> None:
     """
-    Test case 12: Ensure no duplicate partitions are returned.
+    Test case 6: Ensure no duplicate partitions are returned.
     """
     input_set = {1, 2, 3, 4}
     k = 2
@@ -151,3 +97,55 @@ def test_get_set_partitions_no_duplicates() -> None:
         partition_hash = frozenset(frozenset(s) for s in partition)
         assert partition_hash not in unique_check
         unique_check.add(partition_hash)
+def test_get_set_partitions_empty_set() -> None:
+    """
+    Test case 7: Partition empty set.
+    """
+    input_set = set()
+    k = 1
+    with pytest.raises(ValueError, match="k cannot be greater than set size 0"):
+        get_set_partitions(input_set, k)
+
+
+def test_get_set_partitions_type_error_input_set() -> None:
+    """
+    Test case 8: TypeError for invalid input_set type.
+    """
+    with pytest.raises(TypeError, match="input_set must be a set"):
+        get_set_partitions("not a set", 2)
+
+
+def test_get_set_partitions_type_error_k() -> None:
+    """
+    Test case 9: TypeError for invalid k type.
+    """
+    input_set = {1, 2, 3}
+    with pytest.raises(TypeError, match="k must be an int"):
+        get_set_partitions(input_set, "not an int")
+
+
+def test_get_set_partitions_value_error_k_zero() -> None:
+    """
+    Test case 10: ValueError for k=0.
+    """
+    input_set = {1, 2, 3}
+    with pytest.raises(ValueError, match="k must be at least 1"):
+        get_set_partitions(input_set, 0)
+
+
+def test_get_set_partitions_value_error_k_negative() -> None:
+    """
+    Test case 11: ValueError for negative k.
+    """
+    input_set = {1, 2, 3}
+    with pytest.raises(ValueError, match="k must be at least 1"):
+        get_set_partitions(input_set, -1)
+
+
+def test_get_set_partitions_value_error_k_too_large() -> None:
+    """
+    Test case 12: ValueError for k larger than set size.
+    """
+    input_set = {1, 2, 3}
+    with pytest.raises(ValueError, match="k cannot be greater than set size 3"):
+        get_set_partitions(input_set, 4)

--- a/pytest/unit/iterable_functions/set_operations/test_get_subsets_of_size.py
+++ b/pytest/unit/iterable_functions/set_operations/test_get_subsets_of_size.py
@@ -91,9 +91,18 @@ def test_get_subsets_of_size_mixed_types() -> None:
     assert all(len(subset) == 2 for subset in result)
 
 
+def test_get_subsets_of_size_boundary_size_1() -> None:
+    """
+    Test case 9: Boundary test with size=1.
+    """
+    input_set = {1, 2, 3}
+    size = 1
+    result = get_subsets_of_size(input_set, size)
+    expected = [[1], [2], [3]]
+    assert result == expected
 def test_get_subsets_of_size_type_error_input_set() -> None:
     """
-    Test case 9: TypeError for invalid input_set type.
+    Test case 10: TypeError for invalid input_set type.
     """
     with pytest.raises(TypeError, match="input_set must be a set"):
         get_subsets_of_size("not a set", 2)
@@ -101,7 +110,7 @@ def test_get_subsets_of_size_type_error_input_set() -> None:
 
 def test_get_subsets_of_size_type_error_size() -> None:
     """
-    Test case 10: TypeError for invalid size type.
+    Test case 11: TypeError for invalid size type.
     """
     input_set = {1, 2, 3}
     with pytest.raises(TypeError, match="size must be an int"):
@@ -110,7 +119,7 @@ def test_get_subsets_of_size_type_error_size() -> None:
 
 def test_get_subsets_of_size_value_error_negative_size() -> None:
     """
-    Test case 11: ValueError for negative size.
+    Test case 12: ValueError for negative size.
     """
     input_set = {1, 2, 3}
     with pytest.raises(ValueError, match="size must be non-negative"):
@@ -119,19 +128,8 @@ def test_get_subsets_of_size_value_error_negative_size() -> None:
 
 def test_get_subsets_of_size_value_error_size_too_large() -> None:
     """
-    Test case 12: ValueError for size larger than set size.
+    Test case 13: ValueError for size larger than set size.
     """
     input_set = {1, 2, 3}
     with pytest.raises(ValueError, match="size cannot be larger than set size 3"):
         get_subsets_of_size(input_set, 4)
-
-
-def test_get_subsets_of_size_boundary_size_1() -> None:
-    """
-    Test case 13: Boundary test with size=1.
-    """
-    input_set = {1, 2, 3}
-    size = 1
-    result = get_subsets_of_size(input_set, size)
-    expected = [[1], [2], [3]]
-    assert result == expected

--- a/pytest/unit/iterable_functions/set_operations/test_get_unique_elements_across_sets.py
+++ b/pytest/unit/iterable_functions/set_operations/test_get_unique_elements_across_sets.py
@@ -76,25 +76,9 @@ def test_get_unique_elements_across_sets_mixed_types() -> None:
     assert set(result) == set(expected)
 
 
-def test_get_unique_elements_across_sets_type_error() -> None:
-    """
-    Test case 7: TypeError for non-set arguments.
-    """
-    with pytest.raises(TypeError, match="All arguments must be sets"):
-        get_unique_elements_across_sets({1, 2}, "not a set")
-
-
-def test_get_unique_elements_across_sets_value_error() -> None:
-    """
-    Test case 8: ValueError for fewer than 2 sets.
-    """
-    with pytest.raises(ValueError, match="At least 2 sets must be provided"):
-        get_unique_elements_across_sets({1, 2})
-
-
 def test_set_symmetric_difference_two_sets() -> None:
     """
-    Test case 9: Symmetric difference of two sets.
+    Test case 7: Symmetric difference of two sets.
     """
     set1 = {1, 2, 3}
     set2 = {2, 3, 4}
@@ -105,7 +89,7 @@ def test_set_symmetric_difference_two_sets() -> None:
 
 def test_set_symmetric_difference_three_sets() -> None:
     """
-    Test case 10: Symmetric difference of three sets.
+    Test case 8: Symmetric difference of three sets.
     """
     set1 = {1, 2, 3}
     set2 = {2, 3, 4}
@@ -117,7 +101,7 @@ def test_set_symmetric_difference_three_sets() -> None:
 
 def test_set_symmetric_difference_identical_sets() -> None:
     """
-    Test case 11: Symmetric difference of identical sets.
+    Test case 9: Symmetric difference of identical sets.
     """
     set1 = {1, 2, 3}
     set2 = {1, 2, 3}
@@ -129,12 +113,28 @@ def test_set_symmetric_difference_identical_sets() -> None:
 
 def test_set_symmetric_difference_empty_sets() -> None:
     """
-    Test case 12: Symmetric difference including empty sets.
+    Test case 10: Symmetric difference including empty sets.
     """
     set1 = {1, 2, 3}
     set2 = set()
     result = set_symmetric_difference(set1, set2)
     assert result == {1, 2, 3}
+
+
+def test_get_unique_elements_across_sets_type_error() -> None:
+    """
+    Test case 11: TypeError for non-set arguments.
+    """
+    with pytest.raises(TypeError, match="All arguments must be sets"):
+        get_unique_elements_across_sets({1, 2}, "not a set")
+
+
+def test_get_unique_elements_across_sets_value_error() -> None:
+    """
+    Test case 12: ValueError for fewer than 2 sets.
+    """
+    with pytest.raises(ValueError, match="At least 2 sets must be provided"):
+        get_unique_elements_across_sets({1, 2})
 
 
 def test_set_symmetric_difference_type_error() -> None:

--- a/pytest/unit/iterable_functions/set_operations/test_partition_set_by_sizes.py
+++ b/pytest/unit/iterable_functions/set_operations/test_partition_set_by_sizes.py
@@ -48,57 +48,9 @@ def test_partition_set_by_sizes_single_partition() -> None:
     assert result[0] == input_set
 
 
-def test_partition_set_by_sizes_type_error_input_set() -> None:
-    """
-    Test case 4: TypeError for non-set input_set.
-    """
-    with pytest.raises(TypeError, match="input_set must be a set"):
-        partition_set_by_sizes([1, 2, 3], [2, 1])
-
-
-def test_partition_set_by_sizes_type_error_sizes() -> None:
-    """
-    Test case 5: TypeError for non-list sizes.
-    """
-    with pytest.raises(TypeError, match="sizes must be a list"):
-        partition_set_by_sizes({1, 2, 3}, "not a list")
-
-
-def test_partition_set_by_sizes_type_error_sizes_elements() -> None:
-    """
-    Test case 6: TypeError for non-int sizes elements.
-    """
-    with pytest.raises(TypeError, match="All sizes must be integers"):
-        partition_set_by_sizes({1, 2, 3}, [2, "not int"])
-
-
-def test_partition_set_by_sizes_value_error_negative_size() -> None:
-    """
-    Test case 7: ValueError for negative size.
-    """
-    with pytest.raises(ValueError, match="All sizes must be positive"):
-        partition_set_by_sizes({1, 2, 3}, [2, -1])
-
-
-def test_partition_set_by_sizes_value_error_zero_size() -> None:
-    """
-    Test case 8: ValueError for zero size.
-    """
-    with pytest.raises(ValueError, match="All sizes must be positive"):
-        partition_set_by_sizes({1, 2, 3}, [2, 0])
-
-
-def test_partition_set_by_sizes_value_error_wrong_sum() -> None:
-    """
-    Test case 9: ValueError for sizes sum not equal to set size.
-    """
-    with pytest.raises(ValueError, match="Sum of sizes .* must equal set size"):
-        partition_set_by_sizes({1, 2, 3}, [2, 3])
-
-
 def test_partition_set_by_sizes_boundary_empty_set() -> None:
     """
-    Test case 10: Empty set with empty sizes.
+    Test case 4: Empty set with empty sizes.
     """
     input_set = set()
     sizes = []
@@ -108,7 +60,7 @@ def test_partition_set_by_sizes_boundary_empty_set() -> None:
 
 def test_partition_set_by_sizes_large_set() -> None:
     """
-    Test case 11: Performance test with large set.
+    Test case 5: Performance test with large set.
     """
     input_set = set(range(1000))
     sizes = [300, 400, 300]
@@ -118,3 +70,49 @@ def test_partition_set_by_sizes_large_set() -> None:
     assert len(result[0]) == 300
     assert len(result[1]) == 400
     assert len(result[2]) == 300
+def test_partition_set_by_sizes_type_error_input_set() -> None:
+    """
+    Test case 6: TypeError for non-set input_set.
+    """
+    with pytest.raises(TypeError, match="input_set must be a set"):
+        partition_set_by_sizes([1, 2, 3], [2, 1])
+
+
+def test_partition_set_by_sizes_type_error_sizes() -> None:
+    """
+    Test case 7: TypeError for non-list sizes.
+    """
+    with pytest.raises(TypeError, match="sizes must be a list"):
+        partition_set_by_sizes({1, 2, 3}, "not a list")
+
+
+def test_partition_set_by_sizes_type_error_sizes_elements() -> None:
+    """
+    Test case 8: TypeError for non-int sizes elements.
+    """
+    with pytest.raises(TypeError, match="All sizes must be integers"):
+        partition_set_by_sizes({1, 2, 3}, [2, "not int"])
+
+
+def test_partition_set_by_sizes_value_error_negative_size() -> None:
+    """
+    Test case 9: ValueError for negative size.
+    """
+    with pytest.raises(ValueError, match="All sizes must be positive"):
+        partition_set_by_sizes({1, 2, 3}, [2, -1])
+
+
+def test_partition_set_by_sizes_value_error_zero_size() -> None:
+    """
+    Test case 10: ValueError for zero size.
+    """
+    with pytest.raises(ValueError, match="All sizes must be positive"):
+        partition_set_by_sizes({1, 2, 3}, [2, 0])
+
+
+def test_partition_set_by_sizes_value_error_wrong_sum() -> None:
+    """
+    Test case 11: ValueError for sizes sum not equal to set size.
+    """
+    with pytest.raises(ValueError, match="Sum of sizes .* must equal set size"):
+        partition_set_by_sizes({1, 2, 3}, [2, 3])

--- a/pytest/unit/iterable_functions/set_operations/test_partition_set_into_n_parts.py
+++ b/pytest/unit/iterable_functions/set_operations/test_partition_set_into_n_parts.py
@@ -106,44 +106,9 @@ def test_partition_set_into_n_parts_strings() -> None:
     assert union == input_set
 
 
-def test_partition_set_into_n_parts_type_error_input_set() -> None:
-    """
-    Test case 8: TypeError for invalid input_set type.
-    """
-    with pytest.raises(TypeError, match="input_set must be a set"):
-        partition_set_into_n_parts("not a set", 2)
-
-
-def test_partition_set_into_n_parts_type_error_n() -> None:
-    """
-    Test case 9: TypeError for invalid n type.
-    """
-    input_set = {1, 2, 3}
-    with pytest.raises(TypeError, match="n must be an int"):
-        partition_set_into_n_parts(input_set, "not an int")
-
-
-def test_partition_set_into_n_parts_value_error_n_zero() -> None:
-    """
-    Test case 10: ValueError for n=0.
-    """
-    input_set = {1, 2, 3}
-    with pytest.raises(ValueError, match="n must be at least 1"):
-        partition_set_into_n_parts(input_set, 0)
-
-
-def test_partition_set_into_n_parts_value_error_n_negative() -> None:
-    """
-    Test case 11: ValueError for negative n.
-    """
-    input_set = {1, 2, 3}
-    with pytest.raises(ValueError, match="n must be at least 1"):
-        partition_set_into_n_parts(input_set, -1)
-
-
 def test_partition_set_into_n_parts_equal_distribution() -> None:
     """
-    Test case 12: Test that elements are distributed evenly.
+    Test case 8: Test that elements are distributed evenly.
     """
     input_set = set(range(10))  # 10 elements
     n = 3
@@ -152,3 +117,36 @@ def test_partition_set_into_n_parts_equal_distribution() -> None:
     # Should be [4, 3, 3] or similar distribution
     assert sum(sizes) == 10
     assert max(sizes) - min(sizes) <= 1
+def test_partition_set_into_n_parts_type_error_input_set() -> None:
+    """
+    Test case 9: TypeError for invalid input_set type.
+    """
+    with pytest.raises(TypeError, match="input_set must be a set"):
+        partition_set_into_n_parts("not a set", 2)
+
+
+def test_partition_set_into_n_parts_type_error_n() -> None:
+    """
+    Test case 10: TypeError for invalid n type.
+    """
+    input_set = {1, 2, 3}
+    with pytest.raises(TypeError, match="n must be an int"):
+        partition_set_into_n_parts(input_set, "not an int")
+
+
+def test_partition_set_into_n_parts_value_error_n_zero() -> None:
+    """
+    Test case 11: ValueError for n=0.
+    """
+    input_set = {1, 2, 3}
+    with pytest.raises(ValueError, match="n must be at least 1"):
+        partition_set_into_n_parts(input_set, 0)
+
+
+def test_partition_set_into_n_parts_value_error_n_negative() -> None:
+    """
+    Test case 12: ValueError for negative n.
+    """
+    input_set = {1, 2, 3}
+    with pytest.raises(ValueError, match="n must be at least 1"):
+        partition_set_into_n_parts(input_set, -1)

--- a/pytest/unit/iterable_functions/set_operations/test_set_cartesian_product.py
+++ b/pytest/unit/iterable_functions/set_operations/test_set_cartesian_product.py
@@ -76,9 +76,18 @@ def test_set_cartesian_product_mixed_types() -> None:
         assert len(item) == 3
 
 
+def test_set_cartesian_product_large_sets() -> None:
+    """
+    Test case 7: Test with larger sets.
+    """
+    set1 = {1, 2, 3}
+    set2 = {"a", "b", "c"}
+    set3 = {"x", "y"}
+    result = set_cartesian_product(set1, set2, set3)
+    assert len(result) == 18  # 3 * 3 * 2 = 18
 def test_set_cartesian_product_no_sets() -> None:
     """
-    Test case 7: ValueError when no sets provided.
+    Test case 8: ValueError when no sets provided.
     """
     with pytest.raises(ValueError, match="At least one set must be provided"):
         set_cartesian_product()
@@ -86,7 +95,7 @@ def test_set_cartesian_product_no_sets() -> None:
 
 def test_set_cartesian_product_type_error() -> None:
     """
-    Test case 8: TypeError for non-set arguments.
+    Test case 9: TypeError for non-set arguments.
     """
     with pytest.raises(TypeError, match="All arguments must be sets"):
         set_cartesian_product({1, 2}, "not a set")
@@ -94,18 +103,7 @@ def test_set_cartesian_product_type_error() -> None:
 
 def test_set_cartesian_product_type_error_position() -> None:
     """
-    Test case 9: TypeError with position information.
+    Test case 10: TypeError with position information.
     """
     with pytest.raises(TypeError, match="got list at position 1"):
         set_cartesian_product({1, 2}, [3, 4])
-
-
-def test_set_cartesian_product_large_sets() -> None:
-    """
-    Test case 10: Test with larger sets.
-    """
-    set1 = {1, 2, 3}
-    set2 = {"a", "b", "c"}
-    set3 = {"x", "y"}
-    result = set_cartesian_product(set1, set2, set3)
-    assert len(result) == 18  # 3 * 3 * 2 = 18

--- a/pytest/unit/iterable_functions/set_operations/test_set_cartesian_product_as_list.py
+++ b/pytest/unit/iterable_functions/set_operations/test_set_cartesian_product_as_list.py
@@ -81,33 +81,9 @@ def test_set_cartesian_product_as_list_mixed_types() -> None:
     assert result == sorted(result)
 
 
-def test_set_cartesian_product_as_list_no_sets() -> None:
-    """
-    Test case 7: ValueError when no sets provided.
-    """
-    with pytest.raises(ValueError, match="At least one set must be provided"):
-        set_cartesian_product_as_list()
-
-
-def test_set_cartesian_product_as_list_type_error() -> None:
-    """
-    Test case 8: TypeError for non-set arguments.
-    """
-    with pytest.raises(TypeError, match="All arguments must be sets"):
-        set_cartesian_product_as_list({1, 2}, "not a set")
-
-
-def test_set_cartesian_product_as_list_type_error_position() -> None:
-    """
-    Test case 9: TypeError with position information.
-    """
-    with pytest.raises(TypeError, match="got list at position 1"):
-        set_cartesian_product_as_list({1, 2}, [3, 4])
-
-
 def test_set_cartesian_product_as_list_large_sets() -> None:
     """
-    Test case 10: Test with larger sets.
+    Test case 7: Test with larger sets.
     """
     set1 = {1, 2, 3}
     set2 = {"a", "b", "c"}
@@ -117,3 +93,25 @@ def test_set_cartesian_product_as_list_large_sets() -> None:
     assert isinstance(result, list)
     # Check that result is sorted
     assert result == sorted(result)
+def test_set_cartesian_product_as_list_no_sets() -> None:
+    """
+    Test case 8: ValueError when no sets provided.
+    """
+    with pytest.raises(ValueError, match="At least one set must be provided"):
+        set_cartesian_product_as_list()
+
+
+def test_set_cartesian_product_as_list_type_error() -> None:
+    """
+    Test case 9: TypeError for non-set arguments.
+    """
+    with pytest.raises(TypeError, match="All arguments must be sets"):
+        set_cartesian_product_as_list({1, 2}, "not a set")
+
+
+def test_set_cartesian_product_as_list_type_error_position() -> None:
+    """
+    Test case 10: TypeError with position information.
+    """
+    with pytest.raises(TypeError, match="got list at position 1"):
+        set_cartesian_product_as_list({1, 2}, [3, 4])

--- a/pytest/unit/iterable_functions/set_operations/test_set_combinations.py
+++ b/pytest/unit/iterable_functions/set_operations/test_set_combinations.py
@@ -103,57 +103,9 @@ def test_get_combinations_empty_set() -> None:
     assert result == [[]]
 
 
-def test_get_combinations_type_error_non_set() -> None:
-    """
-    Test case 8: TypeError when input_set is not a set.
-    """
-    # Arrange
-    invalid_input = [1, 2, 3]
-
-    # Act & Assert
-    with pytest.raises(TypeError, match="input_set must be a set"):
-        get_combinations(invalid_input, 2)  # type: ignore
-
-
-def test_get_combinations_type_error_non_int_r() -> None:
-    """
-    Test case 9: TypeError when r is not an integer.
-    """
-    # Arrange
-    input_set = {1, 2, 3}
-
-    # Act & Assert
-    with pytest.raises(TypeError, match="r must be an int"):
-        get_combinations(input_set, "2")  # type: ignore
-
-
-def test_get_combinations_value_error_negative_r() -> None:
-    """
-    Test case 10: ValueError when r is negative.
-    """
-    # Arrange
-    input_set = {1, 2, 3}
-
-    # Act & Assert
-    with pytest.raises(ValueError, match="r must be non-negative"):
-        get_combinations(input_set, -1)
-
-
-def test_get_combinations_value_error_r_too_large() -> None:
-    """
-    Test case 11: ValueError when r is larger than set size.
-    """
-    # Arrange
-    input_set = {1, 2, 3}
-
-    # Act & Assert
-    with pytest.raises(ValueError, match="r cannot be larger than set size"):
-        get_combinations(input_set, 5)
-
-
 def test_get_combinations_lexicographic_order() -> None:
     """
-    Test case 12: Results are in lexicographic order.
+    Test case 8: Results are in lexicographic order.
     """
     # Arrange
     input_set = {3, 1, 4, 2}
@@ -165,3 +117,49 @@ def test_get_combinations_lexicographic_order() -> None:
     assert result == [[1, 2], [1, 3], [1, 4], [2, 3], [2, 4], [3, 4]]
     # Verify sorted order
     assert result == sorted(result)
+def test_get_combinations_type_error_non_set() -> None:
+    """
+    Test case 9: TypeError when input_set is not a set.
+    """
+    # Arrange
+    invalid_input = [1, 2, 3]
+
+    # Act & Assert
+    with pytest.raises(TypeError, match="input_set must be a set"):
+        get_combinations(invalid_input, 2)  # type: ignore
+
+
+def test_get_combinations_type_error_non_int_r() -> None:
+    """
+    Test case 10: TypeError when r is not an integer.
+    """
+    # Arrange
+    input_set = {1, 2, 3}
+
+    # Act & Assert
+    with pytest.raises(TypeError, match="r must be an int"):
+        get_combinations(input_set, "2")  # type: ignore
+
+
+def test_get_combinations_value_error_negative_r() -> None:
+    """
+    Test case 11: ValueError when r is negative.
+    """
+    # Arrange
+    input_set = {1, 2, 3}
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="r must be non-negative"):
+        get_combinations(input_set, -1)
+
+
+def test_get_combinations_value_error_r_too_large() -> None:
+    """
+    Test case 12: ValueError when r is larger than set size.
+    """
+    # Arrange
+    input_set = {1, 2, 3}
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="r cannot be larger than set size"):
+        get_combinations(input_set, 5)

--- a/pytest/unit/iterable_functions/set_operations/test_set_partition.py
+++ b/pytest/unit/iterable_functions/set_operations/test_set_partition.py
@@ -111,34 +111,9 @@ def test_partition_set_by_predicate_single_element_false() -> None:
     assert false_set == {-5}
 
 
-def test_partition_set_by_predicate_type_error_non_set() -> None:
-    """
-    Test case 8: TypeError when input_set is not a set.
-    """
-    # Arrange
-    invalid_input = [1, 2, 3, 4]
-
-    # Act & Assert
-    with pytest.raises(TypeError, match="input_set must be a set"):
-        partition_set_by_predicate(invalid_input, lambda x: x % 2 == 0)  # type: ignore
-
-
-def test_partition_set_by_predicate_type_error_non_callable() -> None:
-    """
-    Test case 9: TypeError when predicate is not callable.
-    """
-    # Arrange
-    numbers = {1, 2, 3}
-    invalid_predicate = "not callable"
-
-    # Act & Assert
-    with pytest.raises(TypeError, match="predicate must be callable"):
-        partition_set_by_predicate(numbers, invalid_predicate)  # type: ignore
-
-
 def test_partition_set_by_predicate_complex_predicate() -> None:
     """
-    Test case 10: Complex predicate with multiple conditions.
+    Test case 8: Complex predicate with multiple conditions.
     """
     # Arrange
     numbers = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
@@ -155,7 +130,7 @@ def test_partition_set_by_predicate_complex_predicate() -> None:
 
 def test_partition_set_by_predicate_preserves_union() -> None:
     """
-    Test case 11: Union of partitions equals original set.
+    Test case 9: Union of partitions equals original set.
     """
     # Arrange
     original_set = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
@@ -172,7 +147,7 @@ def test_partition_set_by_predicate_preserves_union() -> None:
 
 def test_partition_set_by_predicate_mixed_types() -> None:
     """
-    Test case 12: Partition set with mixed types.
+    Test case 10: Partition set with mixed types.
     """
     # Arrange
     mixed_set = {1, "a", 2.5, True, None}
@@ -188,3 +163,26 @@ def test_partition_set_by_predicate_mixed_types() -> None:
     assert "a" in false_set
     assert True in false_set
     assert None in false_set
+def test_partition_set_by_predicate_type_error_non_set() -> None:
+    """
+    Test case 11: TypeError when input_set is not a set.
+    """
+    # Arrange
+    invalid_input = [1, 2, 3, 4]
+
+    # Act & Assert
+    with pytest.raises(TypeError, match="input_set must be a set"):
+        partition_set_by_predicate(invalid_input, lambda x: x % 2 == 0)  # type: ignore
+
+
+def test_partition_set_by_predicate_type_error_non_callable() -> None:
+    """
+    Test case 12: TypeError when predicate is not callable.
+    """
+    # Arrange
+    numbers = {1, 2, 3}
+    invalid_predicate = "not callable"
+
+    # Act & Assert
+    with pytest.raises(TypeError, match="predicate must be callable"):
+        partition_set_by_predicate(numbers, invalid_predicate)  # type: ignore

--- a/pytest/unit/iterable_functions/set_operations/test_set_power_set.py
+++ b/pytest/unit/iterable_functions/set_operations/test_set_power_set.py
@@ -74,17 +74,9 @@ def test_set_power_set_mixed_types() -> None:
     assert frozenset({1, "a", 3.14}) in result
 
 
-def test_set_power_set_type_error() -> None:
-    """
-    Test case 7: TypeError for invalid input type.
-    """
-    with pytest.raises(TypeError, match="input_set must be a set"):
-        set_power_set("not a set")
-
-
 def test_set_power_set_large_set() -> None:
     """
-    Test case 8: Test with larger set (but not too large to avoid exponential time).
+    Test case 7: Test with larger set (but not too large to avoid exponential time).
     """
     input_set = {1, 2, 3, 4}
     result = set_power_set(input_set)
@@ -94,3 +86,9 @@ def test_set_power_set_large_set() -> None:
     assert frozenset() in result
     assert frozenset({1, 2, 3, 4}) in result
     assert frozenset({1, 2}) in result
+def test_set_power_set_type_error() -> None:
+    """
+    Test case 8: TypeError for invalid input type.
+    """
+    with pytest.raises(TypeError, match="input_set must be a set"):
+        set_power_set("not a set")

--- a/pytest/unit/iterable_functions/set_operations/test_set_power_set_as_lists.py
+++ b/pytest/unit/iterable_functions/set_operations/test_set_power_set_as_lists.py
@@ -77,17 +77,9 @@ def test_set_power_set_as_lists_mixed_types() -> None:
     assert result in expected_variants
 
 
-def test_set_power_set_as_lists_type_error() -> None:
-    """
-    Test case 7: TypeError for invalid input type.
-    """
-    with pytest.raises(TypeError, match="input_set must be a set"):
-        set_power_set_as_lists("not a set")
-
-
 def test_set_power_set_as_lists_large_set() -> None:
     """
-    Test case 8: Test with larger set.
+    Test case 7: Test with larger set.
     """
     input_set = {1, 2, 3, 4}
     result = set_power_set_as_lists(input_set)
@@ -101,7 +93,7 @@ def test_set_power_set_as_lists_large_set() -> None:
 
 def test_set_power_set_as_lists_ordering() -> None:
     """
-    Test case 9: Test that ordering is correct.
+    Test case 8: Test that ordering is correct.
     """
     input_set = {3, 1, 2}
     result = set_power_set_as_lists(input_set)
@@ -117,3 +109,9 @@ def test_set_power_set_as_lists_ordering() -> None:
         [1, 2, 3],  # length 3
     ]
     assert result == expected
+def test_set_power_set_as_lists_type_error() -> None:
+    """
+    Test case 9: TypeError for invalid input type.
+    """
+    with pytest.raises(TypeError, match="input_set must be a set"):
+        set_power_set_as_lists("not a set")

--- a/pytest/unit/iterable_functions/set_operations/test_set_symmetric_difference.py
+++ b/pytest/unit/iterable_functions/set_operations/test_set_symmetric_difference.py
@@ -71,25 +71,9 @@ def test_set_symmetric_difference_mixed_types() -> None:
     assert result == expected
 
 
-def test_set_symmetric_difference_type_error() -> None:
-    """
-    Test case 7: TypeError for non-set arguments.
-    """
-    with pytest.raises(TypeError, match="All arguments must be sets"):
-        set_symmetric_difference({1, 2}, "not a set")
-
-
-def test_set_symmetric_difference_value_error() -> None:
-    """
-    Test case 8: ValueError for fewer than 2 sets.
-    """
-    with pytest.raises(ValueError, match="At least 2 sets must be provided"):
-        set_symmetric_difference({1, 2})
-
-
 def test_set_symmetric_difference_four_sets() -> None:
     """
-    Test case 9: Symmetric difference of four sets.
+    Test case 7: Symmetric difference of four sets.
     """
     set1 = {1, 2, 3, 4}
     set2 = {2, 3, 4, 5}
@@ -103,10 +87,24 @@ def test_set_symmetric_difference_four_sets() -> None:
 
 def test_set_symmetric_difference_single_element() -> None:
     """
-    Test case 10: Symmetric difference with single elements.
+    Test case 8: Symmetric difference with single elements.
     """
     set1 = {1}
     set2 = {2}
     result = set_symmetric_difference(set1, set2)
     expected = {1, 2}
     assert result == expected
+def test_set_symmetric_difference_type_error() -> None:
+    """
+    Test case 9: TypeError for non-set arguments.
+    """
+    with pytest.raises(TypeError, match="All arguments must be sets"):
+        set_symmetric_difference({1, 2}, "not a set")
+
+
+def test_set_symmetric_difference_value_error() -> None:
+    """
+    Test case 10: ValueError for fewer than 2 sets.
+    """
+    with pytest.raises(ValueError, match="At least 2 sets must be provided"):
+        set_symmetric_difference({1, 2})

--- a/pytest/unit/iterable_functions/type_operations/test_safe_cast.py
+++ b/pytest/unit/iterable_functions/type_operations/test_safe_cast.py
@@ -193,18 +193,9 @@ def test_safe_cast_string_with_decimal_to_int() -> None:
     assert isinstance(result, int)
 
 
-def test_safe_cast_type_error_non_type() -> None:
-    """
-    Test case 17: TypeError when target_type is not a type.
-    """
-    # Act & Assert
-    with pytest.raises(TypeError, match="target_type must be a type"):
-        safe_cast("123", "not a type")  # type: ignore
-
-
 def test_is_numeric_with_int() -> None:
     """
-    Test case 18: is_numeric returns True for integers.
+    Test case 17: is_numeric returns True for integers.
     """
     # Act
     result = is_numeric(42)
@@ -215,7 +206,7 @@ def test_is_numeric_with_int() -> None:
 
 def test_is_numeric_with_float() -> None:
     """
-    Test case 19: is_numeric returns True for floats.
+    Test case 18: is_numeric returns True for floats.
     """
     # Act
     result = is_numeric(3.14)
@@ -226,7 +217,7 @@ def test_is_numeric_with_float() -> None:
 
 def test_is_numeric_with_complex() -> None:
     """
-    Test case 20: is_numeric returns True for complex numbers.
+    Test case 19: is_numeric returns True for complex numbers.
     """
     # Act
     result = is_numeric(1 + 2j)
@@ -237,7 +228,7 @@ def test_is_numeric_with_complex() -> None:
 
 def test_is_numeric_with_string() -> None:
     """
-    Test case 21: is_numeric returns False for strings.
+    Test case 20: is_numeric returns False for strings.
     """
     # Act
     result = is_numeric("123")
@@ -248,7 +239,7 @@ def test_is_numeric_with_string() -> None:
 
 def test_is_numeric_with_none() -> None:
     """
-    Test case 22: is_numeric returns False for None.
+    Test case 21: is_numeric returns False for None.
     """
     # Act
     result = is_numeric(None)
@@ -259,7 +250,7 @@ def test_is_numeric_with_none() -> None:
 
 def test_is_numeric_with_bool() -> None:
     """
-    Test case 23: is_numeric returns False for booleans.
+    Test case 22: is_numeric returns False for booleans.
     """
     # Act
     result = is_numeric(True)
@@ -270,7 +261,7 @@ def test_is_numeric_with_bool() -> None:
 
 def test_safe_cast_empty_string_to_int() -> None:
     """
-    Test case 24: Empty string to int with default.
+    Test case 23: Empty string to int with default.
     """
     # Act
     result = safe_cast("", int, 0)
@@ -281,7 +272,7 @@ def test_safe_cast_empty_string_to_int() -> None:
 
 def test_safe_cast_preserves_original_on_failure() -> None:
     """
-    Test case 25: Failed cast without default preserves original value.
+    Test case 24: Failed cast without default preserves original value.
     """
     # Arrange
     original = {"key": "value"}
@@ -292,3 +283,10 @@ def test_safe_cast_preserves_original_on_failure() -> None:
     # Assert
     assert result == original
     assert result is original
+def test_safe_cast_type_error_non_type() -> None:
+    """
+    Test case 25: TypeError when target_type is not a type.
+    """
+    # Act & Assert
+    with pytest.raises(TypeError, match="target_type must be a type"):
+        safe_cast("123", "not a type")  # type: ignore

--- a/pytest/unit/iterable_functions/type_operations/test_try_convert_to_type.py
+++ b/pytest/unit/iterable_functions/type_operations/test_try_convert_to_type.py
@@ -28,22 +28,8 @@ def test_try_convert_to_type_success_str() -> None:
     assert try_convert_to_type(value, target_type) == expected_output
 
 
-def test_try_convert_to_type_invalid_conversion() -> None:
-    """Test case 4: Test the try_convert_to_type function with an invalid conversion."""
-    value = "abc"
-    target_type = int
-    with pytest.raises(ValueError):
-        try_convert_to_type(value, target_type)
-
-
-def test_try_convert_to_type_type_error() -> None:
-    """Test case 5: Test the try_convert_to_type function with invalid type for target_type."""
-    with pytest.raises(TypeError):
-        try_convert_to_type("123", "not a type")
-
-
 def test_try_convert_to_type_success_list() -> None:
-    """Test case 6: Test the try_convert_to_type function with list conversion."""
+    """Test case 4: Test the try_convert_to_type function with list conversion."""
     value = (1, 2, 3)
     target_type = list
     expected_output = [1, 2, 3]
@@ -51,7 +37,7 @@ def test_try_convert_to_type_success_list() -> None:
 
 
 def test_try_convert_to_type_success_bool() -> None:
-    """Test case 7: Test the try_convert_to_type function with bool conversion."""
+    """Test case 5: Test the try_convert_to_type function with bool conversion."""
     value = 0
     target_type = bool
     expected_output = False
@@ -59,7 +45,7 @@ def test_try_convert_to_type_success_bool() -> None:
 
 
 def test_try_convert_to_type_custom_class() -> None:
-    """Test case 8: Test the try_convert_to_type function with a custom class."""
+    """Test case 6: Test the try_convert_to_type function with a custom class."""
 
     class Custom:
         def __init__(self, val: Any) -> None:
@@ -72,6 +58,20 @@ def test_try_convert_to_type_custom_class() -> None:
     target_type = Custom
     expected_output = Custom(5)
     assert try_convert_to_type(value, target_type) == expected_output
+
+
+def test_try_convert_to_type_invalid_conversion() -> None:
+    """Test case 7: Test the try_convert_to_type function with an invalid conversion."""
+    value = "abc"
+    target_type = int
+    with pytest.raises(ValueError):
+        try_convert_to_type(value, target_type)
+
+
+def test_try_convert_to_type_type_error() -> None:
+    """Test case 8: Test the try_convert_to_type function with invalid type for target_type."""
+    with pytest.raises(TypeError):
+        try_convert_to_type("123", "not a type")
 
 
 def test_try_convert_to_type_invalid_list_conversion() -> None:

--- a/pytest/unit/network_functions/test_resolve_hostname.py
+++ b/pytest/unit/network_functions/test_resolve_hostname.py
@@ -13,9 +13,17 @@ def test_resolve_hostname_success() -> None:
         assert ip == "1.2.3.4"
 
 
+def test_resolve_hostname_performance() -> None:
+    """
+    Test case 2: Performance with repeated calls.
+    """
+    with patch("socket.gethostbyname", return_value="1.2.3.4"):
+        for _ in range(10):
+            ip = resolve_hostname("example.com")
+            assert ip == "1.2.3.4"
 def test_resolve_hostname_type_error() -> None:
     """
-    Test case 2: TypeError for non-string hostname.
+    Test case 3: TypeError for non-string hostname.
     """
     with pytest.raises(TypeError, match="hostname must be a string"):
         resolve_hostname(123)
@@ -23,7 +31,7 @@ def test_resolve_hostname_type_error() -> None:
 
 def test_resolve_hostname_value_error_empty() -> None:
     """
-    Test case 3: ValueError for empty hostname.
+    Test case 4: ValueError for empty hostname.
     """
     with pytest.raises(ValueError, match="hostname cannot be empty"):
         resolve_hostname("")
@@ -31,18 +39,8 @@ def test_resolve_hostname_value_error_empty() -> None:
 
 def test_resolve_hostname_value_error_unresolvable() -> None:
     """
-    Test case 4: ValueError for unresolvable hostname.
+    Test case 5: ValueError for unresolvable hostname.
     """
     with patch("socket.gethostbyname", side_effect=socket.gaierror("not found")):
         with pytest.raises(ValueError, match="Could not resolve hostname"):
             resolve_hostname("badhost")
-
-
-def test_resolve_hostname_performance() -> None:
-    """
-    Test case 5: Performance with repeated calls.
-    """
-    with patch("socket.gethostbyname", return_value="1.2.3.4"):
-        for _ in range(10):
-            ip = resolve_hostname("example.com")
-            assert ip == "1.2.3.4"

--- a/pytest/unit/security_functions/encryption_helpers/test_decrypt_data_aes.py
+++ b/pytest/unit/security_functions/encryption_helpers/test_decrypt_data_aes.py
@@ -36,64 +36,9 @@ def test_decrypt_data_aes_case_2_custom_key_decryption() -> None:
     assert decrypted == original_data
 
 
-def test_decrypt_data_aes_case_3_type_validation() -> None:
-    """
-    Test case 3: Type validation for parameters.
-    """
-    # Test invalid encrypted_data type
-    with pytest.raises(TypeError, match="encrypted_data must be a string"):
-        decrypt_data_aes(123, "key")
-
-    # Test invalid key type
-    with pytest.raises(TypeError, match="key must be a string"):
-        decrypt_data_aes("encrypted", 123)
-
-
-def test_decrypt_data_aes_case_4_value_validation() -> None:
-    """
-    Test case 4: Value validation for parameters.
-    """
-    # Test empty encrypted_data
-    with pytest.raises(ValueError, match="encrypted_data cannot be empty"):
-        decrypt_data_aes("", "key")
-
-    # Test empty key
-    with pytest.raises(ValueError, match="key cannot be empty"):
-        decrypt_data_aes("encrypted", "")
-
-
-def test_decrypt_data_aes_case_5_wrong_key() -> None:
-    """
-    Test case 5: Wrong key should raise ValueError during decryption.
-    """
-    # Arrange
-    original_data = "Secret message"
-    encrypted, correct_key = encrypt_data_aes(original_data)
-    from cryptography.fernet import Fernet
-
-    wrong_key = Fernet.generate_key().decode("utf-8")
-
-    # Act & Assert
-    with pytest.raises(ValueError, match="decryption failed"):
-        decrypt_data_aes(encrypted, wrong_key)
-
-
-def test_decrypt_data_aes_case_6_invalid_encrypted_data() -> None:
-    """
-    Test case 6: Invalid encrypted data should raise ValueError.
-    """
-    # Arrange
-    _, key = encrypt_data_aes("test")
-    invalid_encrypted = "not_valid_encrypted_data"
-
-    # Act & Assert
-    with pytest.raises(ValueError, match="decryption failed"):
-        decrypt_data_aes(invalid_encrypted, key)
-
-
 def test_decrypt_data_aes_case_7_unicode_data() -> None:
     """
-    Test case 7: Handle Unicode characters in data.
+    Test case 3: Handle Unicode characters in data.
     """
     # Arrange
     original_data = "Hello 世界! 🌍 ümläuts"
@@ -108,7 +53,7 @@ def test_decrypt_data_aes_case_7_unicode_data() -> None:
 
 def test_decrypt_data_aes_case_8_long_data() -> None:
     """
-    Test case 8: Decrypt long data string.
+    Test case 4: Decrypt long data string.
     """
     # Arrange
     original_data = "This is a very long message that spans multiple lines. " * 100
@@ -123,7 +68,7 @@ def test_decrypt_data_aes_case_8_long_data() -> None:
 
 def test_decrypt_data_aes_case_9_special_characters() -> None:
     """
-    Test case 9: Handle special characters and symbols.
+    Test case 5: Handle special characters and symbols.
     """
     # Arrange
     original_data = "!@#$%^&*()_+-=[]{}|;':\",./<>?`~"
@@ -138,7 +83,7 @@ def test_decrypt_data_aes_case_9_special_characters() -> None:
 
 def test_decrypt_data_aes_case_10_bytes_to_string_conversion() -> None:
     """
-    Test case 10: Decrypt bytes data that was encrypted.
+    Test case 6: Decrypt bytes data that was encrypted.
     """
     # Arrange
     original_bytes = b"Byte data test"
@@ -154,7 +99,7 @@ def test_decrypt_data_aes_case_10_bytes_to_string_conversion() -> None:
 
 def test_decrypt_data_aes_case_11_roundtrip_multiple_times() -> None:
     """
-    Test case 11: Multiple encrypt/decrypt roundtrips should be consistent.
+    Test case 7: Multiple encrypt/decrypt roundtrips should be consistent.
     """
     # Arrange
     original_data = "Roundtrip test data"
@@ -172,6 +117,61 @@ def test_decrypt_data_aes_case_11_roundtrip_multiple_times() -> None:
     # Assert
     assert decrypted1 == original_data
     assert decrypted2 == original_data
+
+
+def test_decrypt_data_aes_case_3_type_validation() -> None:
+    """
+    Test case 8: Type validation for parameters.
+    """
+    # Test invalid encrypted_data type
+    with pytest.raises(TypeError, match="encrypted_data must be a string"):
+        decrypt_data_aes(123, "key")
+
+    # Test invalid key type
+    with pytest.raises(TypeError, match="key must be a string"):
+        decrypt_data_aes("encrypted", 123)
+
+
+def test_decrypt_data_aes_case_4_value_validation() -> None:
+    """
+    Test case 9: Value validation for parameters.
+    """
+    # Test empty encrypted_data
+    with pytest.raises(ValueError, match="encrypted_data cannot be empty"):
+        decrypt_data_aes("", "key")
+
+    # Test empty key
+    with pytest.raises(ValueError, match="key cannot be empty"):
+        decrypt_data_aes("encrypted", "")
+
+
+def test_decrypt_data_aes_case_5_wrong_key() -> None:
+    """
+    Test case 10: Wrong key should raise ValueError during decryption.
+    """
+    # Arrange
+    original_data = "Secret message"
+    encrypted, correct_key = encrypt_data_aes(original_data)
+    from cryptography.fernet import Fernet
+
+    wrong_key = Fernet.generate_key().decode("utf-8")
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="decryption failed"):
+        decrypt_data_aes(encrypted, wrong_key)
+
+
+def test_decrypt_data_aes_case_6_invalid_encrypted_data() -> None:
+    """
+    Test case 11: Invalid encrypted data should raise ValueError.
+    """
+    # Arrange
+    _, key = encrypt_data_aes("test")
+    invalid_encrypted = "not_valid_encrypted_data"
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="decryption failed"):
+        decrypt_data_aes(invalid_encrypted, key)
 
 
 def test_decrypt_data_aes_case_12_invalid_key_format() -> None:

--- a/pytest/unit/security_functions/encryption_helpers/test_decrypt_xor.py
+++ b/pytest/unit/security_functions/encryption_helpers/test_decrypt_xor.py
@@ -34,48 +34,9 @@ def test_decrypt_xor_case_2_custom_key_decryption() -> None:
     assert decrypted == original_data
 
 
-def test_decrypt_xor_case_3_type_validation() -> None:
-    """
-    Test case 3: Type validation for parameters.
-    """
-    # Test invalid encrypted_data type
-    with pytest.raises(TypeError, match="encrypted_data must be a string"):
-        decrypt_xor(123, "key")
-
-    # Test invalid key type
-    with pytest.raises(TypeError, match="key must be a string"):
-        decrypt_xor("encrypted", 123)
-
-
-def test_decrypt_xor_case_4_value_validation() -> None:
-    """
-    Test case 4: Value validation for parameters.
-    """
-    # Test empty encrypted_data
-    with pytest.raises(ValueError, match="encrypted_data cannot be empty"):
-        decrypt_xor("", "key")
-
-    # Test empty key
-    with pytest.raises(ValueError, match="key cannot be empty"):
-        decrypt_xor("encrypted", "")
-
-
-def test_decrypt_xor_case_5_invalid_hex_format() -> None:
-    """
-    Test case 5: Invalid hex format should raise ValueError.
-    """
-    # Test odd length hex
-    with pytest.raises(ValueError, match="encrypted_data must have even length"):
-        decrypt_xor("abc", "key")  # Odd length
-
-    # Test invalid hex characters
-    with pytest.raises(ValueError, match="encrypted_data must be valid hex string"):
-        decrypt_xor("gggg", "key")  # Invalid hex characters
-
-
 def test_decrypt_xor_case_6_wrong_key_different_result() -> None:
     """
-    Test case 6: Wrong key should produce different (incorrect) result.
+    Test case 3: Wrong key should produce different (incorrect) result.
     """
     # Arrange
     original_data = "Secret message"
@@ -94,7 +55,7 @@ def test_decrypt_xor_case_6_wrong_key_different_result() -> None:
 
 def test_decrypt_xor_case_7_unicode_data() -> None:
     """
-    Test case 7: Handle Unicode characters in data.
+    Test case 4: Handle Unicode characters in data.
     """
     # Arrange
     original_data = "Hello 世界! 🌍 ümläuts"
@@ -109,7 +70,7 @@ def test_decrypt_xor_case_7_unicode_data() -> None:
 
 def test_decrypt_xor_case_8_long_data() -> None:
     """
-    Test case 8: Decrypt long data string.
+    Test case 5: Decrypt long data string.
     """
     # Arrange
     original_data = (
@@ -128,7 +89,7 @@ def test_decrypt_xor_case_8_long_data() -> None:
 
 def test_decrypt_xor_case_9_special_characters() -> None:
     """
-    Test case 9: Handle special characters and symbols.
+    Test case 6: Handle special characters and symbols.
     """
     # Arrange
     original_data = "!@#$%^&*()_+-=[]{}|;':\",./<>?`~"
@@ -142,26 +103,9 @@ def test_decrypt_xor_case_9_special_characters() -> None:
     assert decrypted == original_data
 
 
-def test_decrypt_xor_case_10_empty_original_data() -> None:
-    """
-    Test case 10: Handle empty string encryption/decryption.
-    """
-    # Note: This test is for edge case documentation
-    # The encrypt_xor function doesn't allow empty data, so this tests
-    # the theoretical case where someone manually creates an empty hex string
-
-    # Arrange - manually create "encrypted" empty data
-    encrypted_empty = ""  # Empty hex string
-    key = "somekey"
-
-    # Act & Assert
-    with pytest.raises(ValueError, match="encrypted_data cannot be empty"):
-        decrypt_xor(encrypted_empty, key)
-
-
 def test_decrypt_xor_case_11_roundtrip_multiple_times() -> None:
     """
-    Test case 11: Multiple encrypt/decrypt roundtrips should be consistent.
+    Test case 7: Multiple encrypt/decrypt roundtrips should be consistent.
     """
     # Arrange
     original_data = "Roundtrip test data"
@@ -182,7 +126,7 @@ def test_decrypt_xor_case_11_roundtrip_multiple_times() -> None:
 
 def test_decrypt_xor_case_12_case_sensitive_hex() -> None:
     """
-    Test case 12: Hex decryption should handle both uppercase and lowercase.
+    Test case 8: Hex decryption should handle both uppercase and lowercase.
     """
     # Arrange
     original_data = "Case test"
@@ -199,3 +143,57 @@ def test_decrypt_xor_case_12_case_sensitive_hex() -> None:
     # Assert
     assert decrypted_lower == original_data
     assert decrypted_upper == original_data
+def test_decrypt_xor_case_3_type_validation() -> None:
+    """
+    Test case 9: Type validation for parameters.
+    """
+    # Test invalid encrypted_data type
+    with pytest.raises(TypeError, match="encrypted_data must be a string"):
+        decrypt_xor(123, "key")
+
+    # Test invalid key type
+    with pytest.raises(TypeError, match="key must be a string"):
+        decrypt_xor("encrypted", 123)
+
+
+def test_decrypt_xor_case_4_value_validation() -> None:
+    """
+    Test case 10: Value validation for parameters.
+    """
+    # Test empty encrypted_data
+    with pytest.raises(ValueError, match="encrypted_data cannot be empty"):
+        decrypt_xor("", "key")
+
+    # Test empty key
+    with pytest.raises(ValueError, match="key cannot be empty"):
+        decrypt_xor("encrypted", "")
+
+
+def test_decrypt_xor_case_5_invalid_hex_format() -> None:
+    """
+    Test case 11: Invalid hex format should raise ValueError.
+    """
+    # Test odd length hex
+    with pytest.raises(ValueError, match="encrypted_data must have even length"):
+        decrypt_xor("abc", "key")  # Odd length
+
+    # Test invalid hex characters
+    with pytest.raises(ValueError, match="encrypted_data must be valid hex string"):
+        decrypt_xor("gggg", "key")  # Invalid hex characters
+
+
+def test_decrypt_xor_case_10_empty_original_data() -> None:
+    """
+    Test case 12: Handle empty string encryption/decryption.
+    """
+    # Note: This test is for edge case documentation
+    # The encrypt_xor function doesn't allow empty data, so this tests
+    # the theoretical case where someone manually creates an empty hex string
+
+    # Arrange - manually create "encrypted" empty data
+    encrypted_empty = ""  # Empty hex string
+    key = "somekey"
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="encrypted_data cannot be empty"):
+        decrypt_xor(encrypted_empty, key)

--- a/pytest/unit/security_functions/encryption_helpers/test_encrypt_data_aes.py
+++ b/pytest/unit/security_functions/encryption_helpers/test_encrypt_data_aes.py
@@ -64,48 +64,9 @@ def test_encrypt_data_aes_case_3_string_data_custom_key() -> None:
     assert len(encrypted) > 0
 
 
-def test_encrypt_data_aes_case_4_type_validation() -> None:
-    """
-    Test case 4: Type validation for parameters.
-    """
-    # Test invalid data type
-    with pytest.raises(TypeError, match="data must be str or bytes"):
-        encrypt_data_aes(123)
-
-    # Test invalid key type
-    with pytest.raises(TypeError, match="key must be str, bytes, or None"):
-        encrypt_data_aes("data", key=123)
-
-
-def test_encrypt_data_aes_case_5_value_validation() -> None:
-    """
-    Test case 5: Value validation for parameters.
-    """
-    # Test empty string data
-    with pytest.raises(ValueError, match="data cannot be empty"):
-        encrypt_data_aes("")
-
-    # Test empty bytes data
-    with pytest.raises(ValueError, match="data cannot be empty"):
-        encrypt_data_aes(b"")
-
-
-def test_encrypt_data_aes_case_6_invalid_key_format() -> None:
-    """
-    Test case 6: Invalid key format should raise ValueError.
-    """
-    # Test invalid key format
-    with pytest.raises(ValueError, match="invalid key format"):
-        encrypt_data_aes("data", key="invalid_key")
-
-    # Test key with wrong length
-    with pytest.raises(ValueError, match="key must be 32 bytes when decoded"):
-        encrypt_data_aes("data", key=base64.urlsafe_b64encode(b"short").decode("utf-8"))
-
-
 def test_encrypt_data_aes_case_7_unicode_data() -> None:
     """
-    Test case 7: Handle Unicode characters in data.
+    Test case 4: Handle Unicode characters in data.
     """
     # Arrange
     data = "Hello 世界! 🌍 ümläuts"
@@ -121,7 +82,7 @@ def test_encrypt_data_aes_case_7_unicode_data() -> None:
 
 def test_encrypt_data_aes_case_8_long_data() -> None:
     """
-    Test case 8: Encrypt long data string.
+    Test case 5: Encrypt long data string.
     """
     # Arrange
     data = "This is a very long message that spans multiple lines. " * 100
@@ -137,7 +98,7 @@ def test_encrypt_data_aes_case_8_long_data() -> None:
 
 def test_encrypt_data_aes_case_9_different_data_different_results() -> None:
     """
-    Test case 9: Different data should produce different encrypted results.
+    Test case 6: Different data should produce different encrypted results.
     """
     # Arrange
     data1 = "Message 1"
@@ -156,7 +117,7 @@ def test_encrypt_data_aes_case_9_different_data_different_results() -> None:
 
 def test_encrypt_data_aes_case_10_same_data_different_keys() -> None:
     """
-    Test case 10: Same data with different keys should produce different results.
+    Test case 7: Same data with different keys should produce different results.
     """
     # Arrange
     data = "Same data"
@@ -175,7 +136,7 @@ def test_encrypt_data_aes_case_10_same_data_different_keys() -> None:
 
 def test_encrypt_data_aes_case_11_bytes_key_handling() -> None:
     """
-    Test case 11: Handle bytes key input.
+    Test case 8: Handle bytes key input.
     """
     # Arrange
     data = "Test message"
@@ -194,7 +155,7 @@ def test_encrypt_data_aes_case_11_bytes_key_handling() -> None:
 
 def test_encrypt_data_aes_case_12_special_characters() -> None:
     """
-    Test case 12: Handle special characters and symbols.
+    Test case 9: Handle special characters and symbols.
     """
     # Arrange
     data = "!@#$%^&*()_+-=[]{}|;':\",./<>?`~"
@@ -206,3 +167,40 @@ def test_encrypt_data_aes_case_12_special_characters() -> None:
     assert isinstance(encrypted, str)
     assert isinstance(key, str)
     assert len(encrypted) > 0
+def test_encrypt_data_aes_case_4_type_validation() -> None:
+    """
+    Test case 10: Type validation for parameters.
+    """
+    # Test invalid data type
+    with pytest.raises(TypeError, match="data must be str or bytes"):
+        encrypt_data_aes(123)
+
+    # Test invalid key type
+    with pytest.raises(TypeError, match="key must be str, bytes, or None"):
+        encrypt_data_aes("data", key=123)
+
+
+def test_encrypt_data_aes_case_5_value_validation() -> None:
+    """
+    Test case 11: Value validation for parameters.
+    """
+    # Test empty string data
+    with pytest.raises(ValueError, match="data cannot be empty"):
+        encrypt_data_aes("")
+
+    # Test empty bytes data
+    with pytest.raises(ValueError, match="data cannot be empty"):
+        encrypt_data_aes(b"")
+
+
+def test_encrypt_data_aes_case_6_invalid_key_format() -> None:
+    """
+    Test case 12: Invalid key format should raise ValueError.
+    """
+    # Test invalid key format
+    with pytest.raises(ValueError, match="invalid key format"):
+        encrypt_data_aes("data", key="invalid_key")
+
+    # Test key with wrong length
+    with pytest.raises(ValueError, match="key must be 32 bytes when decoded"):
+        encrypt_data_aes("data", key=base64.urlsafe_b64encode(b"short").decode("utf-8"))

--- a/pytest/unit/security_functions/encryption_helpers/test_encrypt_xor.py
+++ b/pytest/unit/security_functions/encryption_helpers/test_encrypt_xor.py
@@ -40,40 +40,9 @@ def test_encrypt_xor_case_2_custom_key() -> None:
     assert all(c in "0123456789abcdef" for c in encrypted)
 
 
-def test_encrypt_xor_case_3_empty_data_raises_error() -> None:
-    """
-    Test case 3: Empty data should raise ValueError.
-    """
-    # Act & Assert
-    with pytest.raises(ValueError, match="data cannot be empty"):
-        encrypt_xor("")
-
-
-def test_encrypt_xor_case_4_type_validation() -> None:
-    """
-    Test case 4: Type validation for parameters.
-    """
-    # Test invalid data type
-    with pytest.raises(TypeError, match="data must be a string"):
-        encrypt_xor(123)
-
-    # Test invalid key type
-    with pytest.raises(TypeError, match="key must be a string or None"):
-        encrypt_xor("data", key=123)
-
-
-def test_encrypt_xor_case_5_empty_key_raises_error() -> None:
-    """
-    Test case 5: Empty key should raise ValueError.
-    """
-    # Act & Assert
-    with pytest.raises(ValueError, match="key cannot be empty"):
-        encrypt_xor("data", key="")
-
-
 def test_encrypt_xor_case_6_different_keys_different_results() -> None:
     """
-    Test case 6: Different keys should produce different encrypted results.
+    Test case 3: Different keys should produce different encrypted results.
     """
     # Arrange
     data = "Same data"
@@ -90,7 +59,7 @@ def test_encrypt_xor_case_6_different_keys_different_results() -> None:
 
 def test_encrypt_xor_case_7_random_key_generation() -> None:
     """
-    Test case 7: Random key generation produces different keys.
+    Test case 4: Random key generation produces different keys.
     """
     # Arrange
     data = "Test data"
@@ -107,7 +76,7 @@ def test_encrypt_xor_case_7_random_key_generation() -> None:
 
 def test_encrypt_xor_case_8_unicode_data() -> None:
     """
-    Test case 8: Handle Unicode characters in data.
+    Test case 5: Handle Unicode characters in data.
     """
     # Arrange
     data = "Hello 世界! 🌍 ümläuts"
@@ -124,7 +93,7 @@ def test_encrypt_xor_case_8_unicode_data() -> None:
 
 def test_encrypt_xor_case_9_long_data() -> None:
     """
-    Test case 9: Encrypt long data string.
+    Test case 6: Encrypt long data string.
     """
     # Arrange
     data = (
@@ -147,7 +116,7 @@ def test_encrypt_xor_case_9_long_data() -> None:
 
 def test_encrypt_xor_case_10_key_length_adaptation() -> None:
     """
-    Test case 10: Verify key length adaptation based on data size.
+    Test case 7: Verify key length adaptation based on data size.
     """
     # Arrange
     short_data = "Hi"
@@ -166,7 +135,7 @@ def test_encrypt_xor_case_10_key_length_adaptation() -> None:
 
 def test_encrypt_xor_case_11_deterministic_with_same_key() -> None:
     """
-    Test case 11: Same data and key should produce same encrypted result.
+    Test case 8: Same data and key should produce same encrypted result.
     """
     # Arrange
     data = "Consistent data"
@@ -182,7 +151,7 @@ def test_encrypt_xor_case_11_deterministic_with_same_key() -> None:
 
 def test_encrypt_xor_case_12_special_characters() -> None:
     """
-    Test case 12: Handle special characters and symbols.
+    Test case 9: Handle special characters and symbols.
     """
     # Arrange
     data = "!@#$%^&*()_+-=[]{}|;':\",./<>?`~"
@@ -196,3 +165,32 @@ def test_encrypt_xor_case_12_special_characters() -> None:
     assert returned_key == key
     assert len(encrypted) > 0
     assert all(c in "0123456789abcdef" for c in encrypted)
+def test_encrypt_xor_case_3_empty_data_raises_error() -> None:
+    """
+    Test case 10: Empty data should raise ValueError.
+    """
+    # Act & Assert
+    with pytest.raises(ValueError, match="data cannot be empty"):
+        encrypt_xor("")
+
+
+def test_encrypt_xor_case_4_type_validation() -> None:
+    """
+    Test case 11: Type validation for parameters.
+    """
+    # Test invalid data type
+    with pytest.raises(TypeError, match="data must be a string"):
+        encrypt_xor(123)
+
+    # Test invalid key type
+    with pytest.raises(TypeError, match="key must be a string or None"):
+        encrypt_xor("data", key=123)
+
+
+def test_encrypt_xor_case_5_empty_key_raises_error() -> None:
+    """
+    Test case 12: Empty key should raise ValueError.
+    """
+    # Act & Assert
+    with pytest.raises(ValueError, match="key cannot be empty"):
+        encrypt_xor("data", key="")

--- a/pytest/unit/security_functions/password_hashing/test_hash_password_bcrypt.py
+++ b/pytest/unit/security_functions/password_hashing/test_hash_password_bcrypt.py
@@ -71,39 +71,9 @@ def test_hash_password_bcrypt_case_4_maximum_rounds() -> None:
     assert "$2b$15$" in hashed
 
 
-def test_hash_password_bcrypt_case_5_type_validation() -> None:
-    """
-    Test case 5: Type validation for all parameters.
-    """
-    # Test invalid password type
-    with pytest.raises(TypeError, match="password must be a string"):
-        hash_password_bcrypt(123)
-
-    # Test invalid rounds type
-    with pytest.raises(TypeError, match="rounds must be an integer"):
-        hash_password_bcrypt("password", rounds="invalid")
-
-
-def test_hash_password_bcrypt_case_6_value_validation() -> None:
-    """
-    Test case 6: Value validation for parameters.
-    """
-    # Test empty password
-    with pytest.raises(ValueError, match="password cannot be empty"):
-        hash_password_bcrypt("")
-
-    # Test rounds too low
-    with pytest.raises(ValueError, match="rounds must be between 4 and 31"):
-        hash_password_bcrypt("password", rounds=3)
-
-    # Test rounds too high
-    with pytest.raises(ValueError, match="rounds must be between 4 and 31"):
-        hash_password_bcrypt("password", rounds=32)
-
-
 def test_hash_password_bcrypt_case_7_different_passwords_different_hashes() -> None:
     """
-    Test case 7: Different passwords should produce different hashes.
+    Test case 5: Different passwords should produce different hashes.
     """
     # Arrange
     password1 = "password1"
@@ -119,7 +89,7 @@ def test_hash_password_bcrypt_case_7_different_passwords_different_hashes() -> N
 
 def test_hash_password_bcrypt_case_8_same_password_different_hashes() -> None:
     """
-    Test case 8: Same password should produce different hashes due to salt.
+    Test case 6: Same password should produce different hashes due to salt.
     """
     # Arrange
     password = "same_password"
@@ -134,7 +104,7 @@ def test_hash_password_bcrypt_case_8_same_password_different_hashes() -> None:
 
 def test_hash_password_bcrypt_case_9_unicode_password() -> None:
     """
-    Test case 9: Handle Unicode characters in password.
+    Test case 7: Handle Unicode characters in password.
     """
     # Arrange
     password = "pássw0rd_with_ümläuts_🔐"
@@ -150,7 +120,7 @@ def test_hash_password_bcrypt_case_9_unicode_password() -> None:
 
 def test_hash_password_bcrypt_case_10_long_password() -> None:
     """
-    Test case 10: Handle very long password.
+    Test case 8: Handle very long password.
     """
     # Arrange
     password = "a" * 1000  # Very long password
@@ -166,7 +136,7 @@ def test_hash_password_bcrypt_case_10_long_password() -> None:
 
 def test_hash_password_bcrypt_case_11_special_characters() -> None:
     """
-    Test case 11: Handle special characters and symbols.
+    Test case 9: Handle special characters and symbols.
     """
     # Arrange
     password = "!@#$%^&*()_+-=[]{}|;':\",./<>?`~"
@@ -182,7 +152,7 @@ def test_hash_password_bcrypt_case_11_special_characters() -> None:
 
 def test_hash_password_bcrypt_case_12_performance_high_rounds() -> None:
     """
-    Test case 12: Verify that higher rounds work (may be slower).
+    Test case 10: Verify that higher rounds work (may be slower).
     """
     # Arrange
     password = "performance_test"
@@ -201,3 +171,31 @@ def test_hash_password_bcrypt_case_12_performance_high_rounds() -> None:
     assert f"$2b${rounds:02d}$" in hashed
     # Should complete within reasonable time (bcrypt with 15 rounds)
     assert elapsed_time < 5.0  # Should complete within 5 seconds
+def test_hash_password_bcrypt_case_5_type_validation() -> None:
+    """
+    Test case 11: Type validation for all parameters.
+    """
+    # Test invalid password type
+    with pytest.raises(TypeError, match="password must be a string"):
+        hash_password_bcrypt(123)
+
+    # Test invalid rounds type
+    with pytest.raises(TypeError, match="rounds must be an integer"):
+        hash_password_bcrypt("password", rounds="invalid")
+
+
+def test_hash_password_bcrypt_case_6_value_validation() -> None:
+    """
+    Test case 12: Value validation for parameters.
+    """
+    # Test empty password
+    with pytest.raises(ValueError, match="password cannot be empty"):
+        hash_password_bcrypt("")
+
+    # Test rounds too low
+    with pytest.raises(ValueError, match="rounds must be between 4 and 31"):
+        hash_password_bcrypt("password", rounds=3)
+
+    # Test rounds too high
+    with pytest.raises(ValueError, match="rounds must be between 4 and 31"):
+        hash_password_bcrypt("password", rounds=32)

--- a/pytest/unit/security_functions/password_hashing/test_hash_password_pbkdf2.py
+++ b/pytest/unit/security_functions/password_hashing/test_hash_password_pbkdf2.py
@@ -57,39 +57,9 @@ def test_hash_password_pbkdf2_case_3_custom_iterations() -> None:
     assert len(salt) == 32
 
 
-def test_hash_password_pbkdf2_case_4_type_validation() -> None:
-    """
-    Test case 4: Type validation for all parameters.
-    """
-    # Test invalid password type
-    with pytest.raises(TypeError, match="password must be a string"):
-        hash_password_pbkdf2(123)
-
-    # Test invalid salt type
-    with pytest.raises(TypeError, match="salt must be bytes or None"):
-        hash_password_pbkdf2("password", salt="invalid")
-
-    # Test invalid iterations type
-    with pytest.raises(TypeError, match="iterations must be an integer"):
-        hash_password_pbkdf2("password", iterations="invalid")
-
-
-def test_hash_password_pbkdf2_case_5_value_validation() -> None:
-    """
-    Test case 5: Value validation for parameters.
-    """
-    # Test empty password
-    with pytest.raises(ValueError, match="password cannot be empty"):
-        hash_password_pbkdf2("")
-
-    # Test too few iterations
-    with pytest.raises(ValueError, match="iterations must be at least 1000"):
-        hash_password_pbkdf2("password", iterations=500)
-
-
 def test_hash_password_pbkdf2_case_6_deterministic_with_same_salt() -> None:
     """
-    Test case 6: Same password and salt should produce same hash.
+    Test case 4: Same password and salt should produce same hash.
     """
     # Arrange
     password = "consistent_password"
@@ -105,7 +75,7 @@ def test_hash_password_pbkdf2_case_6_deterministic_with_same_salt() -> None:
 
 def test_hash_password_pbkdf2_case_7_different_passwords_different_hashes() -> None:
     """
-    Test case 7: Different passwords should produce different hashes.
+    Test case 5: Different passwords should produce different hashes.
     """
     # Arrange
     password1 = "password1"
@@ -122,7 +92,7 @@ def test_hash_password_pbkdf2_case_7_different_passwords_different_hashes() -> N
 
 def test_hash_password_pbkdf2_case_8_random_salt_generation() -> None:
     """
-    Test case 8: Random salt generation produces different salts.
+    Test case 6: Random salt generation produces different salts.
     """
     # Arrange
     password = "same_password"
@@ -139,7 +109,7 @@ def test_hash_password_pbkdf2_case_8_random_salt_generation() -> None:
 
 def test_hash_password_pbkdf2_case_9_unicode_password() -> None:
     """
-    Test case 9: Handle Unicode characters in password.
+    Test case 7: Handle Unicode characters in password.
     """
     # Arrange
     password = "pássw0rd_with_ümläuts_🔐"
@@ -156,7 +126,7 @@ def test_hash_password_pbkdf2_case_9_unicode_password() -> None:
 
 def test_hash_password_pbkdf2_case_10_boundary_iterations() -> None:
     """
-    Test case 10: Test boundary values for iterations.
+    Test case 8: Test boundary values for iterations.
     """
     # Arrange
     password = "test_password"
@@ -168,3 +138,31 @@ def test_hash_password_pbkdf2_case_10_boundary_iterations() -> None:
     # Test high iterations
     hashed_high, salt_high = hash_password_pbkdf2(password, iterations=200000)
     assert len(hashed_high) == 64
+def test_hash_password_pbkdf2_case_4_type_validation() -> None:
+    """
+    Test case 9: Type validation for all parameters.
+    """
+    # Test invalid password type
+    with pytest.raises(TypeError, match="password must be a string"):
+        hash_password_pbkdf2(123)
+
+    # Test invalid salt type
+    with pytest.raises(TypeError, match="salt must be bytes or None"):
+        hash_password_pbkdf2("password", salt="invalid")
+
+    # Test invalid iterations type
+    with pytest.raises(TypeError, match="iterations must be an integer"):
+        hash_password_pbkdf2("password", iterations="invalid")
+
+
+def test_hash_password_pbkdf2_case_5_value_validation() -> None:
+    """
+    Test case 10: Value validation for parameters.
+    """
+    # Test empty password
+    with pytest.raises(ValueError, match="password cannot be empty"):
+        hash_password_pbkdf2("")
+
+    # Test too few iterations
+    with pytest.raises(ValueError, match="iterations must be at least 1000"):
+        hash_password_pbkdf2("password", iterations=500)

--- a/pytest/unit/security_functions/password_hashing/test_verify_password_bcrypt.py
+++ b/pytest/unit/security_functions/password_hashing/test_verify_password_bcrypt.py
@@ -54,56 +54,9 @@ def test_verify_password_bcrypt_case_3_different_rounds() -> None:
     assert result is True
 
 
-def test_verify_password_bcrypt_case_4_type_validation() -> None:
-    """
-    Test case 4: Type validation for all parameters.
-    """
-    hashed = hash_password_bcrypt("password")
-
-    # Test invalid password type
-    with pytest.raises(TypeError, match="password must be a string"):
-        verify_password_bcrypt(123, hashed)
-
-    # Test invalid hashed_password type
-    with pytest.raises(TypeError, match="hashed_password must be a string"):
-        verify_password_bcrypt("password", 123)
-
-
-def test_verify_password_bcrypt_case_5_value_validation() -> None:
-    """
-    Test case 5: Value validation for parameters.
-    """
-    hashed = hash_password_bcrypt("password")
-
-    # Test empty password
-    with pytest.raises(ValueError, match="password cannot be empty"):
-        verify_password_bcrypt("", hashed)
-
-    # Test empty hashed_password
-    with pytest.raises(ValueError, match="hashed_password cannot be empty"):
-        verify_password_bcrypt("password", "")
-
-
-def test_verify_password_bcrypt_case_6_invalid_hash_format() -> None:
-    """
-    Test case 6: Invalid bcrypt hash format should raise ValueError.
-    """
-    # Test invalid bcrypt identifier
-    with pytest.raises(
-        ValueError, match="Invalid bcrypt hash format"
-    ):
-        verify_password_bcrypt("password", "$1$invalid_hash_format_here")
-
-    # Test wrong length
-    with pytest.raises(
-        ValueError, match="hashed_password must be exactly 60 characters"
-    ):
-        verify_password_bcrypt("password", "$2b$12$short")
-
-
 def test_verify_password_bcrypt_case_7_case_sensitive() -> None:
     """
-    Test case 7: Password verification should be case sensitive.
+    Test case 4: Password verification should be case sensitive.
     """
     # Arrange
     password = "CaseSensitive"
@@ -120,7 +73,7 @@ def test_verify_password_bcrypt_case_7_case_sensitive() -> None:
 
 def test_verify_password_bcrypt_case_8_unicode_password() -> None:
     """
-    Test case 8: Handle Unicode characters in password verification.
+    Test case 5: Handle Unicode characters in password verification.
     """
     # Arrange
     password = "pássw0rd_with_ümläuts_🔐"
@@ -137,7 +90,7 @@ def test_verify_password_bcrypt_case_8_unicode_password() -> None:
 
 def test_verify_password_bcrypt_case_9_special_characters() -> None:
     """
-    Test case 9: Handle special characters in password verification.
+    Test case 6: Handle special characters in password verification.
     """
     # Arrange
     password = "!@#$%^&*()_+-=[]{}|;':\",./<>?`~"
@@ -152,7 +105,7 @@ def test_verify_password_bcrypt_case_9_special_characters() -> None:
 
 def test_verify_password_bcrypt_case_10_long_password() -> None:
     """
-    Test case 10: Handle very long password verification.
+    Test case 7: Handle very long password verification.
     """
     # Arrange
     password = "a" * 1000  # Very long password
@@ -165,20 +118,9 @@ def test_verify_password_bcrypt_case_10_long_password() -> None:
     assert result is True
 
 
-def test_verify_password_bcrypt_case_11_malformed_hash() -> None:
-    """
-    Test case 11: Malformed hash should raise ValueError.
-    """
-    # Test completely invalid hash
-    with pytest.raises(ValueError, match="Invalid bcrypt hash format"):
-        verify_password_bcrypt(
-            "password", "completely_invalid_hash_string_that_is_60_chars_long_x"
-        )
-
-
 def test_verify_password_bcrypt_case_12_timing_attack_resistance() -> None:
     """
-    Test case 12: Verify that function handles invalid hashes gracefully.
+    Test case 8: Verify that function handles invalid hashes gracefully.
     """
     # Arrange
     password = "test_password"
@@ -194,3 +136,59 @@ def test_verify_password_bcrypt_case_12_timing_attack_resistance() -> None:
     for invalid_hash in invalid_hashes:
         result = verify_password_bcrypt(password, invalid_hash)
         assert result is False  # Should return False, not raise exception
+def test_verify_password_bcrypt_case_4_type_validation() -> None:
+    """
+    Test case 9: Type validation for all parameters.
+    """
+    hashed = hash_password_bcrypt("password")
+
+    # Test invalid password type
+    with pytest.raises(TypeError, match="password must be a string"):
+        verify_password_bcrypt(123, hashed)
+
+    # Test invalid hashed_password type
+    with pytest.raises(TypeError, match="hashed_password must be a string"):
+        verify_password_bcrypt("password", 123)
+
+
+def test_verify_password_bcrypt_case_5_value_validation() -> None:
+    """
+    Test case 10: Value validation for parameters.
+    """
+    hashed = hash_password_bcrypt("password")
+
+    # Test empty password
+    with pytest.raises(ValueError, match="password cannot be empty"):
+        verify_password_bcrypt("", hashed)
+
+    # Test empty hashed_password
+    with pytest.raises(ValueError, match="hashed_password cannot be empty"):
+        verify_password_bcrypt("password", "")
+
+
+def test_verify_password_bcrypt_case_6_invalid_hash_format() -> None:
+    """
+    Test case 11: Invalid bcrypt hash format should raise ValueError.
+    """
+    # Test invalid bcrypt identifier
+    with pytest.raises(
+        ValueError, match="Invalid bcrypt hash format"
+    ):
+        verify_password_bcrypt("password", "$1$invalid_hash_format_here")
+
+    # Test wrong length
+    with pytest.raises(
+        ValueError, match="hashed_password must be exactly 60 characters"
+    ):
+        verify_password_bcrypt("password", "$2b$12$short")
+
+
+def test_verify_password_bcrypt_case_11_malformed_hash() -> None:
+    """
+    Test case 12: Malformed hash should raise ValueError.
+    """
+    # Test completely invalid hash
+    with pytest.raises(ValueError, match="Invalid bcrypt hash format"):
+        verify_password_bcrypt(
+            "password", "completely_invalid_hash_string_that_is_60_chars_long_x"
+        )

--- a/pytest/unit/security_functions/password_hashing/test_verify_password_pbkdf2.py
+++ b/pytest/unit/security_functions/password_hashing/test_verify_password_pbkdf2.py
@@ -54,9 +54,73 @@ def test_verify_password_pbkdf2_case_3_custom_iterations() -> None:
     assert result is True
 
 
+def test_verify_password_pbkdf2_case_7_different_iterations() -> None:
+    """
+    Test case 4: Verification fails with different iteration count.
+    """
+    # Arrange
+    password = "test_password"
+    hashed, salt = hash_password_pbkdf2(password, iterations=10000)
+
+    # Act
+    result = verify_password_pbkdf2(password, hashed, salt, iterations=20000)
+
+    # Assert
+    assert result is False
+
+
+def test_verify_password_pbkdf2_case_8_unicode_password() -> None:
+    """
+    Test case 5: Handle Unicode characters in password verification.
+    """
+    # Arrange
+    password = "pássw0rd_with_ümläuts_🔐"
+    hashed, salt = hash_password_pbkdf2(password)
+
+    # Act
+    result = verify_password_pbkdf2(password, hashed, salt)
+
+    # Assert
+    assert result is True
+
+
+def test_verify_password_pbkdf2_case_9_case_sensitive() -> None:
+    """
+    Test case 6: Password verification is case sensitive.
+    """
+    # Arrange
+    password = "CaseSensitivePassword"
+    hashed, salt = hash_password_pbkdf2(password)
+    wrong_case = "casesensitivepassword"
+
+    # Act
+    result_correct = verify_password_pbkdf2(password, hashed, salt)
+    result_wrong_case = verify_password_pbkdf2(wrong_case, hashed, salt)
+
+    # Assert
+    assert result_correct is True
+    assert result_wrong_case is False
+
+
+def test_verify_password_pbkdf2_case_10_edge_case_similar_passwords() -> None:
+    """
+    Test case 7: Verification with very similar but different passwords.
+    """
+    # Arrange
+    password1 = "password123"
+    password2 = "password124"  # Only last character different
+    hashed, salt = hash_password_pbkdf2(password1)
+
+    # Act
+    result1 = verify_password_pbkdf2(password1, hashed, salt)
+    result2 = verify_password_pbkdf2(password2, hashed, salt)
+
+    # Assert
+    assert result1 is True
+    assert result2 is False
 def test_verify_password_pbkdf2_case_4_type_validation() -> None:
     """
-    Test case 4: Type validation for all parameters.
+    Test case 8: Type validation for all parameters.
     """
     # Arrange
     hashed, salt = hash_password_pbkdf2("password")
@@ -80,7 +144,7 @@ def test_verify_password_pbkdf2_case_4_type_validation() -> None:
 
 def test_verify_password_pbkdf2_case_5_value_validation() -> None:
     """
-    Test case 5: Value validation for parameters.
+    Test case 9: Value validation for parameters.
     """
     # Arrange
     hashed, salt = hash_password_pbkdf2("password")
@@ -104,7 +168,7 @@ def test_verify_password_pbkdf2_case_5_value_validation() -> None:
 
 def test_verify_password_pbkdf2_case_6_invalid_hex_format() -> None:
     """
-    Test case 6: Invalid hex format in hashed_password.
+    Test case 10: Invalid hex format in hashed_password.
     """
     # Arrange
     password = "test_password"
@@ -114,69 +178,3 @@ def test_verify_password_pbkdf2_case_6_invalid_hex_format() -> None:
     # Act & Assert
     with pytest.raises(ValueError, match="hashed_password must be a valid hex string"):
         verify_password_pbkdf2(password, invalid_hex, salt)
-
-
-def test_verify_password_pbkdf2_case_7_different_iterations() -> None:
-    """
-    Test case 7: Verification fails with different iteration count.
-    """
-    # Arrange
-    password = "test_password"
-    hashed, salt = hash_password_pbkdf2(password, iterations=10000)
-
-    # Act
-    result = verify_password_pbkdf2(password, hashed, salt, iterations=20000)
-
-    # Assert
-    assert result is False
-
-
-def test_verify_password_pbkdf2_case_8_unicode_password() -> None:
-    """
-    Test case 8: Handle Unicode characters in password verification.
-    """
-    # Arrange
-    password = "pássw0rd_with_ümläuts_🔐"
-    hashed, salt = hash_password_pbkdf2(password)
-
-    # Act
-    result = verify_password_pbkdf2(password, hashed, salt)
-
-    # Assert
-    assert result is True
-
-
-def test_verify_password_pbkdf2_case_9_case_sensitive() -> None:
-    """
-    Test case 9: Password verification is case sensitive.
-    """
-    # Arrange
-    password = "CaseSensitivePassword"
-    hashed, salt = hash_password_pbkdf2(password)
-    wrong_case = "casesensitivepassword"
-
-    # Act
-    result_correct = verify_password_pbkdf2(password, hashed, salt)
-    result_wrong_case = verify_password_pbkdf2(wrong_case, hashed, salt)
-
-    # Assert
-    assert result_correct is True
-    assert result_wrong_case is False
-
-
-def test_verify_password_pbkdf2_case_10_edge_case_similar_passwords() -> None:
-    """
-    Test case 10: Verification with very similar but different passwords.
-    """
-    # Arrange
-    password1 = "password123"
-    password2 = "password124"  # Only last character different
-    hashed, salt = hash_password_pbkdf2(password1)
-
-    # Act
-    result1 = verify_password_pbkdf2(password1, hashed, salt)
-    result2 = verify_password_pbkdf2(password2, hashed, salt)
-
-    # Assert
-    assert result1 is True
-    assert result2 is False

--- a/pytest/unit/security_functions/token_generation/test_generate_jwt_token.py
+++ b/pytest/unit/security_functions/token_generation/test_generate_jwt_token.py
@@ -101,42 +101,9 @@ def test_generate_jwt_token_case_3_complex_payload() -> None:
     assert decoded_payload["metadata"]["login_count"] == 5
 
 
-def test_generate_jwt_token_case_4_type_validation() -> None:
-    """
-    Test case 4: Type validation for all parameters.
-    """
-    # Test invalid payload type
-    with pytest.raises(TypeError, match="payload must be a dictionary"):
-        generate_jwt_token("invalid", "secret")
-
-    # Test invalid secret_key type
-    with pytest.raises(TypeError, match="secret_key must be a string"):
-        generate_jwt_token({}, 123)
-
-    # Test invalid expires_in_hours type
-    with pytest.raises(TypeError, match="expires_in_hours must be an integer"):
-        generate_jwt_token({}, "secret", "invalid")
-
-
-def test_generate_jwt_token_case_5_value_validation() -> None:
-    """
-    Test case 5: Value validation for parameters.
-    """
-    # Test empty secret_key
-    with pytest.raises(ValueError, match="secret_key cannot be empty"):
-        generate_jwt_token({"data": "test"}, "")
-
-    # Test non-positive expires_in_hours
-    with pytest.raises(ValueError, match="expires_in_hours must be positive"):
-        generate_jwt_token({"data": "test"}, "secret", 0)
-
-    with pytest.raises(ValueError, match="expires_in_hours must be positive"):
-        generate_jwt_token({"data": "test"}, "secret", -1)
-
-
 def test_generate_jwt_token_case_6_header_verification() -> None:
     """
-    Test case 6: Verify JWT header is correct.
+    Test case 4: Verify JWT header is correct.
     """
     # Arrange
     payload = {"test": "data"}
@@ -161,7 +128,7 @@ def test_generate_jwt_token_case_6_header_verification() -> None:
 
 def test_generate_jwt_token_case_7_empty_payload() -> None:
     """
-    Test case 7: Generate JWT token with empty payload.
+    Test case 5: Generate JWT token with empty payload.
     """
     # Arrange
     payload = {}
@@ -188,7 +155,7 @@ def test_generate_jwt_token_case_7_empty_payload() -> None:
 
 def test_generate_jwt_token_case_8_different_secrets_different_signatures() -> None:
     """
-    Test case 8: Different secrets should produce different signatures.
+    Test case 6: Different secrets should produce different signatures.
     """
     # Arrange
     payload = {"data": "same"}
@@ -211,7 +178,7 @@ def test_generate_jwt_token_case_8_different_secrets_different_signatures() -> N
 
 def test_generate_jwt_token_case_9_unicode_payload() -> None:
     """
-    Test case 9: Handle Unicode characters in payload.
+    Test case 7: Handle Unicode characters in payload.
     """
     # Arrange
     payload = {
@@ -243,7 +210,7 @@ def test_generate_jwt_token_case_9_unicode_payload() -> None:
 
 def test_generate_jwt_token_case_10_timestamp_validation() -> None:
     """
-    Test case 10: Verify iat and exp timestamps are reasonable.
+    Test case 8: Verify iat and exp timestamps are reasonable.
     """
     # Arrange
     payload = {"test": "timestamps"}
@@ -270,3 +237,34 @@ def test_generate_jwt_token_case_10_timestamp_validation() -> None:
     assert before_time <= iat <= after_time
     # exp should be approximately 1 hour after iat
     assert abs((exp - iat) - 3600) < 10  # Allow 10 second tolerance
+def test_generate_jwt_token_case_4_type_validation() -> None:
+    """
+    Test case 9: Type validation for all parameters.
+    """
+    # Test invalid payload type
+    with pytest.raises(TypeError, match="payload must be a dictionary"):
+        generate_jwt_token("invalid", "secret")
+
+    # Test invalid secret_key type
+    with pytest.raises(TypeError, match="secret_key must be a string"):
+        generate_jwt_token({}, 123)
+
+    # Test invalid expires_in_hours type
+    with pytest.raises(TypeError, match="expires_in_hours must be an integer"):
+        generate_jwt_token({}, "secret", "invalid")
+
+
+def test_generate_jwt_token_case_5_value_validation() -> None:
+    """
+    Test case 10: Value validation for parameters.
+    """
+    # Test empty secret_key
+    with pytest.raises(ValueError, match="secret_key cannot be empty"):
+        generate_jwt_token({"data": "test"}, "")
+
+    # Test non-positive expires_in_hours
+    with pytest.raises(ValueError, match="expires_in_hours must be positive"):
+        generate_jwt_token({"data": "test"}, "secret", 0)
+
+    with pytest.raises(ValueError, match="expires_in_hours must be positive"):
+        generate_jwt_token({"data": "test"}, "secret", -1)

--- a/pytest/unit/security_functions/token_generation/test_generate_secure_token.py
+++ b/pytest/unit/security_functions/token_generation/test_generate_secure_token.py
@@ -80,9 +80,70 @@ def test_generate_secure_token_case_5_with_symbols() -> None:
     assert has_letter or has_digit
 
 
+def test_generate_secure_token_case_8_randomness() -> None:
+    """
+    Test case 6: Generated tokens should be different (randomness).
+    """
+    # Act
+    token1 = generate_secure_token()
+    token2 = generate_secure_token()
+    token3 = generate_secure_token()
+
+    # Assert
+    assert token1 != token2
+    assert token2 != token3
+    assert token1 != token3
+
+
+def test_generate_secure_token_case_9_symbols_only() -> None:
+    """
+    Test case 7: Generate token with symbols only.
+    """
+    # Act
+    token = generate_secure_token(
+        length=20, include_letters=False, include_digits=False, include_symbols=True
+    )
+
+    # Assert
+    assert isinstance(token, str)
+    assert len(token) == 20
+    assert all(c in "!@#$%^&*-_=+[]{}|;:,.<>?" for c in token)
+
+
+def test_generate_secure_token_case_10_boundary_lengths() -> None:
+    """
+    Test case 8: Test boundary values for length.
+    """
+    # Test minimum length
+    token_min = generate_secure_token(length=1)
+    assert len(token_min) == 1
+
+    # Test large length
+    token_large = generate_secure_token(length=1000)
+    assert len(token_large) == 1000
+
+
+def test_generate_secure_token_case_11_all_character_types() -> None:
+    """
+    Test case 9: Generate token with all character types enabled.
+    """
+    # Act
+    token = generate_secure_token(
+        length=100,  # Larger length to increase chance of all types appearing
+        include_letters=True,
+        include_digits=True,
+        include_symbols=True,
+    )
+
+    # Assert
+    assert isinstance(token, str)
+    assert len(token) == 100
+    # Check character set validity
+    valid_chars = string.ascii_letters + string.digits + "!@#$%^&*-_=+[]{}|;:,.<>?"
+    assert all(c in valid_chars for c in token)
 def test_generate_secure_token_case_6_type_validation() -> None:
     """
-    Test case 6: Type validation for all parameters.
+    Test case 10: Type validation for all parameters.
     """
     # Test invalid length type
     with pytest.raises(TypeError, match="length must be an integer"):
@@ -103,7 +164,7 @@ def test_generate_secure_token_case_6_type_validation() -> None:
 
 def test_generate_secure_token_case_7_value_validation() -> None:
     """
-    Test case 7: Value validation for parameters.
+    Test case 11: Value validation for parameters.
     """
     # Test length less than 1
     with pytest.raises(ValueError, match="length must be at least 1"):
@@ -116,66 +177,3 @@ def test_generate_secure_token_case_7_value_validation() -> None:
         generate_secure_token(
             include_letters=False, include_digits=False, include_symbols=False
         )
-
-
-def test_generate_secure_token_case_8_randomness() -> None:
-    """
-    Test case 8: Generated tokens should be different (randomness).
-    """
-    # Act
-    token1 = generate_secure_token()
-    token2 = generate_secure_token()
-    token3 = generate_secure_token()
-
-    # Assert
-    assert token1 != token2
-    assert token2 != token3
-    assert token1 != token3
-
-
-def test_generate_secure_token_case_9_symbols_only() -> None:
-    """
-    Test case 9: Generate token with symbols only.
-    """
-    # Act
-    token = generate_secure_token(
-        length=20, include_letters=False, include_digits=False, include_symbols=True
-    )
-
-    # Assert
-    assert isinstance(token, str)
-    assert len(token) == 20
-    assert all(c in "!@#$%^&*-_=+[]{}|;:,.<>?" for c in token)
-
-
-def test_generate_secure_token_case_10_boundary_lengths() -> None:
-    """
-    Test case 10: Test boundary values for length.
-    """
-    # Test minimum length
-    token_min = generate_secure_token(length=1)
-    assert len(token_min) == 1
-
-    # Test large length
-    token_large = generate_secure_token(length=1000)
-    assert len(token_large) == 1000
-
-
-def test_generate_secure_token_case_11_all_character_types() -> None:
-    """
-    Test case 11: Generate token with all character types enabled.
-    """
-    # Act
-    token = generate_secure_token(
-        length=100,  # Larger length to increase chance of all types appearing
-        include_letters=True,
-        include_digits=True,
-        include_symbols=True,
-    )
-
-    # Assert
-    assert isinstance(token, str)
-    assert len(token) == 100
-    # Check character set validity
-    valid_chars = string.ascii_letters + string.digits + "!@#$%^&*-_=+[]{}|;:,.<>?"
-    assert all(c in valid_chars for c in token)

--- a/pytest/unit/security_functions/token_generation/test_generate_url_safe_token.py
+++ b/pytest/unit/security_functions/token_generation/test_generate_url_safe_token.py
@@ -65,30 +65,9 @@ def test_generate_url_safe_token_case_4_long_length() -> None:
     assert all(c.isalnum() or c in "-_" for c in token)
 
 
-def test_generate_url_safe_token_case_5_type_validation() -> None:
-    """
-    Test case 5: Type validation for length parameter.
-    """
-    # Test invalid length type
-    with pytest.raises(TypeError, match="length must be an integer"):
-        generate_url_safe_token(length="invalid")
-
-
-def test_generate_url_safe_token_case_6_value_validation() -> None:
-    """
-    Test case 6: Value validation for length parameter.
-    """
-    # Test length less than 1
-    with pytest.raises(ValueError, match="length must be at least 1"):
-        generate_url_safe_token(length=0)
-
-    with pytest.raises(ValueError, match="length must be at least 1"):
-        generate_url_safe_token(length=-1)
-
-
 def test_generate_url_safe_token_case_7_randomness() -> None:
     """
-    Test case 7: Generated tokens should be different (randomness).
+    Test case 5: Generated tokens should be different (randomness).
     """
     # Act
     token1 = generate_url_safe_token()
@@ -103,7 +82,7 @@ def test_generate_url_safe_token_case_7_randomness() -> None:
 
 def test_generate_url_safe_token_case_8_url_safe_characters() -> None:
     """
-    Test case 8: Verify only URL-safe characters are used.
+    Test case 6: Verify only URL-safe characters are used.
     """
     # Act
     token = generate_url_safe_token(length=100)  # Larger token for better coverage
@@ -120,7 +99,7 @@ def test_generate_url_safe_token_case_8_url_safe_characters() -> None:
 
 def test_generate_url_safe_token_case_9_no_padding() -> None:
     """
-    Test case 9: Verify that no base64 padding characters are present.
+    Test case 7: Verify that no base64 padding characters are present.
     """
     # Act
     token = generate_url_safe_token(length=50)
@@ -132,7 +111,7 @@ def test_generate_url_safe_token_case_9_no_padding() -> None:
 
 def test_generate_url_safe_token_case_10_minimum_length() -> None:
     """
-    Test case 10: Test minimum valid length.
+    Test case 8: Test minimum valid length.
     """
     # Act
     token = generate_url_safe_token(length=1)
@@ -145,7 +124,7 @@ def test_generate_url_safe_token_case_10_minimum_length() -> None:
 
 def test_generate_url_safe_token_case_11_consistent_character_set() -> None:
     """
-    Test case 11: Verify consistent character set across multiple generations.
+    Test case 9: Verify consistent character set across multiple generations.
     """
     # Act - Generate multiple tokens
     tokens = [generate_url_safe_token(length=50) for _ in range(10)]
@@ -164,7 +143,7 @@ def test_generate_url_safe_token_case_11_consistent_character_set() -> None:
 
 def test_generate_url_safe_token_case_12_base64_properties() -> None:
     """
-    Test case 12: Verify properties inherited from base64 encoding.
+    Test case 10: Verify properties inherited from base64 encoding.
     """
     # Act
     token = generate_url_safe_token(length=32)
@@ -176,3 +155,22 @@ def test_generate_url_safe_token_case_12_base64_properties() -> None:
     # Should not contain characters that need URL encoding
     forbidden_chars = set("+/=")  # Standard base64 chars that are not URL-safe
     assert not any(char in forbidden_chars for char in token)
+def test_generate_url_safe_token_case_5_type_validation() -> None:
+    """
+    Test case 11: Type validation for length parameter.
+    """
+    # Test invalid length type
+    with pytest.raises(TypeError, match="length must be an integer"):
+        generate_url_safe_token(length="invalid")
+
+
+def test_generate_url_safe_token_case_6_value_validation() -> None:
+    """
+    Test case 12: Value validation for length parameter.
+    """
+    # Test length less than 1
+    with pytest.raises(ValueError, match="length must be at least 1"):
+        generate_url_safe_token(length=0)
+
+    with pytest.raises(ValueError, match="length must be at least 1"):
+        generate_url_safe_token(length=-1)

--- a/pytest/unit/ssh_functions/test_ssh_check_connection.py
+++ b/pytest/unit/ssh_functions/test_ssh_check_connection.py
@@ -28,25 +28,9 @@ def test_ssh_check_connection_empty_user() -> None:
         assert result["success"] is True
 
 
-def test_ssh_check_connection_type_error_host() -> None:
-    """
-    Test case 3: TypeError for invalid host type.
-    """
-    with pytest.raises(TypeError, match="host must be a string"):
-        ssh_check_connection(123)
-
-
-def test_ssh_check_connection_value_error_port() -> None:
-    """
-    Test case 4: ValueError for invalid port value.
-    """
-    with pytest.raises(ValueError, match="port must be in 1-65535"):
-        ssh_check_connection("host", port=70000)
-
-
 def test_ssh_check_connection_boundary_conditions_port() -> None:
     """
-    Test case 5: Boundary conditions for port.
+    Test case 3: Boundary conditions for port.
     """
     with patch("subprocess.run") as mock_run:
         mock_run.return_value.stdout = ""
@@ -56,6 +40,22 @@ def test_ssh_check_connection_boundary_conditions_port() -> None:
         result_max = ssh_check_connection("host", port=65535)
         assert result_min["success"] is True
         assert result_max["success"] is True
+
+
+def test_ssh_check_connection_type_error_host() -> None:
+    """
+    Test case 4: TypeError for invalid host type.
+    """
+    with pytest.raises(TypeError, match="host must be a string"):
+        ssh_check_connection(123)
+
+
+def test_ssh_check_connection_value_error_port() -> None:
+    """
+    Test case 5: ValueError for invalid port value.
+    """
+    with pytest.raises(ValueError, match="port must be in 1-65535"):
+        ssh_check_connection("host", port=70000)
 
 
 def test_ssh_check_connection_timeout_error() -> None:

--- a/pytest/unit/ssh_functions/test_ssh_copy_file.py
+++ b/pytest/unit/ssh_functions/test_ssh_copy_file.py
@@ -30,25 +30,9 @@ def test_ssh_copy_file_case_2_edge_case_empty_file() -> None:
         assert result["exit_code"] == 0
 
 
-def test_ssh_copy_file_case_3_type_error_local_path() -> None:
-    """
-    Test case 3: TypeError for invalid local_path type.
-    """
-    with pytest.raises(TypeError, match="local_path must be a string"):
-        ssh_copy_file(123, "/tmp/file.txt", "host")
-
-
-def test_ssh_copy_file_case_4_value_error_port() -> None:
-    """
-    Test case 4: ValueError for invalid port value.
-    """
-    with pytest.raises(ValueError, match="port must be in 1-65535"):
-        ssh_copy_file("file.txt", "/tmp/file.txt", "host", port=70000)
-
-
 def test_ssh_copy_file_case_5_boundary_conditions() -> None:
     """
-    Test case 5: Boundary conditions for port.
+    Test case 3: Boundary conditions for port.
     """
     with patch("subprocess.run") as mock_run:
         mock_run.return_value.stdout = ""
@@ -58,6 +42,22 @@ def test_ssh_copy_file_case_5_boundary_conditions() -> None:
         result_max = ssh_copy_file("file.txt", "/tmp/file.txt", "host", port=65535)
         assert result_min["exit_code"] == 0
         assert result_max["exit_code"] == 0
+
+
+def test_ssh_copy_file_case_3_type_error_local_path() -> None:
+    """
+    Test case 4: TypeError for invalid local_path type.
+    """
+    with pytest.raises(TypeError, match="local_path must be a string"):
+        ssh_copy_file(123, "/tmp/file.txt", "host")
+
+
+def test_ssh_copy_file_case_4_value_error_port() -> None:
+    """
+    Test case 5: ValueError for invalid port value.
+    """
+    with pytest.raises(ValueError, match="port must be in 1-65535"):
+        ssh_copy_file("file.txt", "/tmp/file.txt", "host", port=70000)
 
 
 def test_ssh_copy_file_case_6_timeout_error() -> None:

--- a/pytest/unit/ssh_functions/test_ssh_execute_command.py
+++ b/pytest/unit/ssh_functions/test_ssh_execute_command.py
@@ -30,25 +30,9 @@ def test_ssh_execute_command_case_2_edge_case_empty_command() -> None:
         assert result == {"stdout": "", "stderr": "", "exit_code": 0}
 
 
-def test_ssh_execute_command_case_3_type_error_host() -> None:
-    """
-    Test case 3: TypeError for invalid host type.
-    """
-    with pytest.raises(TypeError, match="host must be a string"):
-        ssh_execute_command(123, "ls")
-
-
-def test_ssh_execute_command_case_4_value_error_port() -> None:
-    """
-    Test case 4: ValueError for invalid port value.
-    """
-    with pytest.raises(ValueError, match="port must be in 1-65535"):
-        ssh_execute_command("host", "ls", port=70000)
-
-
 def test_ssh_execute_command_case_5_boundary_conditions() -> None:
     """
-    Test case 5: Boundary conditions for port.
+    Test case 3: Boundary conditions for port.
     """
     with patch("subprocess.run") as mock_run:
         mock_run.return_value.stdout = "ok"
@@ -58,6 +42,22 @@ def test_ssh_execute_command_case_5_boundary_conditions() -> None:
         result_max = ssh_execute_command("host", "ls", port=65535)
         assert result_min["exit_code"] == 0
         assert result_max["exit_code"] == 0
+
+
+def test_ssh_execute_command_case_3_type_error_host() -> None:
+    """
+    Test case 4: TypeError for invalid host type.
+    """
+    with pytest.raises(TypeError, match="host must be a string"):
+        ssh_execute_command(123, "ls")
+
+
+def test_ssh_execute_command_case_4_value_error_port() -> None:
+    """
+    Test case 5: ValueError for invalid port value.
+    """
+    with pytest.raises(ValueError, match="port must be in 1-65535"):
+        ssh_execute_command("host", "ls", port=70000)
 
 
 def test_ssh_execute_command_case_6_timeout_error() -> None:

--- a/pytest/unit/strings_utility/test_repeat_string.py
+++ b/pytest/unit/strings_utility/test_repeat_string.py
@@ -25,24 +25,16 @@ def test_repeat_string_zero_times() -> None:
     assert repeat_string("hello", 0) == "", "Failed on repeating string zero times"
 
 
-def test_repeat_string_negative_times() -> None:
-    """
-    Test case 4: Test the repeat_string function with a string repeated negative times.
-    """
-    with pytest.raises(ValueError):
-        repeat_string("hello", -1)
-
-
 def test_repeat_string_empty_string() -> None:
     """
-    Test case 5: Test the repeat_string function with an empty string.
+    Test case 4: Test the repeat_string function with an empty string.
     """
     assert repeat_string("", 5) == "", "Failed on repeating empty string"
 
 
 def test_repeat_string_special_characters() -> None:
     """
-    Test case 6: Test the repeat_string function with a string that contains special characters.
+    Test case 5: Test the repeat_string function with a string that contains special characters.
     """
     assert repeat_string("!@#", 3) == "!@#!@#!@#", (
         "Failed on repeating string with special characters"
@@ -51,7 +43,7 @@ def test_repeat_string_special_characters() -> None:
 
 def test_repeat_string_numbers() -> None:
     """
-    Test case 7: Test the repeat_string function with a string that contains numbers.
+    Test case 6: Test the repeat_string function with a string that contains numbers.
     """
     assert repeat_string("123", 2) == "123123", (
         "Failed on repeating string with numbers"
@@ -60,7 +52,7 @@ def test_repeat_string_numbers() -> None:
 
 def test_repeat_string_mixed_case() -> None:
     """
-    Test case 8: Test the repeat_string function with a string that contains mixed case letters.
+    Test case 7: Test the repeat_string function with a string that contains mixed case letters.
     """
     assert repeat_string("AbC", 2) == "AbCAbC", (
         "Failed on repeating string with mixed case letters"
@@ -69,7 +61,7 @@ def test_repeat_string_mixed_case() -> None:
 
 def test_repeat_string_whitespace_characters() -> None:
     """
-    Test case 9: Test the repeat_string function with a string that contains whitespace characters.
+    Test case 8: Test the repeat_string function with a string that contains whitespace characters.
     """
     assert repeat_string("a b", 3) == "a ba ba b", (
         "Failed on repeating string with whitespace characters"
@@ -78,7 +70,7 @@ def test_repeat_string_whitespace_characters() -> None:
 
 def test_repeat_string_newline_characters() -> None:
     """
-    Test case 10: Test the repeat_string function with a string that contains newline characters.
+    Test case 9: Test the repeat_string function with a string that contains newline characters.
     """
     assert repeat_string("a\nb", 2) == "a\nba\nb", (
         "Failed on repeating string with newline characters"
@@ -87,7 +79,7 @@ def test_repeat_string_newline_characters() -> None:
 
 def test_repeat_string_tab_characters() -> None:
     """
-    Test case 11: Test the repeat_string function with a string that contains tab characters.
+    Test case 10: Test the repeat_string function with a string that contains tab characters.
     """
     assert repeat_string("a\tb", 2) == "a\tba\tb", (
         "Failed on repeating string with tab characters"
@@ -96,7 +88,7 @@ def test_repeat_string_tab_characters() -> None:
 
 def test_repeat_string_mixed_whitespace_characters() -> None:
     """
-    Test case 12: Test the repeat_string function with a string that contains mixed whitespace characters.
+    Test case 11: Test the repeat_string function with a string that contains mixed whitespace characters.
     """
     assert repeat_string("a \t\nb", 2) == "a \t\nba \t\nb", (
         "Failed on repeating string with mixed whitespace characters"
@@ -105,11 +97,19 @@ def test_repeat_string_mixed_whitespace_characters() -> None:
 
 def test_repeat_string_non_english_characters() -> None:
     """
-    Test case 13: Test the repeat_string function with a string that contains non-English characters.
+    Test case 12: Test the repeat_string function with a string that contains non-English characters.
     """
     assert repeat_string("héllo", 2) == "héllohéllo", (
         "Failed on repeating string with non-English characters"
     )
+
+
+def test_repeat_string_negative_times() -> None:
+    """
+    Test case 13: Test the repeat_string function with a string repeated negative times.
+    """
+    with pytest.raises(ValueError):
+        repeat_string("hello", -1)
 
 
 def test_repeat_string_invalid_string_type() -> None:


### PR DESCRIPTION
## Summary
- reorder unit test functions so that assertions expecting exceptions follow the non-error scenarios in each module
- renumber the "Test case" docstrings to stay sequential after the new ordering

## Testing
- pytest -q *(fails: ModuleNotFoundError for data_types.avl_node and related modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e93a3fba648325a3932440076c9f2b