### PR TITLE
Add additional union-find edge case tests

### DIFF
--- a/pytest/unit/data_types/test_union_find.py
+++ b/pytest/unit/data_types/test_union_find.py
@@ -70,3 +70,33 @@ def test_find_applies_path_compression():
     assert uf.find(30) == root_before
     # After calling find, parent of 30 should be the root due to path compression
     assert uf.parent[30] == root_before
+
+
+def test_connected_initializes_elements():
+    """
+    Test case 6: Connected initializes previously unseen elements as separate sets.
+    """
+    uf: UnionFind[int] = UnionFind()
+
+    assert not uf.connected(5, 6)
+    assert uf.parent[5] == 5
+    assert uf.parent[6] == 6
+    assert uf.rank[5] == 0
+    assert uf.rank[6] == 0
+
+
+def test_union_on_already_connected_elements_is_noop():
+    """
+    Test case 7: Repeated union on connected elements does not change the structure.
+    """
+    uf: UnionFind[int] = UnionFind()
+
+    uf.union(1, 2)
+    root = uf.find(1)
+    initial_rank = uf.rank[root]
+
+    uf.union(1, 2)
+
+    assert uf.find(1) == root
+    assert uf.find(2) == root
+    assert uf.rank[root] == initial_rank


### PR DESCRIPTION
## Summary
- add coverage for UnionFind connected initialization behavior
- ensure repeated unions on already connected elements do not alter structure

## Testing
- pytest pytest/unit/data_types/test_union_find.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919aa4797dc8325a6176c1dc741d376)