### PR TITLE
Remove module docstrings from unit tests

### DIFF
--- a/pytest/unit/asyncio_functions/test_async_await_with_error_handling.py
+++ b/pytest/unit/asyncio_functions/test_async_await_with_error_handling.py
@@ -1,5 +1,3 @@
-"""Unit tests for async_await_with_error_handling function."""
-
 import pytest
 from asyncio_functions.async_await_with_error_handling import (
     async_await_with_error_handling,

--- a/pytest/unit/asyncio_functions/test_async_batch.py
+++ b/pytest/unit/asyncio_functions/test_async_batch.py
@@ -1,5 +1,3 @@
-"""Unit tests for async_batch function."""
-
 import asyncio
 
 import pytest

--- a/pytest/unit/asyncio_functions/test_async_chain.py
+++ b/pytest/unit/asyncio_functions/test_async_chain.py
@@ -1,5 +1,3 @@
-"""Unit tests for async_chain function."""
-
 import asyncio
 
 import pytest

--- a/pytest/unit/asyncio_functions/test_async_cleanup.py
+++ b/pytest/unit/asyncio_functions/test_async_cleanup.py
@@ -1,5 +1,3 @@
-"""Unit tests for async_cleanup function."""
-
 import asyncio
 
 import pytest

--- a/pytest/unit/asyncio_functions/test_async_connection_pool.py
+++ b/pytest/unit/asyncio_functions/test_async_connection_pool.py
@@ -1,5 +1,3 @@
-"""Unit tests for AsyncConnectionPool class and use_connection function."""
-
 import asyncio
 
 import pytest

--- a/pytest/unit/asyncio_functions/test_async_event_loop.py
+++ b/pytest/unit/asyncio_functions/test_async_event_loop.py
@@ -1,5 +1,3 @@
-"""Unit tests for async_event_loop function."""
-
 import asyncio
 
 import pytest

--- a/pytest/unit/asyncio_functions/test_async_periodic.py
+++ b/pytest/unit/asyncio_functions/test_async_periodic.py
@@ -1,5 +1,3 @@
-"""Unit tests for async_periodic function."""
-
 import asyncio
 
 import pytest

--- a/pytest/unit/asyncio_functions/test_async_retry_with_backoff.py
+++ b/pytest/unit/asyncio_functions/test_async_retry_with_backoff.py
@@ -1,5 +1,3 @@
-"""Unit tests for async_retry_with_backoff function."""
-
 import asyncio
 
 import pytest

--- a/pytest/unit/asyncio_functions/test_async_stream_processor.py
+++ b/pytest/unit/asyncio_functions/test_async_stream_processor.py
@@ -1,5 +1,3 @@
-"""Unit tests for async_stream_processor function."""
-
 from collections.abc import AsyncIterator
 
 import pytest

--- a/pytest/unit/asyncio_functions/test_async_throttle.py
+++ b/pytest/unit/asyncio_functions/test_async_throttle.py
@@ -1,5 +1,3 @@
-"""Unit tests for async_throttle function."""
-
 import asyncio
 from collections.abc import AsyncGenerator
 

--- a/pytest/unit/asyncio_functions/test_fetch_multiple_urls.py
+++ b/pytest/unit/asyncio_functions/test_fetch_multiple_urls.py
@@ -1,5 +1,3 @@
-"""Unit tests for fetch_multiple_urls function."""
-
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/pytest/unit/asyncio_functions/test_fetch_url.py
+++ b/pytest/unit/asyncio_functions/test_fetch_url.py
@@ -1,5 +1,3 @@
-"""Unit tests for fetch_url function."""
-
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest

--- a/pytest/unit/asyncio_functions/test_gather_with_timeout.py
+++ b/pytest/unit/asyncio_functions/test_gather_with_timeout.py
@@ -1,5 +1,3 @@
-"""Unit tests for gather_with_timeout function."""
-
 import asyncio
 
 import pytest

--- a/pytest/unit/asyncio_functions/test_retry_async.py
+++ b/pytest/unit/asyncio_functions/test_retry_async.py
@@ -1,5 +1,3 @@
-"""Unit tests for retry_async function."""
-
 import asyncio
 
 import pytest

--- a/pytest/unit/compression_functions/test_decompress_number.py
+++ b/pytest/unit/compression_functions/test_decompress_number.py
@@ -1,5 +1,3 @@
-"""Unit tests for decompress_number function."""
-
 import pytest
 from compression_functions.decompress_number import decompress_number
 

--- a/pytest/unit/compression_functions/test_polyline_decoding_list_of_ints.py
+++ b/pytest/unit/compression_functions/test_polyline_decoding_list_of_ints.py
@@ -1,5 +1,3 @@
-"""Unit tests for polyline_decoding_list_of_ints function."""
-
 import pytest
 from compression_functions.polyline_decoding_list_of_ints import (
     polyline_decoding_list_of_ints,

--- a/pytest/unit/compression_functions/test_polyline_encoding_list_of_ints.py
+++ b/pytest/unit/compression_functions/test_polyline_encoding_list_of_ints.py
@@ -1,5 +1,3 @@
-"""Unit tests for polyline_encoding_list_of_ints function."""
-
 import pytest
 from compression_functions.polyline_encoding_list_of_ints import (
     polyline_encoding_list_of_ints,

--- a/pytest/unit/datetime_functions/test_get_end_of_year.py
+++ b/pytest/unit/datetime_functions/test_get_end_of_year.py
@@ -1,5 +1,3 @@
-"""Unit tests for get_end_of_year function."""
-
 from datetime import datetime
 
 import pytest

--- a/pytest/unit/datetime_functions/test_get_start_of_year.py
+++ b/pytest/unit/datetime_functions/test_get_start_of_year.py
@@ -1,5 +1,3 @@
-"""Unit tests for get_start_of_year function."""
-
 from datetime import datetime
 
 import pytest

--- a/pytest/unit/file_functions/directory_operations/test_copy_folder.py
+++ b/pytest/unit/file_functions/directory_operations/test_copy_folder.py
@@ -1,5 +1,3 @@
-"""Unit tests for copy_folder function."""
-
 import tempfile
 from pathlib import Path
 

--- a/pytest/unit/file_functions/file_operations/test_copy_file.py
+++ b/pytest/unit/file_functions/file_operations/test_copy_file.py
@@ -1,5 +1,3 @@
-"""Unit tests for copy_file function."""
-
 import tempfile
 from pathlib import Path
 

--- a/pytest/unit/iterable_functions/dictionary_operations/test_dict_value_difference.py
+++ b/pytest/unit/iterable_functions/dictionary_operations/test_dict_value_difference.py
@@ -1,5 +1,3 @@
-"""Unit tests for dict_value_difference function."""
-
 import pytest
 from iterable_functions.dictionary_operations.dict_value_difference import (
     dict_value_difference,

--- a/pytest/unit/iterable_functions/list_operations/test_chunk_by_size.py
+++ b/pytest/unit/iterable_functions/list_operations/test_chunk_by_size.py
@@ -1,5 +1,3 @@
-"""Unit tests for chunk_by_size function."""
-
 import pytest
 from iterable_functions.list_operations.chunk_by_size import chunk_by_size
 

--- a/pytest/unit/iterable_functions/set_operations/test_set_combinations.py
+++ b/pytest/unit/iterable_functions/set_operations/test_set_combinations.py
@@ -1,5 +1,3 @@
-"""Unit tests for get_combinations function."""
-
 import pytest
 from iterable_functions.set_operations.get_combinations import get_combinations
 

--- a/pytest/unit/iterable_functions/set_operations/test_set_partition.py
+++ b/pytest/unit/iterable_functions/set_operations/test_set_partition.py
@@ -1,5 +1,3 @@
-"""Unit tests for partition_set_by_predicate function."""
-
 import pytest
 from iterable_functions.set_operations.set_partition import partition_set_by_predicate
 

--- a/pytest/unit/iterable_functions/type_operations/test_safe_cast.py
+++ b/pytest/unit/iterable_functions/type_operations/test_safe_cast.py
@@ -1,5 +1,3 @@
-"""Unit tests for safe_cast and is_numeric functions."""
-
 import pytest
 from iterable_functions.type_operations.safe_cast import is_numeric, safe_cast
 

--- a/pytest/unit/network_functions/test_get_hostname.py
+++ b/pytest/unit/network_functions/test_get_hostname.py
@@ -1,5 +1,3 @@
-"""Unit tests for get_hostname function."""
-
 from unittest.mock import MagicMock, patch
 
 from network_functions.get_hostname import get_hostname

--- a/pytest/unit/network_functions/test_get_ipv6_addresses.py
+++ b/pytest/unit/network_functions/test_get_ipv6_addresses.py
@@ -1,5 +1,3 @@
-"""Unit tests for get_ipv6_addresses function."""
-
 from unittest.mock import MagicMock, patch
 
 from network_functions.get_ipv6_addresses import get_ipv6_addresses

--- a/pytest/unit/network_functions/test_get_local_ip.py
+++ b/pytest/unit/network_functions/test_get_local_ip.py
@@ -1,5 +1,3 @@
-"""Unit tests for get_local_ip function."""
-
 from unittest.mock import MagicMock, patch
 
 from network_functions.get_local_ip import get_local_ip

--- a/pytest/unit/network_functions/test_is_internet_available.py
+++ b/pytest/unit/network_functions/test_is_internet_available.py
@@ -1,5 +1,3 @@
-"""Unit tests for is_internet_available function."""
-
 from unittest.mock import MagicMock, patch
 
 from network_functions.is_internet_available import is_internet_available


### PR DESCRIPTION
## Summary
- remove module-level docstrings from pytest unit test files to declutter the modules

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f51ee0ad208325bf38b28797fd00da