### PR TITLE
Use strict int type checks for chunk partition helpers

### DIFF
--- a/iterable_functions/list_operations/divide_list_into_n_chunks.py
+++ b/iterable_functions/list_operations/divide_list_into_n_chunks.py
@@ -35,7 +35,7 @@ def divide_list_into_n_chunks(list_to_divide: list[Any], n: int) -> list[list[An
     """
     if not isinstance(list_to_divide, list):
         raise TypeError("list_to_divide must be a list")
-    if not isinstance(n, int):
+    if type(n) is not int:
         raise TypeError("n must be an integer")
     if n <= 0:
         raise ValueError("n must be greater than 0")

--- a/iterable_functions/set_operations/partition_set_into_n_parts.py
+++ b/iterable_functions/set_operations/partition_set_into_n_parts.py
@@ -62,7 +62,7 @@ def partition_set_into_n_parts(input_set: set[T], n: int) -> list[set[T]]:
     if not isinstance(input_set, set):
         raise TypeError(f"input_set must be a set, got {type(input_set).__name__}")
 
-    if not isinstance(n, int):
+    if type(n) is not int:
         raise TypeError(f"n must be an int, got {type(n).__name__}")
 
     if n < 1:


### PR DESCRIPTION
## Summary
- ensure chunking helpers reject boolean values by using exact int type checks

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912271db3908325808f24df66fbc1c9)