### PR TITLE
Add missing env config test cases

### DIFF
--- a/pytest/unit/env_config_functions/test_parse_ini_config.py
+++ b/pytest/unit/env_config_functions/test_parse_ini_config.py
@@ -59,3 +59,15 @@ def test_parse_ini_config_file_not_found(tmp_path):
 
     with pytest.raises(FileNotFoundError):
         parse_ini_config(str(missing_file))
+
+
+def test_parse_ini_config_invalid_format(tmp_path):
+    """
+    Test case 5: Invalid INI content raises configparser.Error.
+    """
+
+    config_file = tmp_path / "config.ini"
+    config_file.write_text("key=value\n")
+
+    with pytest.raises(configparser.Error):
+        parse_ini_config(str(config_file))

--- a/pytest/unit/env_config_functions/test_parse_yaml_config.py
+++ b/pytest/unit/env_config_functions/test_parse_yaml_config.py
@@ -66,3 +66,14 @@ def test_parse_yaml_config_not_dict(tmp_path):
     write_yaml_file(data, config_file)
     with pytest.raises(ValueError, match="must be a dictionary"):
         parse_yaml_config(str(config_file))
+
+
+def test_parse_yaml_config_missing_file(tmp_path):
+    """
+    Test case 6: Missing YAML files raise FileNotFoundError
+    """
+
+    missing_file = tmp_path / "missing.yaml"
+
+    with pytest.raises(FileNotFoundError):
+        parse_yaml_config(str(missing_file))


### PR DESCRIPTION
## Summary
- add regression tests for `parse_ini_config` to ensure invalid INI data raises a parser error
- add a missing-file regression test for `parse_yaml_config`

## Testing
- `pytest pytest/unit/env_config_functions -q`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b5159c7dc8325bcd8e5c3c1dbd963)