### PR TITLE
Fix serialize_output logger validation

### DIFF
--- a/decorators/serialize_output.py
+++ b/decorators/serialize_output.py
@@ -35,10 +35,7 @@ def serialize_output(
     TypeError
         If logger is not an instance of logging.Logger or None.
     """
-    try:
-        validate_logger(logger)
-    except TypeError:
-        logger = None
+    validate_logger(logger)
 
     if not isinstance(format, str):
         if logger:

--- a/pytest/unit/decorators/test_serialize_output.py
+++ b/pytest/unit/decorators/test_serialize_output.py
@@ -70,10 +70,11 @@ def test_serialize_invalid_logger():
     """
     Test case 5: Invalid logger
     """
+    with pytest.raises(TypeError, match="logger must be an instance of logging.Logger or None"):
 
-    @serialize_output("json", logger="invalid_logger")
-    def invalid_logger_function() -> None:
-        pass
+        @serialize_output("json", logger="invalid_logger")
+        def invalid_logger_function() -> None:
+            pass
 
 
 def test_serialize_output_with_logger(caplog):


### PR DESCRIPTION
## Summary
- ensure the `serialize_output` decorator respects logger validation instead of silently ignoring invalid loggers
- adjust the serialization decorator tests to expect a `TypeError` when an invalid logger is supplied

## Testing
- pytest pytest/unit/decorators/test_serialize_output.py

------
https://chatgpt.com/codex/tasks/task_e_6904f2563b308325a06871a98507f90b