### PR TITLE
Handle empty key paths in deep_set

### DIFF
--- a/iterable_functions/dictionary_operations/deep_set.py
+++ b/iterable_functions/dictionary_operations/deep_set.py
@@ -18,7 +18,9 @@ None
 Raises
 ------
 TypeError
-    If d is not a dictionary.
+    If d is not a dictionary or ``keys`` is neither a string nor a list of strings.
+ValueError
+    If ``keys`` is empty after normalization.
 
 Examples
 --------
@@ -52,7 +54,9 @@ def deep_set(d: dict[str, Any], keys: str | list[str], value: Any) -> None:
     Raises
     ------
     TypeError
-        If d is not a dictionary.
+        If d is not a dictionary or ``keys`` is neither a string nor a list of strings.
+    ValueError
+        If ``keys`` is empty after normalization.
 
     Examples
     --------
@@ -66,6 +70,11 @@ def deep_set(d: dict[str, Any], keys: str | list[str], value: Any) -> None:
 
     if isinstance(keys, str):
         keys = keys.split(".")
+    elif not isinstance(keys, list):
+        raise TypeError("keys must be a string or a list of strings")
+
+    if len(keys) == 0:
+        raise ValueError("keys must contain at least one key")
 
     current = d
     for key in keys[:-1]:

--- a/pytest/unit/iterable_functions/dictionary_operations/test_deep_set.py
+++ b/pytest/unit/iterable_functions/dictionary_operations/test_deep_set.py
@@ -193,3 +193,12 @@ def test_deep_set_invalid_type_error() -> None:
     # Act & Assert
     with pytest.raises(TypeError, match=expected_message):
         deep_set(invalid_input, key_path, value)
+
+
+def test_deep_set_empty_key_path_list() -> None:
+    """Test case 12: ValueError when key path list is empty."""
+
+    input_data: dict[str, Any] = {}
+
+    with pytest.raises(ValueError, match="keys must contain at least one key"):
+        deep_set(input_data, [], "value")


### PR DESCRIPTION
## Summary
- validate `deep_set` arguments by rejecting non-string/list key paths and empty key lists
- document the new validation behaviour and add a regression test for empty key paths

## Testing
- pytest pytest/unit/iterable_functions/dictionary_operations/test_deep_set.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691362fdf7b483259e35d173a39487ea)