### PR TITLE
Add missing unit tests for JSON diff and SSH timeout handling

### DIFF
--- a/pytest/unit/json_functions/test_json_diff.py
+++ b/pytest/unit/json_functions/test_json_diff.py
@@ -47,6 +47,16 @@ def test_json_diff_list_length_difference() -> None:
     result = json_diff(a, b)
     # Should have differences for indices 2, 3, 4
     assert ("[2]", 3, None) in result
-    assert ("[3]", 4, None) in result  
+    assert ("[3]", 4, None) in result
     assert ("[4]", 5, None) in result
+
+
+def test_json_diff_second_list_longer() -> None:
+    """Test case 6: Ensure json_diff captures additions when the second list is longer."""
+    a = ["alpha", "beta"]
+    b = ["alpha", "beta", "gamma", "delta"]
+    result = json_diff(a, b)
+
+    assert ("[2]", None, "gamma") in result
+    assert ("[3]", None, "delta") in result
 

--- a/pytest/unit/ssh_functions/test_ssh_execute_command.py
+++ b/pytest/unit/ssh_functions/test_ssh_execute_command.py
@@ -1,3 +1,4 @@
+import subprocess
 from unittest.mock import patch
 
 import pytest
@@ -67,3 +68,15 @@ def test_ssh_execute_command_case_6_timeout_error() -> None:
     with patch("subprocess.run", side_effect=Exception("fail")):
         with pytest.raises(RuntimeError, match="SSH command failed: fail"):
             ssh_execute_command("host", "ls")
+
+
+def test_ssh_execute_command_case_7_timeout_expired() -> None:
+    """
+    Test case 7: subprocess.TimeoutExpired raises RuntimeError with timeout-specific message.
+    """
+    with patch(
+        "subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd=["ssh"], timeout=5),
+    ):
+        with pytest.raises(RuntimeError, match="SSH command timed out after 5 seconds"):
+            ssh_execute_command("host", "ls", timeout=5)


### PR DESCRIPTION
## Summary
- add coverage for json_diff when the second list contains additional items
- test ssh_execute_command timeout handling for subprocess.TimeoutExpired errors

## Testing
- pytest pytest/unit/json_functions/test_json_diff.py pytest/unit/ssh_functions/test_ssh_execute_command.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914c0f9ee888325b2fdf6d4e1f14d1c)