### PR TITLE
Add verify_password tests for invalid custom checks

### DIFF
--- a/pytest/unit/strings_utility/test_verify_password.py
+++ b/pytest/unit/strings_utility/test_verify_password.py
@@ -100,3 +100,22 @@ def test_verify_password_invalid_type() -> None:
     """
     with pytest.raises(TypeError):
         verify_password(12345)
+
+
+def test_verify_password_custom_checks_not_iterable() -> None:
+    """
+    Test case 12: Test the verify_password function with a non-iterable custom_checks argument.
+    """
+
+    with pytest.raises(TypeError, match="custom_checks must be an iterable of callables"):
+        verify_password("Password123!", custom_checks="not iterable")
+
+
+def test_verify_password_custom_checks_non_callable() -> None:
+    """
+    Test case 13: Test the verify_password function with custom checks containing a non-callable item.
+    """
+
+    with pytest.raises(TypeError, match="custom_checks must be an iterable of callables"):
+        verify_password("Password123!", custom_checks=[lambda _: True, "not callable"])
+


### PR DESCRIPTION
## Summary
- add tests that ensure verify_password rejects non-iterable custom checks
- cover the case where a custom_checks iterable contains non-callable values

## Testing
- `pytest pytest/unit/strings_utility/test_verify_password.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691368a712548325add76e3f33191169)