### PR TITLE
Add tests for JSON utilities error handling

### DIFF
--- a/pytest/unit/json_functions/test_safe_json_dump.py
+++ b/pytest/unit/json_functions/test_safe_json_dump.py
@@ -53,3 +53,15 @@ def test_safe_json_dump_custom_encoder():
     obj = {"a": {1, 2, 3}}
     result = safe_json_dump(obj, encoder=MyEncoder)
     assert "1" in result and "2" in result and "3" in result
+
+
+def test_safe_json_dump_value_error_handling():
+    """
+    Test case 5: ValueError during serialization returns the provided default.
+    """
+    obj = float("nan")
+    default_value = "fallback"
+
+    result = safe_json_dump(obj, default=default_value, allow_nan=False)
+
+    assert result == default_value

--- a/pytest/unit/json_functions/test_safe_json_load.py
+++ b/pytest/unit/json_functions/test_safe_json_load.py
@@ -57,3 +57,15 @@ def test_safe_json_load_custom_decoder():
     data = '{"a": 1}'
     result = safe_json_load(data, decoder=MyDecoder)
     assert result["custom"] is True
+
+
+def test_safe_json_load_type_error_input():
+    """
+    Test case 6: Non-string input triggers TypeError and returns the default value.
+    """
+    data = {"a": 1}
+    default_value = {"error": "type"}
+
+    result = safe_json_load(data, default=default_value)
+
+    assert result == default_value


### PR DESCRIPTION
## Summary
- add a regression test ensuring safe_json_dump returns defaults for ValueError cases
- cover the TypeError path in safe_json_load when non-string data is provided

## Testing
- pytest pytest/unit/json_functions -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691365a7d2f083259c980c49e30d85e4)