### PR TITLE
Add edge case tests for is_valid_url file URLs

### DIFF
--- a/pytest/unit/http_functions/test_is_valid_url.py
+++ b/pytest/unit/http_functions/test_is_valid_url.py
@@ -291,3 +291,17 @@ def test_is_valid_url_hostname_none():
     assert is_valid_url("ftp://") is False
 
 
+def test_is_valid_url_file_scheme_without_path():
+    """
+    Test case 41: Is_valid_url function returns False for file scheme without a path.
+    """
+    assert is_valid_url("file://") is False
+
+
+def test_is_valid_url_file_scheme_with_whitespace_path():
+    """
+    Test case 42: Is_valid_url function returns False when the file path only contains whitespace.
+    """
+    assert is_valid_url("file:///   ") is False
+
+


### PR DESCRIPTION
## Summary
- add unit tests covering file scheme URLs without a usable path
- verify validation rejects file URLs that contain only whitespace in the path

## Testing
- pytest pytest/unit/http_functions/test_is_valid_url.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919a33239d48325b1167d6aa93ce2f0)