### PR TITLE
Fix remove_by_regex whitespace handling

### DIFF
--- a/strings_utility/remove_by_regex.py
+++ b/strings_utility/remove_by_regex.py
@@ -39,10 +39,12 @@ def remove_by_regex(string: str, pattern: str) -> str:
     if pattern == "":
         return string
 
-    # Adjust the pattern to also match surrounding spaces
-    adjusted_pattern = r"\s*" + pattern + r"\s*"
-    result = re.sub(adjusted_pattern, " ", string).strip()
-    return re.sub(r"\s+", " ", result)
+    # Remove the pattern from the string and normalise surrounding whitespace.
+    # ``re.sub`` can leave repeated spaces when entire words are removed,
+    # so collapse runs of whitespace to a single space and trim the result.
+    result = re.sub(pattern, "", string)
+    result = re.sub(r"\s{2,}", " ", result)
+    return result.strip()
 
 
 __all__ = ["remove_by_regex"]


### PR DESCRIPTION
## Summary
- normalize whitespace handling in `remove_by_regex` so removing matches inside words no longer leaves stray spaces
- collapse repeated whitespace after substitutions to keep natural spacing

## Testing
- `pytest pytest/unit/strings_utility/test_remove_by_regex.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6904f7e3ec348325b83abb20d17a6c3a