### PR TITLE
Remove `_case_<n>` suffixes from pytest test function names

### DIFF
--- a/pytest/unit/cli_functions/test_check_command_exists.py
+++ b/pytest/unit/cli_functions/test_check_command_exists.py
@@ -2,7 +2,7 @@ import pytest
 from cli_functions.check_command_exists import check_command_exists
 
 
-def test_check_command_exists_case_1_python_exists() -> None:
+def test_check_command_exists_python_exists() -> None:
     """
     Test case 1: Test check_command_exists with python command.
     """
@@ -12,7 +12,7 @@ def test_check_command_exists_case_1_python_exists() -> None:
     assert result is True or check_command_exists('python3') is True
 
 
-def test_check_command_exists_case_2_nonexistent_command() -> None:
+def test_check_command_exists_nonexistent_command() -> None:
     """
     Test case 2: Test check_command_exists with nonexistent command.
     """
@@ -20,7 +20,7 @@ def test_check_command_exists_case_2_nonexistent_command() -> None:
     assert result is False
 
 
-def test_check_command_exists_case_3_common_commands() -> None:
+def test_check_command_exists_common_commands() -> None:
     """
     Test case 3: Test check_command_exists with common commands.
     """
@@ -30,7 +30,7 @@ def test_check_command_exists_case_3_common_commands() -> None:
     assert any(results), "At least one common command should exist"
 
 
-def test_check_command_exists_case_4_invalid_type_error() -> None:
+def test_check_command_exists_invalid_type_error() -> None:
     """
     Test case 4: Invalid command type raises TypeError.
     """
@@ -41,7 +41,7 @@ def test_check_command_exists_case_4_invalid_type_error() -> None:
         check_command_exists(None)
 
 
-def test_check_command_exists_case_5_empty_string_error() -> None:
+def test_check_command_exists_empty_string_error() -> None:
     """
     Test case 5: Empty command string raises ValueError.
     """
@@ -49,7 +49,7 @@ def test_check_command_exists_case_5_empty_string_error() -> None:
         check_command_exists('')
 
 
-def test_check_command_exists_case_6_consistency() -> None:
+def test_check_command_exists_consistency() -> None:
     """
     Test case 6: Multiple calls return consistent results.
     """

--- a/pytest/unit/cli_functions/test_execute_command.py
+++ b/pytest/unit/cli_functions/test_execute_command.py
@@ -5,7 +5,7 @@ import pytest
 from cli_functions.execute_command import execute_command
 
 
-def test_execute_command_case_1_simple_echo() -> None:
+def test_execute_command_simple_echo() -> None:
     """
     Test case 1: Execute simple echo command successfully.
     """
@@ -17,7 +17,7 @@ def test_execute_command_case_1_simple_echo() -> None:
     assert "hello" in result["stdout"]
 
 
-def test_execute_command_case_2_list_command() -> None:
+def test_execute_command_list_command() -> None:
     """
     Test case 2: Execute command as list without shell.
     """
@@ -28,7 +28,7 @@ def test_execute_command_case_2_list_command() -> None:
     assert "hello" in result["stdout"]
 
 
-def test_execute_command_case_3_command_with_timeout() -> None:
+def test_execute_command_command_with_timeout() -> None:
     """
     Test case 3: Execute command with timeout.
     """
@@ -38,7 +38,7 @@ def test_execute_command_case_3_command_with_timeout() -> None:
     assert result["return_code"] == 0
 
 
-def test_execute_command_case_4_invalid_command() -> None:
+def test_execute_command_invalid_command() -> None:
     """
     Test case 4: Execute invalid command returns non-zero exit code.
     """
@@ -48,7 +48,7 @@ def test_execute_command_case_4_invalid_command() -> None:
     assert result["return_code"] != 0
 
 
-def test_execute_command_case_5_invalid_type_error() -> None:
+def test_execute_command_invalid_type_error() -> None:
     """
     Test case 5: Invalid command type raises TypeError.
     """
@@ -59,7 +59,7 @@ def test_execute_command_case_5_invalid_type_error() -> None:
         execute_command(None)
 
 
-def test_execute_command_case_6_negative_timeout_error() -> None:
+def test_execute_command_negative_timeout_error() -> None:
     """
     Test case 6: Negative timeout raises ValueError.
     """

--- a/pytest/unit/cli_functions/test_get_cpu_info.py
+++ b/pytest/unit/cli_functions/test_get_cpu_info.py
@@ -2,7 +2,7 @@ import pytest
 from cli_functions.get_cpu_info import get_cpu_info
 
 
-def test_get_cpu_info_case_1_returns_valid_dict() -> None:
+def test_get_cpu_info_returns_valid_dict() -> None:
     """
     Test case 1: The get_cpu_info function returns a valid dictionary with CPU information.
     """
@@ -29,7 +29,7 @@ def test_get_cpu_info_case_1_returns_valid_dict() -> None:
     assert len(cpu_info["cpu_percent_per_core"]) == cpu_info["cpu_count"]
 
 
-def test_get_cpu_info_case_2_custom_interval() -> None:
+def test_get_cpu_info_custom_interval() -> None:
     """
     Test case 2: Test get_cpu_info with custom interval parameter.
     """
@@ -40,7 +40,7 @@ def test_get_cpu_info_case_2_custom_interval() -> None:
     assert isinstance(cpu_info["cpu_percent"], (int, float))
 
 
-def test_get_cpu_info_case_3_per_core_percents_valid() -> None:
+def test_get_cpu_info_per_core_percents_valid() -> None:
     """
     Test case 3: Verify per-core CPU percentages are valid.
     """
@@ -52,7 +52,7 @@ def test_get_cpu_info_case_3_per_core_percents_valid() -> None:
         assert 0 <= core_percent <= 100
 
 
-def test_get_cpu_info_case_4_frequency_info() -> None:
+def test_get_cpu_info_frequency_info() -> None:
     """
     Test case 4: Verify CPU frequency information is present and valid.
     """
@@ -68,7 +68,7 @@ def test_get_cpu_info_case_4_frequency_info() -> None:
         assert cpu_info["cpu_freq_current"] > 0
 
 
-def test_get_cpu_info_case_5_load_average() -> None:
+def test_get_cpu_info_load_average() -> None:
     """
     Test case 5: Verify load average information is present.
     """
@@ -81,7 +81,7 @@ def test_get_cpu_info_case_5_load_average() -> None:
         assert len(cpu_info["load_average"]) == 3
 
 
-def test_get_cpu_info_case_6_consistency() -> None:
+def test_get_cpu_info_consistency() -> None:
     """
     Test case 6: Verify consistency between multiple calls.
     """

--- a/pytest/unit/cli_functions/test_get_current_user.py
+++ b/pytest/unit/cli_functions/test_get_current_user.py
@@ -2,7 +2,7 @@ import pytest
 from cli_functions.get_current_user import get_current_user
 
 
-def test_get_current_user_case_1_returns_string() -> None:
+def test_get_current_user_returns_string() -> None:
     """
     Test case 1: Test get_current_user returns a string.
     """
@@ -10,7 +10,7 @@ def test_get_current_user_case_1_returns_string() -> None:
     assert isinstance(user, str)
 
 
-def test_get_current_user_case_2_non_empty() -> None:
+def test_get_current_user_non_empty() -> None:
     """
     Test case 2: Test get_current_user returns non-empty string.
     """
@@ -18,7 +18,7 @@ def test_get_current_user_case_2_non_empty() -> None:
     assert len(user) > 0
 
 
-def test_get_current_user_case_3_consistency() -> None:
+def test_get_current_user_consistency() -> None:
     """
     Test case 3: Test get_current_user returns consistent value.
     """
@@ -27,7 +27,7 @@ def test_get_current_user_case_3_consistency() -> None:
     assert user1 == user2
 
 
-def test_get_current_user_case_4_no_whitespace_only() -> None:
+def test_get_current_user_no_whitespace_only() -> None:
     """
     Test case 4: Test username is not just whitespace.
     """
@@ -36,7 +36,7 @@ def test_get_current_user_case_4_no_whitespace_only() -> None:
     assert len(user.strip()) > 0
 
 
-def test_get_current_user_case_5_valid_characters() -> None:
+def test_get_current_user_valid_characters() -> None:
     """
     Test case 5: Test username contains valid characters.
     """
@@ -45,7 +45,7 @@ def test_get_current_user_case_5_valid_characters() -> None:
     assert any(c.isalnum() or c in '_-.' for c in user)
 
 
-def test_get_current_user_case_6_multiple_calls() -> None:
+def test_get_current_user_multiple_calls() -> None:
     """
     Test case 6: Test multiple calls return same value.
     """

--- a/pytest/unit/cli_functions/test_get_disk_usage.py
+++ b/pytest/unit/cli_functions/test_get_disk_usage.py
@@ -4,7 +4,7 @@ import pytest
 from cli_functions.get_disk_usage import get_disk_usage
 
 
-def test_get_disk_usage_case_1_valid_path() -> None:
+def test_get_disk_usage_valid_path() -> None:
     """
     Test case 1: Test get_disk_usage function with valid path returns correct disk information.
     """
@@ -29,7 +29,7 @@ def test_get_disk_usage_case_1_valid_path() -> None:
     assert disk_info["free"] <= disk_info["total"]
 
 
-def test_get_disk_usage_case_2_temp_directory() -> None:
+def test_get_disk_usage_temp_directory() -> None:
     """
     Test case 2: Test get_disk_usage function with temporary directory.
     """
@@ -39,7 +39,7 @@ def test_get_disk_usage_case_2_temp_directory() -> None:
         assert disk_info["total"] > 0
 
 
-def test_get_disk_usage_case_3_invalid_path_error() -> None:
+def test_get_disk_usage_invalid_path_error() -> None:
     """
     Test case 3: Test get_disk_usage function with invalid path raises FileNotFoundError.
     """
@@ -47,7 +47,7 @@ def test_get_disk_usage_case_3_invalid_path_error() -> None:
         get_disk_usage("/nonexistent/path")
 
 
-def test_get_disk_usage_case_4_invalid_type_error() -> None:
+def test_get_disk_usage_invalid_type_error() -> None:
     """
     Test case 4: Test get_disk_usage function with invalid input type raises TypeError.
     """
@@ -58,7 +58,7 @@ def test_get_disk_usage_case_4_invalid_type_error() -> None:
         get_disk_usage(None)
 
 
-def test_get_disk_usage_case_5_percent_calculation() -> None:
+def test_get_disk_usage_percent_calculation() -> None:
     """
     Test case 5: Verify percent_used calculation is accurate.
     """
@@ -68,7 +68,7 @@ def test_get_disk_usage_case_5_percent_calculation() -> None:
     assert abs(disk_info["percent_used"] - expected_percent) < 0.01
 
 
-def test_get_disk_usage_case_6_multiple_paths() -> None:
+def test_get_disk_usage_multiple_paths() -> None:
     """
     Test case 6: Test disk usage for multiple valid paths.
     """

--- a/pytest/unit/cli_functions/test_get_environment_variable.py
+++ b/pytest/unit/cli_functions/test_get_environment_variable.py
@@ -4,7 +4,7 @@ import pytest
 from cli_functions.get_environment_variable import get_environment_variable
 
 
-def test_get_environment_variable_case_1_existing_variable() -> None:
+def test_get_environment_variable_existing_variable() -> None:
     """
     Test case 1: Get existing environment variable.
     """
@@ -16,7 +16,7 @@ def test_get_environment_variable_case_1_existing_variable() -> None:
         del os.environ['TEST_VAR']
 
 
-def test_get_environment_variable_case_2_nonexistent_with_default() -> None:
+def test_get_environment_variable_nonexistent_with_default() -> None:
     """
     Test case 2: Get nonexistent variable with default value.
     """
@@ -24,7 +24,7 @@ def test_get_environment_variable_case_2_nonexistent_with_default() -> None:
     assert result == 'default_value'
 
 
-def test_get_environment_variable_case_3_nonexistent_without_default() -> None:
+def test_get_environment_variable_nonexistent_without_default() -> None:
     """
     Test case 3: Get nonexistent variable without default returns None.
     """
@@ -32,7 +32,7 @@ def test_get_environment_variable_case_3_nonexistent_without_default() -> None:
     assert result is None
 
 
-def test_get_environment_variable_case_4_required_missing_error() -> None:
+def test_get_environment_variable_required_missing_error() -> None:
     """
     Test case 4: Required variable that is missing raises ValueError.
     """
@@ -40,7 +40,7 @@ def test_get_environment_variable_case_4_required_missing_error() -> None:
         get_environment_variable('NONEXISTENT_REQUIRED_VAR', required=True)
 
 
-def test_get_environment_variable_case_5_invalid_type_error() -> None:
+def test_get_environment_variable_invalid_type_error() -> None:
     """
     Test case 5: Invalid var_name type raises TypeError.
     """
@@ -51,7 +51,7 @@ def test_get_environment_variable_case_5_invalid_type_error() -> None:
         get_environment_variable(None)
 
 
-def test_get_environment_variable_case_6_required_existing() -> None:
+def test_get_environment_variable_required_existing() -> None:
     """
     Test case 6: Required variable that exists returns value.
     """

--- a/pytest/unit/cli_functions/test_get_file_size.py
+++ b/pytest/unit/cli_functions/test_get_file_size.py
@@ -5,7 +5,7 @@ import pytest
 from cli_functions.get_file_size import get_file_size
 
 
-def test_get_file_size_case_1_valid_file() -> None:
+def test_get_file_size_valid_file() -> None:
     """
     Test case 1: Test get_file_size function with a valid file returns correct size.
     """
@@ -23,7 +23,7 @@ def test_get_file_size_case_1_valid_file() -> None:
             os.unlink(temp_file.name)
 
 
-def test_get_file_size_case_2_empty_file() -> None:
+def test_get_file_size_empty_file() -> None:
     """
     Test case 2: Test get_file_size function with an empty file returns zero.
     """
@@ -35,7 +35,7 @@ def test_get_file_size_case_2_empty_file() -> None:
             os.unlink(temp_file.name)
 
 
-def test_get_file_size_case_3_nonexistent_file_error() -> None:
+def test_get_file_size_nonexistent_file_error() -> None:
     """
     Test case 3: Test get_file_size function with a nonexistent file raises FileNotFoundError.
     """
@@ -43,7 +43,7 @@ def test_get_file_size_case_3_nonexistent_file_error() -> None:
         get_file_size("/nonexistent/file.txt")
 
 
-def test_get_file_size_case_4_directory_error() -> None:
+def test_get_file_size_directory_error() -> None:
     """
     Test case 4: Test get_file_size function with a directory raises IsADirectoryError.
     """
@@ -52,7 +52,7 @@ def test_get_file_size_case_4_directory_error() -> None:
             get_file_size(temp_dir)
 
 
-def test_get_file_size_case_5_invalid_type_error() -> None:
+def test_get_file_size_invalid_type_error() -> None:
     """
     Test case 5: Test get_file_size function with invalid input type raises TypeError.
     """
@@ -63,7 +63,7 @@ def test_get_file_size_case_5_invalid_type_error() -> None:
         get_file_size(None)
 
 
-def test_get_file_size_case_6_large_file() -> None:
+def test_get_file_size_large_file() -> None:
     """
     Test case 6: Test get_file_size with larger file.
     """

--- a/pytest/unit/cli_functions/test_get_hostname.py
+++ b/pytest/unit/cli_functions/test_get_hostname.py
@@ -2,7 +2,7 @@ import pytest
 from cli_functions.get_hostname import get_hostname
 
 
-def test_get_hostname_case_1_returns_string() -> None:
+def test_get_hostname_returns_string() -> None:
     """
     Test case 1: Test get_hostname returns a string.
     """
@@ -10,7 +10,7 @@ def test_get_hostname_case_1_returns_string() -> None:
     assert isinstance(hostname, str)
 
 
-def test_get_hostname_case_2_non_empty() -> None:
+def test_get_hostname_non_empty() -> None:
     """
     Test case 2: Test get_hostname returns non-empty string.
     """
@@ -18,7 +18,7 @@ def test_get_hostname_case_2_non_empty() -> None:
     assert len(hostname) > 0
 
 
-def test_get_hostname_case_3_consistency() -> None:
+def test_get_hostname_consistency() -> None:
     """
     Test case 3: Test get_hostname returns consistent value.
     """
@@ -27,7 +27,7 @@ def test_get_hostname_case_3_consistency() -> None:
     assert hostname1 == hostname2
 
 
-def test_get_hostname_case_4_valid_characters() -> None:
+def test_get_hostname_valid_characters() -> None:
     """
     Test case 4: Test hostname contains valid characters.
     """
@@ -36,7 +36,7 @@ def test_get_hostname_case_4_valid_characters() -> None:
     assert all(c.isalnum() or c in '.-_' for c in hostname)
 
 
-def test_get_hostname_case_5_no_spaces() -> None:
+def test_get_hostname_no_spaces() -> None:
     """
     Test case 5: Test hostname does not contain spaces.
     """
@@ -44,7 +44,7 @@ def test_get_hostname_case_5_no_spaces() -> None:
     assert ' ' not in hostname
 
 
-def test_get_hostname_case_6_multiple_calls() -> None:
+def test_get_hostname_multiple_calls() -> None:
     """
     Test case 6: Test multiple calls return same value.
     """

--- a/pytest/unit/cli_functions/test_get_memory_info.py
+++ b/pytest/unit/cli_functions/test_get_memory_info.py
@@ -2,7 +2,7 @@ import pytest
 from cli_functions.get_memory_info import get_memory_info
 
 
-def test_get_memory_info_case_1_returns_valid_dict() -> None:
+def test_get_memory_info_returns_valid_dict() -> None:
     """
     Test case 1: Test get_memory_info returns valid dictionary.
     """
@@ -16,7 +16,7 @@ def test_get_memory_info_case_1_returns_valid_dict() -> None:
     assert 'percent_used' in mem_info
 
 
-def test_get_memory_info_case_2_positive_values() -> None:
+def test_get_memory_info_positive_values() -> None:
     """
     Test case 2: Test all memory values are non-negative.
     """
@@ -28,7 +28,7 @@ def test_get_memory_info_case_2_positive_values() -> None:
     assert mem_info['free'] >= 0
 
 
-def test_get_memory_info_case_3_percent_range() -> None:
+def test_get_memory_info_percent_range() -> None:
     """
     Test case 3: Test percent_used is in valid range.
     """
@@ -36,7 +36,7 @@ def test_get_memory_info_case_3_percent_range() -> None:
     assert 0 <= mem_info['percent_used'] <= 100
 
 
-def test_get_memory_info_case_4_relationships() -> None:
+def test_get_memory_info_relationships() -> None:
     """
     Test case 4: Test relationships between memory values.
     """
@@ -48,7 +48,7 @@ def test_get_memory_info_case_4_relationships() -> None:
     assert mem_info['available'] <= mem_info['total']
 
 
-def test_get_memory_info_case_5_consistency() -> None:
+def test_get_memory_info_consistency() -> None:
     """
     Test case 5: Test consistency between multiple calls.
     """
@@ -59,7 +59,7 @@ def test_get_memory_info_case_5_consistency() -> None:
     assert mem_info1['total'] == mem_info2['total']
 
 
-def test_get_memory_info_case_6_value_types() -> None:
+def test_get_memory_info_value_types() -> None:
     """
     Test case 6: Test all values are correct types.
     """

--- a/pytest/unit/cli_functions/test_get_network_info.py
+++ b/pytest/unit/cli_functions/test_get_network_info.py
@@ -2,7 +2,7 @@ import pytest
 from cli_functions.get_network_info import get_network_info
 
 
-def test_get_network_info_case_1_returns_dict() -> None:
+def test_get_network_info_returns_dict() -> None:
     """
     Test case 1: Test get_network_info returns a dictionary.
     """
@@ -10,7 +10,7 @@ def test_get_network_info_case_1_returns_dict() -> None:
     assert isinstance(net_info, dict)
 
 
-def test_get_network_info_case_2_interface_structure() -> None:
+def test_get_network_info_interface_structure() -> None:
     """
     Test case 2: Test each interface has expected structure.
     """
@@ -26,7 +26,7 @@ def test_get_network_info_case_2_interface_structure() -> None:
         assert 'mac' in interface_data
 
 
-def test_get_network_info_case_3_address_lists() -> None:
+def test_get_network_info_address_lists() -> None:
     """
     Test case 3: Test address lists are valid.
     """
@@ -38,7 +38,7 @@ def test_get_network_info_case_3_address_lists() -> None:
         assert isinstance(interface_data['mac'], list)
 
 
-def test_get_network_info_case_4_address_dict_structure() -> None:
+def test_get_network_info_address_dict_structure() -> None:
     """
     Test case 4: Test individual address dictionaries have expected keys.
     """
@@ -52,7 +52,7 @@ def test_get_network_info_case_4_address_dict_structure() -> None:
                 assert 'netmask' in addr_dict
 
 
-def test_get_network_info_case_5_at_least_one_interface() -> None:
+def test_get_network_info_at_least_one_interface() -> None:
     """
     Test case 5: Most systems should have at least one network interface.
     """
@@ -61,7 +61,7 @@ def test_get_network_info_case_5_at_least_one_interface() -> None:
     assert len(net_info) >= 0  # Can be 0 in some test environments
 
 
-def test_get_network_info_case_6_consistency() -> None:
+def test_get_network_info_consistency() -> None:
     """
     Test case 6: Test consistency between multiple calls.
     """

--- a/pytest/unit/cli_functions/test_get_uptime.py
+++ b/pytest/unit/cli_functions/test_get_uptime.py
@@ -2,7 +2,7 @@ import pytest
 from cli_functions.get_uptime import get_uptime
 
 
-def test_get_uptime_case_1_returns_positive_float() -> None:
+def test_get_uptime_returns_positive_float() -> None:
     """
     Test case 1: Test the get_uptime function returns a positive float value.
     """
@@ -13,7 +13,7 @@ def test_get_uptime_case_1_returns_positive_float() -> None:
     assert uptime > 0
 
 
-def test_get_uptime_case_2_reasonable_value() -> None:
+def test_get_uptime_reasonable_value() -> None:
     """
     Test case 2: Verify uptime is within reasonable bounds.
     """
@@ -25,7 +25,7 @@ def test_get_uptime_case_2_reasonable_value() -> None:
     assert uptime > 0.001
 
 
-def test_get_uptime_case_3_consistency() -> None:
+def test_get_uptime_consistency() -> None:
     """
     Test case 3: Verify uptime increases over time.
     """
@@ -41,7 +41,7 @@ def test_get_uptime_case_3_consistency() -> None:
     assert 0.05 < (uptime2 - uptime1) < 0.5
 
 
-def test_get_uptime_case_4_return_type() -> None:
+def test_get_uptime_return_type() -> None:
     """
     Test case 4: Verify return type is consistently float.
     """
@@ -49,7 +49,7 @@ def test_get_uptime_case_4_return_type() -> None:
     assert type(uptime) is float
 
 
-def test_get_uptime_case_5_multiple_calls() -> None:
+def test_get_uptime_multiple_calls() -> None:
     """
     Test case 5: Verify multiple calls work correctly.
     """
@@ -61,7 +61,7 @@ def test_get_uptime_case_5_multiple_calls() -> None:
         assert isinstance(uptime, float)
 
 
-def test_get_uptime_case_6_monotonic_increase() -> None:
+def test_get_uptime_monotonic_increase() -> None:
     """
     Test case 6: Verify uptime is monotonically increasing.
     """

--- a/pytest/unit/cli_functions/test_is_process_running.py
+++ b/pytest/unit/cli_functions/test_is_process_running.py
@@ -2,7 +2,7 @@ import pytest
 from cli_functions.is_process_running import is_process_running
 
 
-def test_is_process_running_case_1_valid_process() -> None:
+def test_is_process_running_valid_process() -> None:
     """
     Test case 1: Test is_process_running function with a process that should exist.
     """
@@ -10,7 +10,7 @@ def test_is_process_running_case_1_valid_process() -> None:
     assert isinstance(result, bool)
 
 
-def test_is_process_running_case_2_nonexistent_process() -> None:
+def test_is_process_running_nonexistent_process() -> None:
     """
     Test case 2: Test is_process_running function with a nonexistent process.
     """
@@ -18,7 +18,7 @@ def test_is_process_running_case_2_nonexistent_process() -> None:
     assert not result
 
 
-def test_is_process_running_case_3_handles_psutil_exceptions() -> None:
+def test_is_process_running_handles_psutil_exceptions() -> None:
     """
     Test case 3: Test is_process_running handles psutil exceptions gracefully.
     """
@@ -39,7 +39,7 @@ def test_is_process_running_case_3_handles_psutil_exceptions() -> None:
         assert isinstance(result, bool)
 
 
-def test_is_process_running_case_4_invalid_type_error() -> None:
+def test_is_process_running_invalid_type_error() -> None:
     """
     Test case 4: Test is_process_running function with invalid input type raises TypeError.
     """
@@ -53,7 +53,7 @@ def test_is_process_running_case_4_invalid_type_error() -> None:
         is_process_running(["process_name"])
 
 
-def test_is_process_running_case_5_empty_string() -> None:
+def test_is_process_running_empty_string() -> None:
     """
     Test case 5: Test is_process_running with empty string returns False.
     """
@@ -61,7 +61,7 @@ def test_is_process_running_case_5_empty_string() -> None:
     assert result is False
 
 
-def test_is_process_running_case_6_current_process() -> None:
+def test_is_process_running_current_process() -> None:
     """
     Test case 6: Test is_process_running can find python process.
     """

--- a/pytest/unit/cli_functions/test_kill_process.py
+++ b/pytest/unit/cli_functions/test_kill_process.py
@@ -2,7 +2,7 @@ import pytest
 from cli_functions.kill_process import kill_process
 
 
-def test_kill_process_case_1_nonexistent_pid() -> None:
+def test_kill_process_nonexistent_pid() -> None:
     """
     Test case 1: Test kill_process function with a nonexistent PID returns False.
     """
@@ -10,7 +10,7 @@ def test_kill_process_case_1_nonexistent_pid() -> None:
     assert not result
 
 
-def test_kill_process_case_2_handles_os_errors() -> None:
+def test_kill_process_handles_os_errors() -> None:
     """
     Test case 2: Test kill_process handles OSError and PermissionError gracefully.
     """
@@ -29,7 +29,7 @@ def test_kill_process_case_2_handles_os_errors() -> None:
             assert result is False
 
 
-def test_kill_process_case_3_invalid_type_error() -> None:
+def test_kill_process_invalid_type_error() -> None:
     """
     Test case 3: Test kill_process function with invalid input types raises TypeError.
     """
@@ -43,7 +43,7 @@ def test_kill_process_case_3_invalid_type_error() -> None:
         kill_process(12.5)
 
 
-def test_kill_process_case_4_invalid_pid_error() -> None:
+def test_kill_process_invalid_pid_error() -> None:
     """
     Test case 4: Test kill_process function with invalid PID values raises ValueError.
     """
@@ -57,7 +57,7 @@ def test_kill_process_case_4_invalid_pid_error() -> None:
         kill_process(-999)
 
 
-def test_kill_process_case_5_with_different_signals() -> None:
+def test_kill_process_with_different_signals() -> None:
     """
     Test case 5: Test kill_process with different signal types.
     """
@@ -71,7 +71,7 @@ def test_kill_process_case_5_with_different_signals() -> None:
     assert result2 is False
 
 
-def test_kill_process_case_6_process_lookup_error() -> None:
+def test_kill_process_process_lookup_error() -> None:
     """
     Test case 6: Test kill_process handles ProcessLookupError.
     """

--- a/pytest/unit/cli_functions/test_list_directories.py
+++ b/pytest/unit/cli_functions/test_list_directories.py
@@ -5,7 +5,7 @@ import pytest
 from cli_functions.list_directories import list_directories
 
 
-def test_list_directories_case_1_valid_directory() -> None:
+def test_list_directories_valid_directory() -> None:
     """
     Test case 1: Test list_directories function with a valid directory returns correct directory list.
     """
@@ -32,7 +32,7 @@ def test_list_directories_case_1_valid_directory() -> None:
         assert len(dirs_with_hidden) == 3
 
 
-def test_list_directories_case_2_empty_directory() -> None:
+def test_list_directories_empty_directory() -> None:
     """
     Test case 2: Test list_directories function with an empty directory returns empty list.
     """
@@ -42,7 +42,7 @@ def test_list_directories_case_2_empty_directory() -> None:
         assert len(directories) == 0
 
 
-def test_list_directories_case_3_with_files() -> None:
+def test_list_directories_with_files() -> None:
     """
     Test case 3: Test list_directories function ignores files and only returns directories.
     """
@@ -61,7 +61,7 @@ def test_list_directories_case_3_with_files() -> None:
         assert len(directories) == 1
 
 
-def test_list_directories_case_4_nonexistent_directory_error() -> None:
+def test_list_directories_nonexistent_directory_error() -> None:
     """
     Test case 4: Test list_directories function with a nonexistent directory raises FileNotFoundError.
     """
@@ -69,7 +69,7 @@ def test_list_directories_case_4_nonexistent_directory_error() -> None:
         list_directories("/nonexistent/directory")
 
 
-def test_list_directories_case_5_not_a_directory_error() -> None:
+def test_list_directories_not_a_directory_error() -> None:
     """
     Test case 5: Test list_directories function with a file instead of directory raises NotADirectoryError.
     """
@@ -81,7 +81,7 @@ def test_list_directories_case_5_not_a_directory_error() -> None:
             os.unlink(temp_file.name)
 
 
-def test_list_directories_case_6_invalid_type_error() -> None:
+def test_list_directories_invalid_type_error() -> None:
     """
     Test case 6: Test list_directories function with invalid input type raises TypeError.
     """

--- a/pytest/unit/cli_functions/test_list_files.py
+++ b/pytest/unit/cli_functions/test_list_files.py
@@ -5,7 +5,7 @@ import pytest
 from cli_functions.list_files import list_files
 
 
-def test_list_files_case_1_valid_directory() -> None:
+def test_list_files_valid_directory() -> None:
     """
     Test case 1: Test list_files function with a valid directory returns correct file list.
     """
@@ -33,7 +33,7 @@ def test_list_files_case_1_valid_directory() -> None:
         assert len(files_with_hidden) == 3
 
 
-def test_list_files_case_2_empty_directory() -> None:
+def test_list_files_empty_directory() -> None:
     """
     Test case 2: Test list_files function with an empty directory returns empty list.
     """
@@ -43,7 +43,7 @@ def test_list_files_case_2_empty_directory() -> None:
         assert len(files) == 0
 
 
-def test_list_files_case_3_with_subdirectories() -> None:
+def test_list_files_with_subdirectories() -> None:
     """
     Test case 3: Test list_files function ignores subdirectories and only returns files.
     """
@@ -62,7 +62,7 @@ def test_list_files_case_3_with_subdirectories() -> None:
         assert len(files) == 1
 
 
-def test_list_files_case_4_nonexistent_directory_error() -> None:
+def test_list_files_nonexistent_directory_error() -> None:
     """
     Test case 4: Test list_files function with a nonexistent directory raises FileNotFoundError.
     """
@@ -70,7 +70,7 @@ def test_list_files_case_4_nonexistent_directory_error() -> None:
         list_files("/nonexistent/directory")
 
 
-def test_list_files_case_5_not_a_directory_error() -> None:
+def test_list_files_not_a_directory_error() -> None:
     """
     Test case 5: Test list_files function with a file instead of directory raises NotADirectoryError.
     """
@@ -82,7 +82,7 @@ def test_list_files_case_5_not_a_directory_error() -> None:
             os.unlink(temp_file.name)
 
 
-def test_list_files_case_6_invalid_type_error() -> None:
+def test_list_files_invalid_type_error() -> None:
     """
     Test case 6: Test list_files function with invalid input type raises TypeError.
     """

--- a/pytest/unit/cli_functions/test_set_environment_variable.py
+++ b/pytest/unit/cli_functions/test_set_environment_variable.py
@@ -4,7 +4,7 @@ import pytest
 from cli_functions.set_environment_variable import set_environment_variable
 
 
-def test_set_environment_variable_case_1_simple_set() -> None:
+def test_set_environment_variable_simple_set() -> None:
     """
     Test case 1: Set environment variable successfully.
     """
@@ -16,7 +16,7 @@ def test_set_environment_variable_case_1_simple_set() -> None:
             del os.environ['MY_VAR']
 
 
-def test_set_environment_variable_case_2_overwrite_existing() -> None:
+def test_set_environment_variable_overwrite_existing() -> None:
     """
     Test case 2: Overwrite existing environment variable.
     """
@@ -29,7 +29,7 @@ def test_set_environment_variable_case_2_overwrite_existing() -> None:
             del os.environ['MY_VAR']
 
 
-def test_set_environment_variable_case_3_empty_value() -> None:
+def test_set_environment_variable_empty_value() -> None:
     """
     Test case 3: Set environment variable to empty string.
     """
@@ -41,7 +41,7 @@ def test_set_environment_variable_case_3_empty_value() -> None:
             del os.environ['MY_VAR']
 
 
-def test_set_environment_variable_case_4_invalid_var_name_type() -> None:
+def test_set_environment_variable_invalid_var_name_type() -> None:
     """
     Test case 4: Invalid var_name type raises TypeError.
     """
@@ -52,7 +52,7 @@ def test_set_environment_variable_case_4_invalid_var_name_type() -> None:
         set_environment_variable(None, 'value')
 
 
-def test_set_environment_variable_case_5_invalid_value_type() -> None:
+def test_set_environment_variable_invalid_value_type() -> None:
     """
     Test case 5: Invalid value type raises TypeError.
     """
@@ -63,7 +63,7 @@ def test_set_environment_variable_case_5_invalid_value_type() -> None:
         set_environment_variable('MY_VAR', None)
 
 
-def test_set_environment_variable_case_6_empty_var_name_error() -> None:
+def test_set_environment_variable_empty_var_name_error() -> None:
     """
     Test case 6: Empty var_name raises ValueError.
     """

--- a/pytest/unit/data_validation/basic_validation/test_validate_collection.py
+++ b/pytest/unit/data_validation/basic_validation/test_validate_collection.py
@@ -2,7 +2,7 @@ import pytest
 from data_validation import validate_collection
 
 
-def test_validate_collection_case_1_basic_collections() -> None:
+def test_validate_collection_basic_collections() -> None:
     """
     Test case 1: Basic collection type validation.
     """
@@ -23,7 +23,7 @@ def test_validate_collection_case_1_basic_collections() -> None:
     validate_collection({}, dict)
 
 
-def test_validate_collection_case_2_length_validation() -> None:
+def test_validate_collection_length_validation() -> None:
     """
     Test case 2: Collection length validation with min/max bounds.
     """
@@ -40,7 +40,7 @@ def test_validate_collection_case_2_length_validation() -> None:
     validate_collection({"a": 1, "b": 2, "c": 3}, dict, min_length=2, max_length=5)
 
 
-def test_validate_collection_case_3_empty_collection_handling() -> None:
+def test_validate_collection_empty_collection_handling() -> None:
     """
     Test case 3: Empty collection handling with allow_empty parameter.
     """
@@ -54,7 +54,7 @@ def test_validate_collection_case_3_empty_collection_handling() -> None:
     validate_collection([], list, min_length=0, max_length=5, allow_empty=True)
 
 
-def test_validate_collection_case_4_element_type_validation() -> None:
+def test_validate_collection_element_type_validation() -> None:
     """
     Test case 4: Element type validation for homogeneous collections.
     """
@@ -71,7 +71,7 @@ def test_validate_collection_case_4_element_type_validation() -> None:
     validate_collection((True, False, True), tuple, element_type=bool)
 
 
-def test_validate_collection_case_5_dict_value_validation() -> None:
+def test_validate_collection_dict_value_validation() -> None:
     """
     Test case 5: Dictionary value type validation.
     """
@@ -85,7 +85,7 @@ def test_validate_collection_case_5_dict_value_validation() -> None:
     validate_collection({"a": 1, "b": "hello"}, dict, element_type=(int, str))
 
 
-def test_validate_collection_case_6_union_element_types() -> None:
+def test_validate_collection_union_element_types() -> None:
     """
     Test case 6: Union element type validation.
     """
@@ -99,7 +99,7 @@ def test_validate_collection_case_6_union_element_types() -> None:
     validate_collection((True, 1, False, 0), tuple, element_type=(bool, int))
 
 
-def test_validate_collection_case_7_complex_validation_combinations() -> None:
+def test_validate_collection_complex_validation_combinations() -> None:
     """
     Test case 7: Complex combinations of validation parameters.
     """
@@ -124,7 +124,7 @@ def test_validate_collection_case_7_complex_validation_combinations() -> None:
     )
 
 
-def test_validate_collection_case_13_edge_cases() -> None:
+def test_validate_collection_edge_cases() -> None:
     """
     Test case 8: Edge cases and boundary conditions.
     """
@@ -144,7 +144,7 @@ def test_validate_collection_case_13_edge_cases() -> None:
     validate_collection([1, None, 3], list, element_type=(int, type(None)))
 
 
-def test_validate_collection_case_14_performance_large_collections() -> None:
+def test_validate_collection_performance_large_collections() -> None:
     """
     Test case 9: Performance with large collections.
     """
@@ -165,7 +165,7 @@ def test_validate_collection_case_14_performance_large_collections() -> None:
     assert elapsed_time < 1.0  # Should complete within 1 second
 
 
-def test_validate_collection_case_8_type_error_wrong_collection_type() -> None:
+def test_validate_collection_type_error_wrong_collection_type() -> None:
     """
     Test case 10: TypeError for wrong collection type.
     """
@@ -183,7 +183,7 @@ def test_validate_collection_case_8_type_error_wrong_collection_type() -> None:
         validate_collection("not a list", list, param_name="items")
 
 
-def test_validate_collection_case_9_value_error_empty_not_allowed() -> None:
+def test_validate_collection_value_error_empty_not_allowed() -> None:
     """
     Test case 11: ValueError when empty collections are not allowed.
     """
@@ -201,7 +201,7 @@ def test_validate_collection_case_9_value_error_empty_not_allowed() -> None:
         validate_collection([], list, allow_empty=False, param_name="items")
 
 
-def test_validate_collection_case_10_value_error_length_bounds() -> None:
+def test_validate_collection_value_error_length_bounds() -> None:
     """
     Test case 12: ValueError for length constraint violations.
     """
@@ -226,7 +226,7 @@ def test_validate_collection_case_10_value_error_length_bounds() -> None:
         validate_collection([1, 2], list, min_length=5, param_name="items")
 
 
-def test_validate_collection_case_11_type_error_element_validation() -> None:
+def test_validate_collection_type_error_element_validation() -> None:
     """
     Test case 13: TypeError for wrong element types.
     """
@@ -255,7 +255,7 @@ def test_validate_collection_case_11_type_error_element_validation() -> None:
         validate_collection([1, 2, 3], list, element_type=str, param_name="items")
 
 
-def test_validate_collection_case_12_type_error_invalid_parameters() -> None:
+def test_validate_collection_type_error_invalid_parameters() -> None:
     """
     Test case 14: TypeError for invalid parameter types.
     """
@@ -289,19 +289,19 @@ def test_validate_collection_case_12_type_error_invalid_parameters() -> None:
         validate_collection([1, 2, 3], list, min_length=5, max_length=3)
 
 
-def test_validate_collection_case_15_allow_empty_type_error() -> None:
+def test_validate_collection_allow_empty_type_error() -> None:
     """Test case 15: Test TypeError for non-bool allow_empty parameter."""
     with pytest.raises(TypeError, match="allow_empty must be bool"):
         validate_collection([1, 2, 3], list, allow_empty=1)  # type: ignore
 
 
-def test_validate_collection_case_16_max_length_type_error() -> None:
+def test_validate_collection_max_length_type_error() -> None:
     """Test case 16: Test TypeError for non-integer max_length parameter."""
     with pytest.raises(TypeError, match="max_length must be int or None"):
         validate_collection([1, 2, 3], list, max_length="10")  # type: ignore
 
 
-def test_validate_collection_case_17_non_iterable_element_validation() -> None:
+def test_validate_collection_non_iterable_element_validation() -> None:
     """Test case 17: Test TypeError for non-iterable with element_type validation."""
     # Create a custom class that is Sized but not Iterable to trigger line 159
     class SizedNotIterable:
@@ -313,7 +313,7 @@ def test_validate_collection_case_17_non_iterable_element_validation() -> None:
         validate_collection(obj, SizedNotIterable, element_type=int)  # type: ignore
 
 
-def test_validate_collection_case_18_dict_element_validation_failure() -> None:
+def test_validate_collection_dict_element_validation_failure() -> None:
     """Test case 18: Test element type validation for dictionary values."""
     with pytest.raises(TypeError, match="value for key 'b' must be int"):
         validate_collection({"a": 1, "b": "two"}, dict, element_type=int)

--- a/pytest/unit/data_validation/basic_validation/test_validate_email.py
+++ b/pytest/unit/data_validation/basic_validation/test_validate_email.py
@@ -5,7 +5,7 @@ import pytest
 from data_validation import validate_email
 
 
-def test_validate_email_case_1_valid_emails() -> None:
+def test_validate_email_valid_emails() -> None:
     """
     Test case 1: Valid email address formats.
     """
@@ -21,7 +21,7 @@ def test_validate_email_case_1_valid_emails() -> None:
     validate_email("first.last+tag@subdomain.example.co.uk")
 
 
-def test_validate_email_case_2_subdomain_and_tld_variations() -> None:
+def test_validate_email_subdomain_and_tld_variations() -> None:
     """
     Test case 2: Valid emails with various subdomain and TLD combinations.
     """
@@ -36,7 +36,7 @@ def test_validate_email_case_2_subdomain_and_tld_variations() -> None:
     validate_email("user@example.travel")
 
 
-def test_validate_email_case_3_unicode_emails() -> None:
+def test_validate_email_unicode_emails() -> None:
     """
     Test case 3: Unicode email addresses when allowed.
     """
@@ -46,7 +46,7 @@ def test_validate_email_case_3_unicode_emails() -> None:
     validate_email("user@üñíçøðé.com", allow_unicode=True)
 
 
-def test_validate_email_case_4_edge_case_valid_emails() -> None:
+def test_validate_email_edge_case_valid_emails() -> None:
     """
     Test case 4: Edge cases that should be valid.
     """
@@ -62,7 +62,7 @@ def test_validate_email_case_4_edge_case_valid_emails() -> None:
     validate_email("user@sub-domain.example-site.org")
 
 
-def test_validate_email_case_13_mx_checking_success() -> None:
+def test_validate_email_mx_checking_success() -> None:
     """
     Test case 5: MX record validation using dnspython (success).
     """
@@ -74,7 +74,7 @@ def test_validate_email_case_13_mx_checking_success() -> None:
 
 @patch("dns.resolver.resolve", side_effect=Exception("No MX"))
 @patch("socket.gethostbyname")
-def test_validate_email_case_15_mx_checking_socket_fallback_success(
+def test_validate_email_mx_checking_socket_fallback_success(
     mock_gethostbyname, mock_resolve
 ) -> None:
     """
@@ -85,7 +85,7 @@ def test_validate_email_case_15_mx_checking_socket_fallback_success(
     mock_gethostbyname.assert_called_with("example.com")
 
 
-def test_validate_email_case_17_edge_cases() -> None:
+def test_validate_email_edge_cases() -> None:
     """
     Test case 7: Edge cases and boundary conditions.
     """
@@ -105,7 +105,7 @@ def test_validate_email_case_17_edge_cases() -> None:
     validate_email("user-name@domain-name.org")
 
 
-def test_validate_email_case_18_performance_complex_emails() -> None:
+def test_validate_email_performance_complex_emails() -> None:
     """
     Test case 8: Performance with complex email validation.
     """
@@ -128,7 +128,7 @@ def test_validate_email_case_18_performance_complex_emails() -> None:
     assert elapsed_time < 1.0  # Should complete within 1 second
 
 
-def test_validate_email_case_5_type_error_invalid_input() -> None:
+def test_validate_email_type_error_invalid_input() -> None:
     """
     Test case 9: TypeError for non-string input.
     """
@@ -146,7 +146,7 @@ def test_validate_email_case_5_type_error_invalid_input() -> None:
         validate_email(123, param_name="user_email")
 
 
-def test_validate_email_case_6_type_error_invalid_parameters() -> None:
+def test_validate_email_type_error_invalid_parameters() -> None:
     """
     Test case 10: TypeError for invalid parameter types.
     """
@@ -160,7 +160,7 @@ def test_validate_email_case_6_type_error_invalid_parameters() -> None:
         validate_email("user@example.com", param_name=123)
 
 
-def test_validate_email_case_7_value_error_empty_email() -> None:
+def test_validate_email_value_error_empty_email() -> None:
     """
     Test case 11: ValueError for empty email addresses.
     """
@@ -172,7 +172,7 @@ def test_validate_email_case_7_value_error_empty_email() -> None:
         validate_email("", param_name="user_email")
 
 
-def test_validate_email_case_8_value_error_length_violations() -> None:
+def test_validate_email_value_error_length_violations() -> None:
     """
     Test case 12: ValueError for length constraint violations.
     """
@@ -198,7 +198,7 @@ def test_validate_email_case_8_value_error_length_violations() -> None:
         validate_email(long_domain)
 
 
-def test_validate_email_case_9_value_error_invalid_structure() -> None:
+def test_validate_email_value_error_invalid_structure() -> None:
     """
     Test case 13: ValueError for invalid email structure.
     """
@@ -222,7 +222,7 @@ def test_validate_email_case_9_value_error_invalid_structure() -> None:
         validate_email("user@")
 
 
-def test_validate_email_case_10_value_error_invalid_format() -> None:
+def test_validate_email_value_error_invalid_format() -> None:
     """
     Test case 14: ValueError for invalid email format.
     """
@@ -249,7 +249,7 @@ def test_validate_email_case_10_value_error_invalid_format() -> None:
         validate_email("user@example..com")
 
 
-def test_validate_email_case_11_value_error_domain_requirements() -> None:
+def test_validate_email_value_error_domain_requirements() -> None:
     """
     Test case 15: ValueError for domain requirement violations.
     """
@@ -261,7 +261,7 @@ def test_validate_email_case_11_value_error_domain_requirements() -> None:
         validate_email("user@domain")
 
 
-def test_validate_email_case_12_value_error_unicode_not_allowed() -> None:
+def test_validate_email_value_error_unicode_not_allowed() -> None:
     """
     Test case 16: ValueError for Unicode characters when not allowed.
     """
@@ -281,7 +281,7 @@ def test_validate_email_case_12_value_error_unicode_not_allowed() -> None:
         validate_email("用户@example.com")  # default allow_unicode=False
 
 
-def test_validate_email_case_14_mx_checking_failure() -> None:
+def test_validate_email_mx_checking_failure() -> None:
     """
     Test case 17: MX record validation using dnspython (failure).
     """
@@ -296,7 +296,7 @@ def test_validate_email_case_14_mx_checking_failure() -> None:
 
 @patch("dns.resolver.resolve", side_effect=Exception("No MX"))
 @patch("socket.gethostbyname")
-def test_validate_email_case_16_mx_checking_socket_fallback_failure(
+def test_validate_email_mx_checking_socket_fallback_failure(
     mock_gethostbyname, mock_resolve
 ) -> None:
     """
@@ -307,32 +307,32 @@ def test_validate_email_case_16_mx_checking_socket_fallback_failure(
         validate_email("user@nonexistent-domain-12345.com", check_mx=True)
 
 
-def test_validate_email_case_19_local_part_too_long() -> None:
+def test_validate_email_local_part_too_long() -> None:
     """Test case 19: ValueError for local part exceeding 64 characters."""
     long_local = "a" * 65 + "@example.com"
     with pytest.raises(ValueError, match="email local part exceeds maximum length"):
         validate_email(long_local)
 
 
-def test_validate_email_case_20_non_ascii_unicode_disabled() -> None:
+def test_validate_email_non_ascii_unicode_disabled() -> None:
     """Test case 20: ValueError for non-ASCII characters with allow_unicode=False."""
     with pytest.raises(ValueError, match="contains non-ASCII characters but allow_unicode=False"):
         validate_email("tëst@example.com", allow_unicode=False)
 
 
-def test_validate_email_case_21_domain_without_dot() -> None:
+def test_validate_email_domain_without_dot() -> None:
     """Test case 21: ValueError for domain without a dot."""
     with pytest.raises(ValueError, match="domain must contain at least one dot"):
         validate_email("user@localhost")
 
 
-def test_validate_email_case_22_domain_with_consecutive_dots() -> None:
+def test_validate_email_domain_with_consecutive_dots() -> None:
     """Test case 22: ValueError for domain with consecutive dots."""
     with pytest.raises(ValueError, match="domain cannot contain consecutive dots"):
         validate_email("user@example..com")
 
 
-def test_validate_email_case_23_domain_too_long() -> None:
+def test_validate_email_domain_too_long() -> None:
     """Test case 23: ValueError for email exceeding maximum length."""
     long_domain = "user@" + "a" * 254 + ".com"
     with pytest.raises(ValueError, match="email exceeds maximum length"):

--- a/pytest/unit/data_validation/basic_validation/test_validate_range.py
+++ b/pytest/unit/data_validation/basic_validation/test_validate_range.py
@@ -109,7 +109,7 @@ def test_validate_range_decimal_ranges() -> None:
     )
 
 
-def test_validate_range_case_11_boundary_conditions() -> None:
+def test_validate_range_boundary_conditions() -> None:
     """
     Test case 7: Edge cases and boundary conditions.
     """
@@ -127,7 +127,7 @@ def test_validate_range_case_11_boundary_conditions() -> None:
     validate_range(1e-10, min_value=0.0, max_value=1e-9)
 
 
-def test_validate_range_case_12_performance_large_numbers() -> None:
+def test_validate_range_performance_large_numbers() -> None:
     """
     Test case 8: Performance with large numbers and many validations.
     """
@@ -210,7 +210,7 @@ def test_validate_range_invalid_range_bounds() -> None:
         validate_range(5, min_value=5, max_value=5, max_inclusive=False)
 
 
-def test_validate_range_case_10_type_errors() -> None:
+def test_validate_range_type_errors() -> None:
     """
     Test case 12: TypeError for invalid parameter types and incompatible comparisons.
     """

--- a/pytest/unit/data_validation/schema_validation/test_validate_cerberus_schema.py
+++ b/pytest/unit/data_validation/schema_validation/test_validate_cerberus_schema.py
@@ -16,7 +16,7 @@ except ImportError:
 pytestmark = pytest.mark.skipif(not CERBERUS_AVAILABLE, reason="Cerberus not installed")
 
 
-def test_validate_cerberus_schema_case_1_simple_valid_data() -> None:
+def test_validate_cerberus_schema_simple_valid_data() -> None:
     """
     Test case 1: Simple valid data validation.
     """
@@ -34,7 +34,7 @@ def test_validate_cerberus_schema_case_1_simple_valid_data() -> None:
     assert result["email"] == "john@example.com"
 
 
-def test_validate_cerberus_schema_case_2_with_defaults() -> None:
+def test_validate_cerberus_schema_with_defaults() -> None:
     """
     Test case 2: Schema with default values.
     """
@@ -54,7 +54,7 @@ def test_validate_cerberus_schema_case_2_with_defaults() -> None:
     assert result["score"] == 0.0
 
 
-def test_validate_cerberus_schema_case_3_type_coercion() -> None:
+def test_validate_cerberus_schema_type_coercion() -> None:
     """
     Test case 3: Type coercion during validation.
     """
@@ -72,7 +72,7 @@ def test_validate_cerberus_schema_case_3_type_coercion() -> None:
     assert result["active"] is True
 
 
-def test_validate_cerberus_schema_case_4_nested_schemas() -> None:
+def test_validate_cerberus_schema_nested_schemas() -> None:
     """
     Test case 4: Nested schema validation.
     """
@@ -96,7 +96,7 @@ def test_validate_cerberus_schema_case_4_nested_schemas() -> None:
     assert result["metadata"]["source"] == "api"
 
 
-def test_validate_cerberus_schema_case_5_list_validation() -> None:
+def test_validate_cerberus_schema_list_validation() -> None:
     """
     Test case 5: List schema validation.
     """
@@ -113,7 +113,7 @@ def test_validate_cerberus_schema_case_5_list_validation() -> None:
     assert result["tags"] == ["python", "validation", "test"]
 
 
-def test_validate_cerberus_schema_case_6_value_constraints() -> None:
+def test_validate_cerberus_schema_value_constraints() -> None:
     """
     Test case 6: Value constraint validation.
     """
@@ -134,7 +134,7 @@ def test_validate_cerberus_schema_case_6_value_constraints() -> None:
     assert result["status"] == "active"
 
 
-def test_validate_cerberus_schema_case_7_allow_unknown_fields() -> None:
+def test_validate_cerberus_schema_allow_unknown_fields() -> None:
     """
     Test case 7: Allow unknown fields validation.
     """
@@ -149,7 +149,7 @@ def test_validate_cerberus_schema_case_7_allow_unknown_fields() -> None:
     assert result["extra_field"] == "should be allowed"
 
 
-def test_validate_cerberus_schema_case_8_without_normalization() -> None:
+def test_validate_cerberus_schema_without_normalization() -> None:
     """
     Test case 8: Validation without normalization.
     """
@@ -165,7 +165,7 @@ def test_validate_cerberus_schema_case_8_without_normalization() -> None:
     assert "count" not in result  # Default not applied without normalization
 
 
-def test_validate_cerberus_schema_case_17_edge_cases() -> None:
+def test_validate_cerberus_schema_edge_cases() -> None:
     """
     Test case 9: Edge cases and boundary conditions.
     """
@@ -190,7 +190,7 @@ def test_validate_cerberus_schema_case_17_edge_cases() -> None:
     assert result["score"] == 100
 
 
-def test_validate_cerberus_schema_case_19_performance_large_data() -> None:
+def test_validate_cerberus_schema_performance_large_data() -> None:
     """
     Test case 10: Performance with large data structures.
     """
@@ -217,7 +217,7 @@ def test_validate_cerberus_schema_case_19_performance_large_data() -> None:
     assert elapsed_time < 2.0  # Should complete within 2 seconds
 
 
-def test_validate_cerberus_schema_case_9_type_error_invalid_data() -> None:
+def test_validate_cerberus_schema_type_error_invalid_data() -> None:
     """
     Test case 11: TypeError for invalid data type.
     """
@@ -234,7 +234,7 @@ def test_validate_cerberus_schema_case_9_type_error_invalid_data() -> None:
         validate_cerberus_schema(123, schema, param_name="user_data")
 
 
-def test_validate_cerberus_schema_case_10_type_error_invalid_schema() -> None:
+def test_validate_cerberus_schema_type_error_invalid_schema() -> None:
     """
     Test case 12: TypeError for invalid schema type.
     """
@@ -247,7 +247,7 @@ def test_validate_cerberus_schema_case_10_type_error_invalid_schema() -> None:
         validate_cerberus_schema(data, "not a dict")
 
 
-def test_validate_cerberus_schema_case_11_type_error_invalid_parameters() -> None:
+def test_validate_cerberus_schema_type_error_invalid_parameters() -> None:
     """
     Test case 13: TypeError for invalid parameter types.
     """
@@ -264,7 +264,7 @@ def test_validate_cerberus_schema_case_11_type_error_invalid_parameters() -> Non
         validate_cerberus_schema(data, schema, param_name=123)
 
 
-def test_validate_cerberus_schema_case_12_value_error_missing_required() -> None:
+def test_validate_cerberus_schema_value_error_missing_required() -> None:
     """
     Test case 14: ValueError for missing required fields.
     """
@@ -279,7 +279,7 @@ def test_validate_cerberus_schema_case_12_value_error_missing_required() -> None
         validate_cerberus_schema(data, schema)
 
 
-def test_validate_cerberus_schema_case_13_value_error_type_mismatch() -> None:
+def test_validate_cerberus_schema_value_error_type_mismatch() -> None:
     """
     Test case 15: ValueError for type mismatches.
     """
@@ -291,7 +291,7 @@ def test_validate_cerberus_schema_case_13_value_error_type_mismatch() -> None:
         validate_cerberus_schema(data, schema)
 
 
-def test_validate_cerberus_schema_case_14_value_error_constraint_violations() -> None:
+def test_validate_cerberus_schema_value_error_constraint_violations() -> None:
     """
     Test case 16: ValueError for constraint violations.
     """
@@ -317,7 +317,7 @@ def test_validate_cerberus_schema_case_14_value_error_constraint_violations() ->
         validate_cerberus_schema(data, schema)
 
 
-def test_validate_cerberus_schema_case_15_value_error_unknown_fields() -> None:
+def test_validate_cerberus_schema_value_error_unknown_fields() -> None:
     """
     Test case 17: ValueError for unknown fields when not allowed.
     """
@@ -329,7 +329,7 @@ def test_validate_cerberus_schema_case_15_value_error_unknown_fields() -> None:
         validate_cerberus_schema(data, schema, allow_unknown=False)
 
 
-def test_validate_cerberus_schema_case_16_value_error_nested_validation() -> None:
+def test_validate_cerberus_schema_value_error_nested_validation() -> None:
     """
     Test case 18: ValueError for nested validation failures.
     """
@@ -354,7 +354,7 @@ def test_validate_cerberus_schema_case_16_value_error_nested_validation() -> Non
         validate_cerberus_schema(data, schema)
 
 
-def test_validate_cerberus_schema_case_18_custom_param_name() -> None:
+def test_validate_cerberus_schema_custom_param_name() -> None:
     """
     Test case 19: Custom parameter name in error messages.
     """
@@ -365,7 +365,7 @@ def test_validate_cerberus_schema_case_18_custom_param_name() -> None:
         validate_cerberus_schema(data, schema, param_name="config_data")
 
 
-def test_validate_cerberus_schema_case_20_cerberus_not_available() -> None:
+def test_validate_cerberus_schema_cerberus_not_available() -> None:
     """Test case 20: ImportError when Cerberus is not available."""
     # Save the original module if it exists
     original_module = sys.modules.get('data_validation.schema_validation.validate_cerberus_schema')
@@ -391,7 +391,7 @@ def test_validate_cerberus_schema_case_20_cerberus_not_available() -> None:
             sys.modules['data_validation.schema_validation.validate_cerberus_schema'] = original_module
 
 
-def test_validate_cerberus_schema_case_21_normalize_type_error() -> None:
+def test_validate_cerberus_schema_normalize_type_error() -> None:
     """Test case 21: TypeError for invalid normalize parameter."""
     schema = {"name": {"type": "string"}}
     data = {"name": "test"}
@@ -399,7 +399,7 @@ def test_validate_cerberus_schema_case_21_normalize_type_error() -> None:
         validate_cerberus_schema(data, schema, normalize="yes")
 
 
-def test_validate_cerberus_schema_case_22_param_name_type_error() -> None:
+def test_validate_cerberus_schema_param_name_type_error() -> None:
     """Test case 22: TypeError for invalid param_name parameter."""
     schema = {"name": {"type": "string"}}
     data = {"name": "test"}
@@ -407,7 +407,7 @@ def test_validate_cerberus_schema_case_22_param_name_type_error() -> None:
         validate_cerberus_schema(data, schema, param_name=123)
 
 
-def test_validate_cerberus_schema_case_23_allow_unknown_type_error() -> None:
+def test_validate_cerberus_schema_allow_unknown_type_error() -> None:
     """Test case 23: TypeError for invalid allow_unknown parameter."""
     schema = {"name": {"type": "string"}}
     data = {"name": "test"}

--- a/pytest/unit/file_functions/file_hashing/test_calculate_md5_hash.py
+++ b/pytest/unit/file_functions/file_hashing/test_calculate_md5_hash.py
@@ -7,7 +7,7 @@ import pytest
 from file_functions import calculate_md5_hash
 
 
-def test_calculate_md5_hash_case_1_normal_operation() -> None:
+def test_calculate_md5_hash_normal_operation() -> None:
     """
     Test case 1: Normal operation with known content.
     """
@@ -27,7 +27,7 @@ def test_calculate_md5_hash_case_1_normal_operation() -> None:
         Path(temp_file_path).unlink()
 
 
-def test_calculate_md5_hash_case_2_empty_file() -> None:
+def test_calculate_md5_hash_empty_file() -> None:
     """
     Test case 2: MD5 hash of empty file.
     """
@@ -46,7 +46,7 @@ def test_calculate_md5_hash_case_2_empty_file() -> None:
         Path(temp_file_path).unlink()
 
 
-def test_calculate_md5_hash_case_3_custom_chunk_size() -> None:
+def test_calculate_md5_hash_custom_chunk_size() -> None:
     """
     Test case 3: Function works with custom chunk size.
     """
@@ -66,7 +66,7 @@ def test_calculate_md5_hash_case_3_custom_chunk_size() -> None:
         Path(temp_file_path).unlink()
 
 
-def test_calculate_md5_hash_case_4_large_file() -> None:
+def test_calculate_md5_hash_large_file() -> None:
     """
     Test case 4: Handle large file efficiently.
     """
@@ -87,7 +87,7 @@ def test_calculate_md5_hash_case_4_large_file() -> None:
         Path(temp_file_path).unlink()
 
 
-def test_calculate_md5_hash_case_5_path_object_input() -> None:
+def test_calculate_md5_hash_path_object_input() -> None:
     """
     Test case 5: Function works with Path object input.
     """
@@ -107,7 +107,7 @@ def test_calculate_md5_hash_case_5_path_object_input() -> None:
         temp_file_path.unlink()
 
 
-def test_calculate_md5_hash_case_6_non_existent_file_error() -> None:
+def test_calculate_md5_hash_non_existent_file_error() -> None:
     """
     Test case 6: ValueError for non-existent file.
     """
@@ -119,7 +119,7 @@ def test_calculate_md5_hash_case_6_non_existent_file_error() -> None:
         calculate_md5_hash(non_existent_file)
 
 
-def test_calculate_md5_hash_case_7_invalid_type_errors() -> None:
+def test_calculate_md5_hash_invalid_type_errors() -> None:
     """
     Test case 7: TypeError for invalid parameter types.
     """
@@ -132,7 +132,7 @@ def test_calculate_md5_hash_case_7_invalid_type_errors() -> None:
         calculate_md5_hash("/tmp/file.txt", chunk_size="not_int")
 
 
-def test_calculate_md5_hash_case_8_directory_path_error() -> None:
+def test_calculate_md5_hash_directory_path_error() -> None:
     """
     Test case 8: ValueError when path points to directory.
     """
@@ -143,7 +143,7 @@ def test_calculate_md5_hash_case_8_directory_path_error() -> None:
             calculate_md5_hash(temp_dir)
 
 
-def test_calculate_md5_hash_case_9_invalid_chunk_size_error() -> None:
+def test_calculate_md5_hash_invalid_chunk_size_error() -> None:
     """
     Test case 9: ValueError for invalid chunk size.
     """
@@ -157,7 +157,7 @@ def test_calculate_md5_hash_case_9_invalid_chunk_size_error() -> None:
             calculate_md5_hash(temp_file.name, chunk_size=-1)
 
 
-def test_calculate_md5_hash_case_10_file_read_error() -> None:
+def test_calculate_md5_hash_file_read_error() -> None:
     """
     Test case 10: OSError handling during file reading.
     """

--- a/pytest/unit/file_functions/file_hashing/test_calculate_sha1_hash.py
+++ b/pytest/unit/file_functions/file_hashing/test_calculate_sha1_hash.py
@@ -7,7 +7,7 @@ import pytest
 from file_functions import calculate_sha1_hash
 
 
-def test_calculate_sha1_hash_case_1_normal_operation() -> None:
+def test_calculate_sha1_hash_normal_operation() -> None:
     """
     Test case 1: Normal operation with known content.
     """
@@ -27,7 +27,7 @@ def test_calculate_sha1_hash_case_1_normal_operation() -> None:
         Path(temp_file_path).unlink()
 
 
-def test_calculate_sha1_hash_case_2_empty_file() -> None:
+def test_calculate_sha1_hash_empty_file() -> None:
     """
     Test case 2: SHA1 hash of empty file.
     """
@@ -46,7 +46,7 @@ def test_calculate_sha1_hash_case_2_empty_file() -> None:
         Path(temp_file_path).unlink()
 
 
-def test_calculate_sha1_hash_case_3_custom_chunk_size() -> None:
+def test_calculate_sha1_hash_custom_chunk_size() -> None:
     """
     Test case 3: Function works with custom chunk size.
     """
@@ -66,7 +66,7 @@ def test_calculate_sha1_hash_case_3_custom_chunk_size() -> None:
         Path(temp_file_path).unlink()
 
 
-def test_calculate_sha1_hash_case_4_large_file() -> None:
+def test_calculate_sha1_hash_large_file() -> None:
     """
     Test case 4: Handle large file efficiently.
     """
@@ -87,7 +87,7 @@ def test_calculate_sha1_hash_case_4_large_file() -> None:
         Path(temp_file_path).unlink()
 
 
-def test_calculate_sha1_hash_case_5_path_object_input() -> None:
+def test_calculate_sha1_hash_path_object_input() -> None:
     """
     Test case 5: Function works with Path object input.
     """
@@ -107,7 +107,7 @@ def test_calculate_sha1_hash_case_5_path_object_input() -> None:
         temp_file_path.unlink()
 
 
-def test_calculate_sha1_hash_case_6_non_existent_file_error() -> None:
+def test_calculate_sha1_hash_non_existent_file_error() -> None:
     """
     Test case 6: ValueError for non-existent file.
     """
@@ -119,7 +119,7 @@ def test_calculate_sha1_hash_case_6_non_existent_file_error() -> None:
         calculate_sha1_hash(non_existent_file)
 
 
-def test_calculate_sha1_hash_case_7_invalid_type_errors() -> None:
+def test_calculate_sha1_hash_invalid_type_errors() -> None:
     """
     Test case 7: TypeError for invalid parameter types.
     """
@@ -132,7 +132,7 @@ def test_calculate_sha1_hash_case_7_invalid_type_errors() -> None:
         calculate_sha1_hash("/tmp/file.txt", chunk_size="not_int")
 
 
-def test_calculate_sha1_hash_case_8_directory_path_error() -> None:
+def test_calculate_sha1_hash_directory_path_error() -> None:
     """
     Test case 8: ValueError when path points to directory.
     """
@@ -143,7 +143,7 @@ def test_calculate_sha1_hash_case_8_directory_path_error() -> None:
             calculate_sha1_hash(temp_dir)
 
 
-def test_calculate_sha1_hash_case_9_invalid_chunk_size_error() -> None:
+def test_calculate_sha1_hash_invalid_chunk_size_error() -> None:
     """
     Test case 9: ValueError for invalid chunk size.
     """
@@ -157,7 +157,7 @@ def test_calculate_sha1_hash_case_9_invalid_chunk_size_error() -> None:
             calculate_sha1_hash(temp_file.name, chunk_size=-1)
 
 
-def test_calculate_sha1_hash_case_10_file_read_error() -> None:
+def test_calculate_sha1_hash_file_read_error() -> None:
     """
     Test case 10: OSError handling during file reading.
     """

--- a/pytest/unit/file_functions/file_hashing/test_calculate_sha256_hash.py
+++ b/pytest/unit/file_functions/file_hashing/test_calculate_sha256_hash.py
@@ -7,7 +7,7 @@ import pytest
 from file_functions import calculate_sha256_hash
 
 
-def test_calculate_sha256_hash_case_1_normal_operation() -> None:
+def test_calculate_sha256_hash_normal_operation() -> None:
     """
     Test case 1: Normal operation with known content.
     """
@@ -27,7 +27,7 @@ def test_calculate_sha256_hash_case_1_normal_operation() -> None:
         Path(temp_file_path).unlink()
 
 
-def test_calculate_sha256_hash_case_2_empty_file() -> None:
+def test_calculate_sha256_hash_empty_file() -> None:
     """
     Test case 2: SHA256 hash of empty file.
     """
@@ -46,7 +46,7 @@ def test_calculate_sha256_hash_case_2_empty_file() -> None:
         Path(temp_file_path).unlink()
 
 
-def test_calculate_sha256_hash_case_3_custom_chunk_size() -> None:
+def test_calculate_sha256_hash_custom_chunk_size() -> None:
     """
     Test case 3: Function works with custom chunk size.
     """
@@ -66,7 +66,7 @@ def test_calculate_sha256_hash_case_3_custom_chunk_size() -> None:
         Path(temp_file_path).unlink()
 
 
-def test_calculate_sha256_hash_case_4_large_file() -> None:
+def test_calculate_sha256_hash_large_file() -> None:
     """
     Test case 4: Handle large file efficiently.
     """
@@ -87,7 +87,7 @@ def test_calculate_sha256_hash_case_4_large_file() -> None:
         Path(temp_file_path).unlink()
 
 
-def test_calculate_sha256_hash_case_5_path_object_input() -> None:
+def test_calculate_sha256_hash_path_object_input() -> None:
     """
     Test case 5: Function works with Path object input.
     """
@@ -107,7 +107,7 @@ def test_calculate_sha256_hash_case_5_path_object_input() -> None:
         temp_file_path.unlink()
 
 
-def test_calculate_sha256_hash_case_6_non_existent_file_error() -> None:
+def test_calculate_sha256_hash_non_existent_file_error() -> None:
     """
     Test case 6: ValueError for non-existent file.
     """
@@ -119,7 +119,7 @@ def test_calculate_sha256_hash_case_6_non_existent_file_error() -> None:
         calculate_sha256_hash(non_existent_file)
 
 
-def test_calculate_sha256_hash_case_7_invalid_type_errors() -> None:
+def test_calculate_sha256_hash_invalid_type_errors() -> None:
     """
     Test case 7: TypeError for invalid parameter types.
     """
@@ -132,7 +132,7 @@ def test_calculate_sha256_hash_case_7_invalid_type_errors() -> None:
         calculate_sha256_hash("/tmp/file.txt", chunk_size="not_int")
 
 
-def test_calculate_sha256_hash_case_8_directory_path_error() -> None:
+def test_calculate_sha256_hash_directory_path_error() -> None:
     """
     Test case 8: ValueError when path points to directory.
     """
@@ -143,7 +143,7 @@ def test_calculate_sha256_hash_case_8_directory_path_error() -> None:
             calculate_sha256_hash(temp_dir)
 
 
-def test_calculate_sha256_hash_case_9_invalid_chunk_size_error() -> None:
+def test_calculate_sha256_hash_invalid_chunk_size_error() -> None:
     """
     Test case 9: ValueError for invalid chunk size.
     """
@@ -157,7 +157,7 @@ def test_calculate_sha256_hash_case_9_invalid_chunk_size_error() -> None:
             calculate_sha256_hash(temp_file.name, chunk_size=-1)
 
 
-def test_calculate_sha256_hash_case_10_file_read_error() -> None:
+def test_calculate_sha256_hash_file_read_error() -> None:
     """
     Test case 10: OSError handling during file reading.
     """

--- a/pytest/unit/file_functions/file_hashing/test_compare_file_hashes.py
+++ b/pytest/unit/file_functions/file_hashing/test_compare_file_hashes.py
@@ -5,7 +5,7 @@ import pytest
 from file_functions import compare_file_hashes
 
 
-def test_compare_file_hashes_case_1_identical_files() -> None:
+def test_compare_file_hashes_identical_files() -> None:
     """
     Test case 1: Compare identical files returns True.
     """
@@ -29,7 +29,7 @@ def test_compare_file_hashes_case_1_identical_files() -> None:
         Path(file2_path).unlink()
 
 
-def test_compare_file_hashes_case_2_different_files() -> None:
+def test_compare_file_hashes_different_files() -> None:
     """
     Test case 2: Compare different files returns False.
     """
@@ -53,7 +53,7 @@ def test_compare_file_hashes_case_2_different_files() -> None:
         Path(file2_path).unlink()
 
 
-def test_compare_file_hashes_case_3_sha256_algorithm() -> None:
+def test_compare_file_hashes_sha256_algorithm() -> None:
     """
     Test case 3: Compare files using SHA256 algorithm.
     """
@@ -77,7 +77,7 @@ def test_compare_file_hashes_case_3_sha256_algorithm() -> None:
         Path(file2_path).unlink()
 
 
-def test_compare_file_hashes_case_4_sha1_algorithm() -> None:
+def test_compare_file_hashes_sha1_algorithm() -> None:
     """
     Test case 4: Compare files using SHA1 algorithm.
     """
@@ -101,7 +101,7 @@ def test_compare_file_hashes_case_4_sha1_algorithm() -> None:
         Path(file2_path).unlink()
 
 
-def test_compare_file_hashes_case_5_custom_chunk_size() -> None:
+def test_compare_file_hashes_custom_chunk_size() -> None:
     """
     Test case 5: Compare files with custom chunk size.
     """
@@ -125,7 +125,7 @@ def test_compare_file_hashes_case_5_custom_chunk_size() -> None:
         Path(file2_path).unlink()
 
 
-def test_compare_file_hashes_case_6_path_objects() -> None:
+def test_compare_file_hashes_path_objects() -> None:
     """
     Test case 6: Function works with Path object inputs.
     """
@@ -149,7 +149,7 @@ def test_compare_file_hashes_case_6_path_objects() -> None:
         file2_path.unlink()
 
 
-def test_compare_file_hashes_case_7_invalid_algorithm_error() -> None:
+def test_compare_file_hashes_invalid_algorithm_error() -> None:
     """
     Test case 7: ValueError for invalid hash algorithm.
     """
@@ -160,7 +160,7 @@ def test_compare_file_hashes_case_7_invalid_algorithm_error() -> None:
             compare_file_hashes(file1.name, file2.name, hash_algorithm="invalid")
 
 
-def test_compare_file_hashes_case_8_invalid_type_errors() -> None:
+def test_compare_file_hashes_invalid_type_errors() -> None:
     """
     Test case 8: TypeError for invalid parameter types.
     """
@@ -181,7 +181,7 @@ def test_compare_file_hashes_case_8_invalid_type_errors() -> None:
         compare_file_hashes("/tmp/file1.txt", "/tmp/file2.txt", chunk_size="not_int")
 
 
-def test_compare_file_hashes_case_9_invalid_chunk_size_error() -> None:
+def test_compare_file_hashes_invalid_chunk_size_error() -> None:
     """
     Test case 9: ValueError for invalid chunk size.
     """
@@ -192,7 +192,7 @@ def test_compare_file_hashes_case_9_invalid_chunk_size_error() -> None:
             compare_file_hashes(file1.name, file2.name, chunk_size=0)
 
 
-def test_compare_file_hashes_case_10_file_not_found_propagation() -> None:
+def test_compare_file_hashes_file_not_found_propagation() -> None:
     """
     Test case 10: Proper error propagation when files don't exist.
     """

--- a/pytest/unit/file_functions/file_operations/test_write_lines.py
+++ b/pytest/unit/file_functions/file_operations/test_write_lines.py
@@ -5,7 +5,7 @@ import pytest
 from file_functions import write_lines
 
 
-def test_write_lines_case_1_default_joiner() -> None:
+def test_write_lines_default_joiner() -> None:
     """
     Test case 1: Write lines with default newline joiner.
     """
@@ -23,7 +23,7 @@ def test_write_lines_case_1_default_joiner() -> None:
         assert content == "line1\nline2\nline3\n"
 
 
-def test_write_lines_case_2_custom_joiner() -> None:
+def test_write_lines_custom_joiner() -> None:
     """
     Test case 2: Write lines with custom joiner.
     """
@@ -41,7 +41,7 @@ def test_write_lines_case_2_custom_joiner() -> None:
         assert content == "apple, banana, cherry\n"
 
 
-def test_write_lines_case_3_append_mode() -> None:
+def test_write_lines_append_mode() -> None:
     """
     Test case 3: Write lines in append mode.
     """
@@ -64,7 +64,7 @@ def test_write_lines_case_3_append_mode() -> None:
         assert content == "initial\nappended1\nappended2\n"
 
 
-def test_write_lines_case_6_empty_list() -> None:
+def test_write_lines_empty_list() -> None:
     """
     Test case 4: Write empty list of lines.
     """
@@ -82,7 +82,7 @@ def test_write_lines_case_6_empty_list() -> None:
         assert content == "\n"  # Just the final newline
 
 
-def test_write_lines_case_7_lines_with_non_strings() -> None:
+def test_write_lines_lines_with_non_strings() -> None:
     """
     Test case 5: Handle non-string items in lines list.
     """
@@ -100,7 +100,7 @@ def test_write_lines_case_7_lines_with_non_strings() -> None:
         assert content == "string\n123\nTrue\nNone\n"
 
 
-def test_write_lines_case_8_unicode_content() -> None:
+def test_write_lines_unicode_content() -> None:
     """
     Test case 6: Handle Unicode characters in lines.
     """
@@ -118,7 +118,7 @@ def test_write_lines_case_8_unicode_content() -> None:
         assert content == "Hello 世界\nümläuts\némojis 🎉\n"
 
 
-def test_write_lines_case_9_overwrite_mode() -> None:
+def test_write_lines_overwrite_mode() -> None:
     """
     Test case 7: Write lines in overwrite mode (default).
     """
@@ -141,7 +141,7 @@ def test_write_lines_case_9_overwrite_mode() -> None:
         assert content == "new\ncontent\n"
 
 
-def test_write_lines_case_10_custom_joiner_no_spaces() -> None:
+def test_write_lines_custom_joiner_no_spaces() -> None:
     """
     Test case 8: Write lines with custom joiner without spaces.
     """
@@ -159,7 +159,7 @@ def test_write_lines_case_10_custom_joiner_no_spaces() -> None:
         assert content == "a|b|c|d\n"
 
 
-def test_write_lines_case_4_type_validation() -> None:
+def test_write_lines_type_validation() -> None:
     """
     Test case 9: Type validation for parameters.
     """
@@ -180,7 +180,7 @@ def test_write_lines_case_4_type_validation() -> None:
         write_lines(["line1"], "output.txt", write_mode=123)
 
 
-def test_write_lines_case_5_value_validation() -> None:
+def test_write_lines_value_validation() -> None:
     """
     Test case 10: Value validation for parameters.
     """

--- a/pytest/unit/file_functions/file_operations/test_write_to_file.py
+++ b/pytest/unit/file_functions/file_operations/test_write_to_file.py
@@ -5,7 +5,7 @@ import pytest
 from file_functions import write_to_file
 
 
-def test_write_to_file_case_1_basic_write() -> None:
+def test_write_to_file_basic_write() -> None:
     """
     Test case 1: Basic file write operation.
     """
@@ -22,7 +22,7 @@ def test_write_to_file_case_1_basic_write() -> None:
             assert f.read() == content
 
 
-def test_write_to_file_case_2_write_mode() -> None:
+def test_write_to_file_write_mode() -> None:
     """
     Test case 2: Write with explicit write mode.
     """
@@ -39,7 +39,7 @@ def test_write_to_file_case_2_write_mode() -> None:
             assert f.read() == content
 
 
-def test_write_to_file_case_3_append_mode() -> None:
+def test_write_to_file_append_mode() -> None:
     """
     Test case 3: Write in append mode.
     """
@@ -62,7 +62,7 @@ def test_write_to_file_case_3_append_mode() -> None:
             assert f.read() == initial_content + additional_content
 
 
-def test_write_to_file_case_4_custom_end_char() -> None:
+def test_write_to_file_custom_end_char() -> None:
     """
     Test case 4: Write with custom end character.
     """
@@ -80,7 +80,7 @@ def test_write_to_file_case_4_custom_end_char() -> None:
             assert f.read() == content + end_char
 
 
-def test_write_to_file_case_7_unicode_content() -> None:
+def test_write_to_file_unicode_content() -> None:
     """
     Test case 5: Handle Unicode characters in content.
     """
@@ -97,7 +97,7 @@ def test_write_to_file_case_7_unicode_content() -> None:
             assert f.read() == content
 
 
-def test_write_to_file_case_8_empty_content() -> None:
+def test_write_to_file_empty_content() -> None:
     """
     Test case 6: Write empty content.
     """
@@ -114,7 +114,7 @@ def test_write_to_file_case_8_empty_content() -> None:
             assert f.read() == content
 
 
-def test_write_to_file_case_9_exclusive_mode() -> None:
+def test_write_to_file_exclusive_mode() -> None:
     """
     Test case 7: Write in exclusive mode (file must not exist).
     """
@@ -131,7 +131,7 @@ def test_write_to_file_case_9_exclusive_mode() -> None:
             assert f.read() == content
 
 
-def test_write_to_file_case_11_multiline_content() -> None:
+def test_write_to_file_multiline_content() -> None:
     """
     Test case 8: Handle multiline content.
     """
@@ -148,7 +148,7 @@ def test_write_to_file_case_11_multiline_content() -> None:
             assert f.read() == content
 
 
-def test_write_to_file_case_12_special_characters() -> None:
+def test_write_to_file_special_characters() -> None:
     """
     Test case 9: Handle special characters in content.
     """
@@ -165,7 +165,7 @@ def test_write_to_file_case_12_special_characters() -> None:
             assert f.read() == content
 
 
-def test_write_to_file_case_5_type_validation() -> None:
+def test_write_to_file_type_validation() -> None:
     """
     Test case 10: Type validation for parameters.
     """
@@ -186,7 +186,7 @@ def test_write_to_file_case_5_type_validation() -> None:
         write_to_file("content", "output.txt", end_char=123)
 
 
-def test_write_to_file_case_6_value_validation() -> None:
+def test_write_to_file_value_validation() -> None:
     """
     Test case 11: Value validation for parameters.
     """
@@ -199,7 +199,7 @@ def test_write_to_file_case_6_value_validation() -> None:
         write_to_file("content", "output.txt", mode="invalid")
 
 
-def test_write_to_file_case_10_exclusive_mode_file_exists() -> None:
+def test_write_to_file_exclusive_mode_file_exists() -> None:
     """
     Test case 12: Exclusive mode should raise error if file exists.
     """

--- a/pytest/unit/file_functions/recursive_search/test_find_files_by_extension.py
+++ b/pytest/unit/file_functions/recursive_search/test_find_files_by_extension.py
@@ -6,7 +6,7 @@ import pytest
 from file_functions import find_files_by_extension
 
 
-def test_find_files_by_extension_case_1_normal_operation() -> None:
+def test_find_files_by_extension_normal_operation() -> None:
     """
     Test case 1: Normal operation with Python files.
     """
@@ -30,7 +30,7 @@ def test_find_files_by_extension_case_1_normal_operation() -> None:
         assert "utils.py" in py_files
 
 
-def test_find_files_by_extension_case_2_extension_without_dot() -> None:
+def test_find_files_by_extension_extension_without_dot() -> None:
     """
     Test case 2: Extension specified without leading dot.
     """
@@ -47,7 +47,7 @@ def test_find_files_by_extension_case_2_extension_without_dot() -> None:
         assert Path(result[0]).name == "file.txt"
 
 
-def test_find_files_by_extension_case_3_case_sensitive() -> None:
+def test_find_files_by_extension_case_sensitive() -> None:
     """
     Test case 3: Case sensitive search.
     """
@@ -74,7 +74,7 @@ def test_find_files_by_extension_case_3_case_sensitive() -> None:
         assert found_names == {"file1.TXT", "file2.txt"}
 
 
-def test_find_files_by_extension_case_4_empty_directory() -> None:
+def test_find_files_by_extension_empty_directory() -> None:
     """
     Test case 4: Empty directory returns empty list.
     """
@@ -87,7 +87,7 @@ def test_find_files_by_extension_case_4_empty_directory() -> None:
         assert result == []
 
 
-def test_find_files_by_extension_case_8_path_object_input() -> None:
+def test_find_files_by_extension_path_object_input() -> None:
     """
     Test case 5: Function works with Path object input.
     """
@@ -104,7 +104,7 @@ def test_find_files_by_extension_case_8_path_object_input() -> None:
         assert Path(result[0]).name == "test.py"
 
 
-def test_find_files_by_extension_case_5_invalid_directory_error() -> None:
+def test_find_files_by_extension_invalid_directory_error() -> None:
     """
     Test case 6: ValueError for non-existent directory.
     """
@@ -116,7 +116,7 @@ def test_find_files_by_extension_case_5_invalid_directory_error() -> None:
         find_files_by_extension(non_existent_dir, ".py")
 
 
-def test_find_files_by_extension_case_6_invalid_type_errors() -> None:
+def test_find_files_by_extension_invalid_type_errors() -> None:
     """
     Test case 7: TypeError for invalid parameter types.
     """
@@ -133,7 +133,7 @@ def test_find_files_by_extension_case_6_invalid_type_errors() -> None:
         find_files_by_extension("/tmp", ".py", "not_bool")
 
 
-def test_find_files_by_extension_case_7_empty_extension_error() -> None:
+def test_find_files_by_extension_empty_extension_error() -> None:
     """
     Test case 8: ValueError for empty extension.
     """
@@ -144,7 +144,7 @@ def test_find_files_by_extension_case_7_empty_extension_error() -> None:
             find_files_by_extension(temp_dir, "")
 
 
-def test_find_files_by_extension_case_9_file_path_not_directory_error() -> None:
+def test_find_files_by_extension_file_path_not_directory_error() -> None:
     """
     Test case 9: ValueError when path points to a file, not directory.
     """
@@ -155,7 +155,7 @@ def test_find_files_by_extension_case_9_file_path_not_directory_error() -> None:
             find_files_by_extension(temp_file.name, ".py")
 
 
-def test_find_files_by_extension_case_10_os_error_handling() -> None:
+def test_find_files_by_extension_os_error_handling() -> None:
     """
     Test case 10: OSError handling during directory walk.
     """

--- a/pytest/unit/file_functions/recursive_search/test_find_files_by_mtime.py
+++ b/pytest/unit/file_functions/recursive_search/test_find_files_by_mtime.py
@@ -9,7 +9,7 @@ import pytest
 from file_functions import find_files_by_mtime
 
 
-def test_find_files_by_mtime_case_1_newer_than_filter() -> None:
+def test_find_files_by_mtime_newer_than_filter() -> None:
     """
     Test case 1: Filter files newer than specified datetime.
     """
@@ -38,7 +38,7 @@ def test_find_files_by_mtime_case_1_newer_than_filter() -> None:
         assert Path(file_path).name == "new.txt"
 
 
-def test_find_files_by_mtime_case_2_older_than_filter() -> None:
+def test_find_files_by_mtime_older_than_filter() -> None:
     """
     Test case 2: Filter files older than specified datetime.
     """
@@ -67,7 +67,7 @@ def test_find_files_by_mtime_case_2_older_than_filter() -> None:
         assert Path(file_path).name == "old.txt"
 
 
-def test_find_files_by_mtime_case_3_days_old_filter() -> None:
+def test_find_files_by_mtime_days_old_filter() -> None:
     """
     Test case 3: Filter files modified exactly N days ago.
     """
@@ -93,7 +93,7 @@ def test_find_files_by_mtime_case_3_days_old_filter() -> None:
         assert Path(file_path).name == "target.txt"
 
 
-def test_find_files_by_mtime_case_4_combined_filters() -> None:
+def test_find_files_by_mtime_combined_filters() -> None:
     """
     Test case 4: Combined newer_than and older_than filters.
     """
@@ -130,7 +130,7 @@ def test_find_files_by_mtime_case_4_combined_filters() -> None:
         assert Path(file_path).name == "middle.txt"
 
 
-def test_find_files_by_mtime_case_10_file_access_error_handling() -> None:
+def test_find_files_by_mtime_file_access_error_handling() -> None:
     """
     Test case 5: Graceful handling of file access errors.
     """
@@ -157,7 +157,7 @@ def test_find_files_by_mtime_case_10_file_access_error_handling() -> None:
             assert result == []
 
 
-def test_find_files_by_mtime_case_5_no_criteria_error() -> None:
+def test_find_files_by_mtime_no_criteria_error() -> None:
     """
     Test case 6: ValueError when no time criteria specified.
     """
@@ -170,7 +170,7 @@ def test_find_files_by_mtime_case_5_no_criteria_error() -> None:
                         find_files_by_mtime(temp_dir)
 
 
-def test_find_files_by_mtime_case_11_path_is_file_not_directory() -> None:
+def test_find_files_by_mtime_path_is_file_not_directory() -> None:
     """
     Test case 7: ValueError when path is a file, not a directory.
     """
@@ -185,7 +185,7 @@ def test_find_files_by_mtime_case_11_path_is_file_not_directory() -> None:
             find_files_by_mtime(str(file_path), newer_than=cutoff)
 
 
-def test_find_files_by_mtime_case_6_invalid_directory_error() -> None:
+def test_find_files_by_mtime_invalid_directory_error() -> None:
     """
     Test case 8: ValueError for non-existent directory.
     """
@@ -198,7 +198,7 @@ def test_find_files_by_mtime_case_6_invalid_directory_error() -> None:
         find_files_by_mtime(non_existent_dir, newer_than=cutoff)
 
 
-def test_find_files_by_mtime_case_7_invalid_type_errors() -> None:
+def test_find_files_by_mtime_invalid_type_errors() -> None:
     """
     Test case 9: TypeError for invalid parameter types.
     """
@@ -221,7 +221,7 @@ def test_find_files_by_mtime_case_7_invalid_type_errors() -> None:
         find_files_by_mtime("/tmp", older_than="not_datetime")
 
 
-def test_find_files_by_mtime_case_8_invalid_time_range() -> None:
+def test_find_files_by_mtime_invalid_time_range() -> None:
     """
     Test case 10: ValueError for invalid time range.
     """
@@ -235,7 +235,7 @@ def test_find_files_by_mtime_case_8_invalid_time_range() -> None:
             find_files_by_mtime(temp_dir, newer_than=newer_than, older_than=older_than)
 
 
-def test_find_files_by_mtime_case_9_negative_days_old_error() -> None:
+def test_find_files_by_mtime_negative_days_old_error() -> None:
     """
     Test case 11: ValueError for negative days_old.
     """

--- a/pytest/unit/file_functions/recursive_search/test_find_files_by_pattern.py
+++ b/pytest/unit/file_functions/recursive_search/test_find_files_by_pattern.py
@@ -6,7 +6,7 @@ import pytest
 from file_functions import find_files_by_pattern
 
 
-def test_find_files_by_pattern_case_1_wildcard_pattern() -> None:
+def test_find_files_by_pattern_wildcard_pattern() -> None:
     """
     Test case 1: Normal operation with wildcard pattern.
     """
@@ -30,7 +30,7 @@ def test_find_files_by_pattern_case_1_wildcard_pattern() -> None:
         assert "test_utils.py" in file_names
 
 
-def test_find_files_by_pattern_case_2_question_mark_pattern() -> None:
+def test_find_files_by_pattern_question_mark_pattern() -> None:
     """
     Test case 2: Pattern with question mark wildcard.
     """
@@ -51,7 +51,7 @@ def test_find_files_by_pattern_case_2_question_mark_pattern() -> None:
         assert "file10.txt" not in file_names
 
 
-def test_find_files_by_pattern_case_3_case_sensitive() -> None:
+def test_find_files_by_pattern_case_sensitive() -> None:
     """
     Test case 3: Case sensitive pattern matching.
     """
@@ -75,7 +75,7 @@ def test_find_files_by_pattern_case_3_case_sensitive() -> None:
     assert len(result_insensitive) == 1
 
 
-def test_find_files_by_pattern_case_4_bracket_pattern() -> None:
+def test_find_files_by_pattern_bracket_pattern() -> None:
     """
     Test case 4: Pattern with character class brackets.
     """
@@ -98,7 +98,7 @@ def test_find_files_by_pattern_case_4_bracket_pattern() -> None:
         assert "file9.txt" not in file_names
 
 
-def test_find_files_by_pattern_case_5_empty_directory() -> None:
+def test_find_files_by_pattern_empty_directory() -> None:
     """
     Test case 5: Empty directory returns empty list.
     """
@@ -111,7 +111,7 @@ def test_find_files_by_pattern_case_5_empty_directory() -> None:
         assert result == []
 
 
-def test_find_files_by_pattern_case_9_path_object_input() -> None:
+def test_find_files_by_pattern_path_object_input() -> None:
     """
     Test case 6: Function works with Path object input.
     """
@@ -128,7 +128,7 @@ def test_find_files_by_pattern_case_9_path_object_input() -> None:
         assert Path(result[0]).name == "test.py"
 
 
-def test_find_files_by_pattern_case_6_invalid_directory_error() -> None:
+def test_find_files_by_pattern_invalid_directory_error() -> None:
     """
     Test case 7: ValueError for non-existent directory.
     """
@@ -140,7 +140,7 @@ def test_find_files_by_pattern_case_6_invalid_directory_error() -> None:
         find_files_by_pattern(non_existent_dir, "*")
 
 
-def test_find_files_by_pattern_case_7_invalid_type_errors() -> None:
+def test_find_files_by_pattern_invalid_type_errors() -> None:
     """
     Test case 8: TypeError for invalid parameter types.
     """
@@ -157,7 +157,7 @@ def test_find_files_by_pattern_case_7_invalid_type_errors() -> None:
         find_files_by_pattern("/tmp", "*", "not_bool")
 
 
-def test_find_files_by_pattern_case_8_empty_pattern_error() -> None:
+def test_find_files_by_pattern_empty_pattern_error() -> None:
     """
     Test case 9: ValueError for empty pattern.
     """
@@ -168,7 +168,7 @@ def test_find_files_by_pattern_case_8_empty_pattern_error() -> None:
             find_files_by_pattern(temp_dir, "")
 
 
-def test_find_files_by_pattern_case_10_os_error_handling() -> None:
+def test_find_files_by_pattern_os_error_handling() -> None:
     """
     Test case 10: OSError handling during directory walk.
     """

--- a/pytest/unit/file_functions/recursive_search/test_find_files_by_size.py
+++ b/pytest/unit/file_functions/recursive_search/test_find_files_by_size.py
@@ -7,7 +7,7 @@ import pytest
 from file_functions import find_files_by_size
 
 
-def test_find_files_by_size_case_1_normal_operation() -> None:
+def test_find_files_by_size_normal_operation() -> None:
     """
     Test case 1: Normal operation with size filtering.
     """
@@ -32,7 +32,7 @@ def test_find_files_by_size_case_1_normal_operation() -> None:
         assert file_size == 100
 
 
-def test_find_files_by_size_case_2_min_size_only() -> None:
+def test_find_files_by_size_min_size_only() -> None:
     """
     Test case 2: Filter with minimum size only.
     """
@@ -54,7 +54,7 @@ def test_find_files_by_size_case_2_min_size_only() -> None:
         assert file_size == 1000
 
 
-def test_find_files_by_size_case_3_max_size_only() -> None:
+def test_find_files_by_size_max_size_only() -> None:
     """
     Test case 3: Filter with maximum size only.
     """
@@ -76,7 +76,7 @@ def test_find_files_by_size_case_3_max_size_only() -> None:
         assert file_size == 1
 
 
-def test_find_files_by_size_case_4_empty_directory() -> None:
+def test_find_files_by_size_empty_directory() -> None:
     """
     Test case 4: Empty directory returns empty list.
     """
@@ -89,7 +89,7 @@ def test_find_files_by_size_case_4_empty_directory() -> None:
         assert result == []
 
 
-def test_find_files_by_size_case_5_recursive_search() -> None:
+def test_find_files_by_size_recursive_search() -> None:
     """
     Test case 5: Recursive search in subdirectories.
     """
@@ -115,7 +115,7 @@ def test_find_files_by_size_case_5_recursive_search() -> None:
         assert "file2.txt" in file_names
 
 
-def test_find_files_by_size_case_9_path_object_input() -> None:
+def test_find_files_by_size_path_object_input() -> None:
     """
     Test case 6: Function works with Path object input.
     """
@@ -134,7 +134,7 @@ def test_find_files_by_size_case_9_path_object_input() -> None:
         assert Path(file_path).name == "test.txt"
 
 
-def test_find_files_by_size_case_10_file_access_error_handling() -> None:
+def test_find_files_by_size_file_access_error_handling() -> None:
     """
     Test case 7: Graceful handling of file access errors.
     """
@@ -160,7 +160,7 @@ def test_find_files_by_size_case_10_file_access_error_handling() -> None:
             assert result == []
 
 
-def test_find_files_by_size_case_11_path_is_file_not_directory() -> None:
+def test_find_files_by_size_path_is_file_not_directory() -> None:
     """
     Test case 8: ValueError when path is a file, not a directory.
     """
@@ -174,7 +174,7 @@ def test_find_files_by_size_case_11_path_is_file_not_directory() -> None:
             find_files_by_size(str(file_path))
 
 
-def test_find_files_by_size_case_6_invalid_directory_error() -> None:
+def test_find_files_by_size_invalid_directory_error() -> None:
     """
     Test case 9: ValueError for non-existent directory.
     """
@@ -186,7 +186,7 @@ def test_find_files_by_size_case_6_invalid_directory_error() -> None:
         find_files_by_size(non_existent_dir)
 
 
-def test_find_files_by_size_case_7_invalid_type_errors() -> None:
+def test_find_files_by_size_invalid_type_errors() -> None:
     """
     Test case 10: TypeError for invalid parameter types.
     """
@@ -203,7 +203,7 @@ def test_find_files_by_size_case_7_invalid_type_errors() -> None:
         find_files_by_size("/tmp", max_size="not_int")
 
 
-def test_find_files_by_size_case_8_invalid_size_values() -> None:
+def test_find_files_by_size_invalid_size_values() -> None:
     """
     Test case 11: ValueError for invalid size values.
     """

--- a/pytest/unit/file_functions/temp_management/test_cleanup_temp_files.py
+++ b/pytest/unit/file_functions/temp_management/test_cleanup_temp_files.py
@@ -8,7 +8,7 @@ import pytest
 from file_functions import cleanup_temp_files
 
 
-def test_cleanup_temp_files_case_1_normal_operation() -> None:
+def test_cleanup_temp_files_normal_operation() -> None:
     """
     Test case 1: Normal operation cleaning old files.
     """
@@ -36,7 +36,7 @@ def test_cleanup_temp_files_case_1_normal_operation() -> None:
         assert new_file.exists()
 
 
-def test_cleanup_temp_files_case_2_pattern_filtering() -> None:
+def test_cleanup_temp_files_pattern_filtering() -> None:
     """
     Test case 2: Clean files matching specific pattern.
     """
@@ -64,7 +64,7 @@ def test_cleanup_temp_files_case_2_pattern_filtering() -> None:
         assert txt_file.exists()
 
 
-def test_cleanup_temp_files_case_3_dry_run() -> None:
+def test_cleanup_temp_files_dry_run() -> None:
     """
     Test case 3: Dry run mode lists files without deleting.
     """
@@ -86,7 +86,7 @@ def test_cleanup_temp_files_case_3_dry_run() -> None:
         assert old_file.exists()  # File should still exist
 
 
-def test_cleanup_temp_files_case_4_default_temp_directory() -> None:
+def test_cleanup_temp_files_default_temp_directory() -> None:
     """
     Test case 4: Use system temp directory when none specified.
     """
@@ -99,7 +99,7 @@ def test_cleanup_temp_files_case_4_default_temp_directory() -> None:
     assert isinstance(deleted_files, list)
 
 
-def test_cleanup_temp_files_case_5_empty_directory() -> None:
+def test_cleanup_temp_files_empty_directory() -> None:
     """
     Test case 5: Empty directory returns empty list.
     """
@@ -112,7 +112,7 @@ def test_cleanup_temp_files_case_5_empty_directory() -> None:
         assert deleted_files == []
 
 
-def test_cleanup_temp_files_case_6_no_old_files() -> None:
+def test_cleanup_temp_files_no_old_files() -> None:
     """
     Test case 6: No files older than threshold.
     """
@@ -129,7 +129,7 @@ def test_cleanup_temp_files_case_6_no_old_files() -> None:
         assert new_file.exists()
 
 
-def test_cleanup_temp_files_case_7_invalid_directory_error() -> None:
+def test_cleanup_temp_files_invalid_directory_error() -> None:
     """
     Test case 7: ValueError for non-existent directory.
     """
@@ -141,7 +141,7 @@ def test_cleanup_temp_files_case_7_invalid_directory_error() -> None:
         cleanup_temp_files(non_existent_dir, max_age_hours=1.0)
 
 
-def test_cleanup_temp_files_case_8_invalid_type_errors() -> None:
+def test_cleanup_temp_files_invalid_type_errors() -> None:
     """
     Test case 8: TypeError for invalid parameter types.
     """
@@ -162,7 +162,7 @@ def test_cleanup_temp_files_case_8_invalid_type_errors() -> None:
         cleanup_temp_files("/tmp", dry_run="not_bool")
 
 
-def test_cleanup_temp_files_case_9_invalid_max_age_hours() -> None:
+def test_cleanup_temp_files_invalid_max_age_hours() -> None:
     """
     Test case 9: ValueError for invalid max_age_hours value.
     """
@@ -176,7 +176,7 @@ def test_cleanup_temp_files_case_9_invalid_max_age_hours() -> None:
             cleanup_temp_files(temp_dir, max_age_hours=-1)
 
 
-def test_cleanup_temp_files_case_10_file_access_error_handling() -> None:
+def test_cleanup_temp_files_file_access_error_handling() -> None:
     """
     Test case 10: Graceful handling of file access errors.
     """

--- a/pytest/unit/file_functions/temp_management/test_create_temp_directory.py
+++ b/pytest/unit/file_functions/temp_management/test_create_temp_directory.py
@@ -7,7 +7,7 @@ import pytest
 from file_functions import create_temp_directory
 
 
-def test_create_temp_directory_case_1_normal_operation() -> None:
+def test_create_temp_directory_normal_operation() -> None:
     """
     Test case 1: Normal operation with default parameters.
     """
@@ -27,7 +27,7 @@ def test_create_temp_directory_case_1_normal_operation() -> None:
     assert not Path(temp_dir).exists()
 
 
-def test_create_temp_directory_case_2_custom_suffix() -> None:
+def test_create_temp_directory_custom_suffix() -> None:
     """
     Test case 2: Create temp directory with custom suffix.
     """
@@ -39,7 +39,7 @@ def test_create_temp_directory_case_2_custom_suffix() -> None:
         assert Path(temp_dir).exists()
 
 
-def test_create_temp_directory_case_3_custom_prefix() -> None:
+def test_create_temp_directory_custom_prefix() -> None:
     """
     Test case 3: Create temp directory with custom prefix.
     """
@@ -51,7 +51,7 @@ def test_create_temp_directory_case_3_custom_prefix() -> None:
         assert Path(temp_dir).exists()
 
 
-def test_create_temp_directory_case_4_custom_parent_directory() -> None:
+def test_create_temp_directory_custom_parent_directory() -> None:
     """
     Test case 4: Create temp directory in custom parent directory.
     """
@@ -64,7 +64,7 @@ def test_create_temp_directory_case_4_custom_parent_directory() -> None:
             assert Path(temp_dir).exists()
 
 
-def test_create_temp_directory_case_5_no_delete() -> None:
+def test_create_temp_directory_no_delete() -> None:
     """
     Test case 5: Create persistent temp directory (delete=False).
     """
@@ -88,7 +88,7 @@ def test_create_temp_directory_case_5_no_delete() -> None:
         pass
 
 
-def test_create_temp_directory_case_6_nested_structure() -> None:
+def test_create_temp_directory_nested_structure() -> None:
     """
     Test case 6: Create nested structure in temp directory.
     """
@@ -110,7 +110,7 @@ def test_create_temp_directory_case_6_nested_structure() -> None:
     assert not temp_path.exists()
 
 
-def test_create_temp_directory_case_7_path_object_directory() -> None:
+def test_create_temp_directory_path_object_directory() -> None:
     """
     Test case 7: Function works with Path object for parent directory.
     """
@@ -125,7 +125,7 @@ def test_create_temp_directory_case_7_path_object_directory() -> None:
             assert Path(temp_dir).exists()
 
 
-def test_create_temp_directory_case_10_cleanup_error_handling() -> None:
+def test_create_temp_directory_cleanup_error_handling() -> None:
     """
     Test case 8: Graceful handling of cleanup errors.
     """
@@ -143,7 +143,7 @@ def test_create_temp_directory_case_10_cleanup_error_handling() -> None:
     assert not Path(temp_dir_holder[0]).exists()
 
 
-def test_create_temp_directory_case_8_invalid_type_errors() -> None:
+def test_create_temp_directory_invalid_type_errors() -> None:
     """
     Test case 9: TypeError for invalid parameter types.
     """
@@ -168,7 +168,7 @@ def test_create_temp_directory_case_8_invalid_type_errors() -> None:
             pass
 
 
-def test_create_temp_directory_case_9_directory_creation_error() -> None:
+def test_create_temp_directory_directory_creation_error() -> None:
     """
     Test case 10: OSError handling during directory creation.
     """

--- a/pytest/unit/file_functions/temp_management/test_create_temp_file.py
+++ b/pytest/unit/file_functions/temp_management/test_create_temp_file.py
@@ -6,7 +6,7 @@ import pytest
 from file_functions import create_temp_file
 
 
-def test_create_temp_file_case_1_normal_operation() -> None:
+def test_create_temp_file_normal_operation() -> None:
     """
     Test case 1: Normal operation with default parameters.
     """
@@ -30,7 +30,7 @@ def test_create_temp_file_case_1_normal_operation() -> None:
     assert not Path(temp_path).exists()
 
 
-def test_create_temp_file_case_2_custom_suffix() -> None:
+def test_create_temp_file_custom_suffix() -> None:
     """
     Test case 2: Create temp file with custom suffix.
     """
@@ -41,7 +41,7 @@ def test_create_temp_file_case_2_custom_suffix() -> None:
         assert Path(temp_path).exists()
 
 
-def test_create_temp_file_case_3_custom_prefix() -> None:
+def test_create_temp_file_custom_prefix() -> None:
     """
     Test case 3: Create temp file with custom prefix.
     """
@@ -53,7 +53,7 @@ def test_create_temp_file_case_3_custom_prefix() -> None:
         assert Path(temp_path).exists()
 
 
-def test_create_temp_file_case_4_custom_directory() -> None:
+def test_create_temp_file_custom_directory() -> None:
     """
     Test case 4: Create temp file in custom directory.
     """
@@ -66,7 +66,7 @@ def test_create_temp_file_case_4_custom_directory() -> None:
             assert Path(temp_path).exists()
 
 
-def test_create_temp_file_case_5_no_delete() -> None:
+def test_create_temp_file_no_delete() -> None:
     """
     Test case 5: Create persistent temp file (delete=False).
     """
@@ -89,7 +89,7 @@ def test_create_temp_file_case_5_no_delete() -> None:
         pass
 
 
-def test_create_temp_file_case_6_binary_mode() -> None:
+def test_create_temp_file_binary_mode() -> None:
     """
     Test case 6: Create temp file in binary mode.
     """
@@ -108,7 +108,7 @@ def test_create_temp_file_case_6_binary_mode() -> None:
         assert content == b"binary content"
 
 
-def test_create_temp_file_case_7_path_object_directory() -> None:
+def test_create_temp_file_path_object_directory() -> None:
     """
     Test case 7: Function works with Path object for directory.
     """
@@ -123,7 +123,7 @@ def test_create_temp_file_case_7_path_object_directory() -> None:
             assert Path(temp_path).exists()
 
 
-def test_create_temp_file_case_10_cleanup_error_handling() -> None:
+def test_create_temp_file_cleanup_error_handling() -> None:
     """
     Test case 8: Graceful handling of cleanup errors.
     """
@@ -141,7 +141,7 @@ def test_create_temp_file_case_10_cleanup_error_handling() -> None:
     assert not Path(temp_path_holder[0]).exists()
 
 
-def test_create_temp_file_case_8_invalid_type_errors() -> None:
+def test_create_temp_file_invalid_type_errors() -> None:
     """
     Test case 9: TypeError for invalid parameter types.
     """
@@ -171,7 +171,7 @@ def test_create_temp_file_case_8_invalid_type_errors() -> None:
             pass
 
 
-def test_create_temp_file_case_9_file_creation_error() -> None:
+def test_create_temp_file_file_creation_error() -> None:
     """
     Test case 10: OSError handling during file creation.
     """

--- a/pytest/unit/file_functions/temp_management/test_get_temp_dir_info.py
+++ b/pytest/unit/file_functions/temp_management/test_get_temp_dir_info.py
@@ -6,7 +6,7 @@ import pytest
 from file_functions import get_temp_dir_info
 
 
-def test_get_temp_dir_info_case_1_normal_operation() -> None:
+def test_get_temp_dir_info_normal_operation() -> None:
     """
     Test case 1: Normal operation returns valid info dictionary.
     """
@@ -32,7 +32,7 @@ def test_get_temp_dir_info_case_1_normal_operation() -> None:
             assert isinstance(info["available_space_bytes"], int)
 
 
-def test_get_temp_dir_info_case_2_temp_directory_exists() -> None:
+def test_get_temp_dir_info_temp_directory_exists() -> None:
     """
     Test case 2: System temp directory should exist and be writable.
     """
@@ -47,7 +47,7 @@ def test_get_temp_dir_info_case_2_temp_directory_exists() -> None:
             assert info["total_size_bytes"] >= 0
 
 
-def test_get_temp_dir_info_case_3_path_matches_system_temp() -> None:
+def test_get_temp_dir_info_path_matches_system_temp() -> None:
     """
     Test case 3: Path should match system temp directory.
     """
@@ -60,7 +60,7 @@ def test_get_temp_dir_info_case_3_path_matches_system_temp() -> None:
             assert info["path"] == expected_path
 
 
-def test_get_temp_dir_info_case_4_file_counting() -> None:
+def test_get_temp_dir_info_file_counting() -> None:
     """
     Test case 4: File counting with known files in temp directory.
     """
@@ -83,7 +83,7 @@ def test_get_temp_dir_info_case_4_file_counting() -> None:
             assert info["total_size_bytes"] > 0
 
 
-def test_get_temp_dir_info_case_5_nested_files() -> None:
+def test_get_temp_dir_info_nested_files() -> None:
     """
     Test case 5: Counting includes files in subdirectories.
     """
@@ -105,7 +105,7 @@ def test_get_temp_dir_info_case_5_nested_files() -> None:
             assert info["total_files"] == 2
 
 
-def test_get_temp_dir_info_case_6_empty_directory() -> None:
+def test_get_temp_dir_info_empty_directory() -> None:
     """
     Test case 6: Empty temp directory returns zero counts.
     """
@@ -120,7 +120,7 @@ def test_get_temp_dir_info_case_6_empty_directory() -> None:
             assert info["total_size_bytes"] == 0
 
 
-def test_get_temp_dir_info_case_7_non_existent_directory() -> None:
+def test_get_temp_dir_info_non_existent_directory() -> None:
     """
     Test case 7: Non-existent temp directory handling.
     """
@@ -138,7 +138,7 @@ def test_get_temp_dir_info_case_7_non_existent_directory() -> None:
         assert info["total_size_bytes"] == 0
 
 
-def test_get_temp_dir_info_case_9_statvfs_not_available() -> None:
+def test_get_temp_dir_info_statvfs_not_available() -> None:
     """
     Test case 8: Handle systems where statvfs is not available.
     """
@@ -153,7 +153,7 @@ def test_get_temp_dir_info_case_9_statvfs_not_available() -> None:
                 assert info["available_space_bytes"] == 0
 
 
-def test_get_temp_dir_info_case_8_file_access_error_handling() -> None:
+def test_get_temp_dir_info_file_access_error_handling() -> None:
     """
     Test case 9: Graceful handling of file access errors.
     """
@@ -181,7 +181,7 @@ def test_get_temp_dir_info_case_8_file_access_error_handling() -> None:
                     get_temp_dir_info()
 
 
-def test_get_temp_dir_info_case_10_directory_access_error() -> None:
+def test_get_temp_dir_info_directory_access_error() -> None:
     """
     Test case 10: OSError handling during directory access.
     """

--- a/pytest/unit/security_functions/encryption_helpers/test_decrypt_data_aes.py
+++ b/pytest/unit/security_functions/encryption_helpers/test_decrypt_data_aes.py
@@ -3,7 +3,7 @@ from security_functions.encryption_helpers.decrypt_data_aes import decrypt_data_
 from security_functions.encryption_helpers.encrypt_data_aes import encrypt_data_aes
 
 
-def test_decrypt_data_aes_case_1_basic_decryption() -> None:
+def test_decrypt_data_aes_basic_decryption() -> None:
     """
     Test case 1: Basic AES decryption should recover original data.
     """
@@ -18,7 +18,7 @@ def test_decrypt_data_aes_case_1_basic_decryption() -> None:
     assert decrypted == original_data
 
 
-def test_decrypt_data_aes_case_2_custom_key_decryption() -> None:
+def test_decrypt_data_aes_custom_key_decryption() -> None:
     """
     Test case 2: Decrypt data encrypted with custom key.
     """
@@ -36,7 +36,7 @@ def test_decrypt_data_aes_case_2_custom_key_decryption() -> None:
     assert decrypted == original_data
 
 
-def test_decrypt_data_aes_case_7_unicode_data() -> None:
+def test_decrypt_data_aes_unicode_data() -> None:
     """
     Test case 3: Handle Unicode characters in data.
     """
@@ -51,7 +51,7 @@ def test_decrypt_data_aes_case_7_unicode_data() -> None:
     assert decrypted == original_data
 
 
-def test_decrypt_data_aes_case_8_long_data() -> None:
+def test_decrypt_data_aes_long_data() -> None:
     """
     Test case 4: Decrypt long data string.
     """
@@ -66,7 +66,7 @@ def test_decrypt_data_aes_case_8_long_data() -> None:
     assert decrypted == original_data
 
 
-def test_decrypt_data_aes_case_9_special_characters() -> None:
+def test_decrypt_data_aes_special_characters() -> None:
     """
     Test case 5: Handle special characters and symbols.
     """
@@ -81,7 +81,7 @@ def test_decrypt_data_aes_case_9_special_characters() -> None:
     assert decrypted == original_data
 
 
-def test_decrypt_data_aes_case_10_bytes_to_string_conversion() -> None:
+def test_decrypt_data_aes_bytes_to_string_conversion() -> None:
     """
     Test case 6: Decrypt bytes data that was encrypted.
     """
@@ -97,7 +97,7 @@ def test_decrypt_data_aes_case_10_bytes_to_string_conversion() -> None:
     assert decrypted == original_bytes.decode("utf-8")
 
 
-def test_decrypt_data_aes_case_11_roundtrip_multiple_times() -> None:
+def test_decrypt_data_aes_roundtrip_multiple_times() -> None:
     """
     Test case 7: Multiple encrypt/decrypt roundtrips should be consistent.
     """
@@ -119,7 +119,7 @@ def test_decrypt_data_aes_case_11_roundtrip_multiple_times() -> None:
     assert decrypted2 == original_data
 
 
-def test_decrypt_data_aes_case_3_type_validation() -> None:
+def test_decrypt_data_aes_type_validation() -> None:
     """
     Test case 8: Type validation for parameters.
     """
@@ -132,7 +132,7 @@ def test_decrypt_data_aes_case_3_type_validation() -> None:
         decrypt_data_aes("encrypted", 123)
 
 
-def test_decrypt_data_aes_case_4_value_validation() -> None:
+def test_decrypt_data_aes_value_validation() -> None:
     """
     Test case 9: Value validation for parameters.
     """
@@ -145,7 +145,7 @@ def test_decrypt_data_aes_case_4_value_validation() -> None:
         decrypt_data_aes("encrypted", "")
 
 
-def test_decrypt_data_aes_case_5_wrong_key() -> None:
+def test_decrypt_data_aes_wrong_key() -> None:
     """
     Test case 10: Wrong key should raise ValueError during decryption.
     """
@@ -161,7 +161,7 @@ def test_decrypt_data_aes_case_5_wrong_key() -> None:
         decrypt_data_aes(encrypted, wrong_key)
 
 
-def test_decrypt_data_aes_case_6_invalid_encrypted_data() -> None:
+def test_decrypt_data_aes_invalid_encrypted_data() -> None:
     """
     Test case 11: Invalid encrypted data should raise ValueError.
     """
@@ -174,7 +174,7 @@ def test_decrypt_data_aes_case_6_invalid_encrypted_data() -> None:
         decrypt_data_aes(invalid_encrypted, key)
 
 
-def test_decrypt_data_aes_case_12_invalid_key_format() -> None:
+def test_decrypt_data_aes_invalid_key_format() -> None:
     """
     Test case 12: Invalid key format should raise ValueError.
     """

--- a/pytest/unit/security_functions/encryption_helpers/test_decrypt_xor.py
+++ b/pytest/unit/security_functions/encryption_helpers/test_decrypt_xor.py
@@ -3,7 +3,7 @@ from security_functions.encryption_helpers.decrypt_xor import decrypt_xor
 from security_functions.encryption_helpers.encrypt_xor import encrypt_xor
 
 
-def test_decrypt_xor_case_1_basic_decryption() -> None:
+def test_decrypt_xor_basic_decryption() -> None:
     """
     Test case 1: Basic XOR decryption should recover original data.
     """
@@ -18,7 +18,7 @@ def test_decrypt_xor_case_1_basic_decryption() -> None:
     assert decrypted == original_data
 
 
-def test_decrypt_xor_case_2_custom_key_decryption() -> None:
+def test_decrypt_xor_custom_key_decryption() -> None:
     """
     Test case 2: Decrypt data encrypted with custom key.
     """
@@ -34,7 +34,7 @@ def test_decrypt_xor_case_2_custom_key_decryption() -> None:
     assert decrypted == original_data
 
 
-def test_decrypt_xor_case_6_wrong_key_different_result() -> None:
+def test_decrypt_xor_wrong_key_different_result() -> None:
     """
     Test case 3: Wrong key should produce different (incorrect) result.
     """
@@ -53,7 +53,7 @@ def test_decrypt_xor_case_6_wrong_key_different_result() -> None:
     assert wrong_decrypted != original_data
 
 
-def test_decrypt_xor_case_7_unicode_data() -> None:
+def test_decrypt_xor_unicode_data() -> None:
     """
     Test case 4: Handle Unicode characters in data.
     """
@@ -68,7 +68,7 @@ def test_decrypt_xor_case_7_unicode_data() -> None:
     assert decrypted == original_data
 
 
-def test_decrypt_xor_case_8_long_data() -> None:
+def test_decrypt_xor_long_data() -> None:
     """
     Test case 5: Decrypt long data string.
     """
@@ -87,7 +87,7 @@ def test_decrypt_xor_case_8_long_data() -> None:
     assert decrypted == original_data
 
 
-def test_decrypt_xor_case_9_special_characters() -> None:
+def test_decrypt_xor_special_characters() -> None:
     """
     Test case 6: Handle special characters and symbols.
     """
@@ -103,7 +103,7 @@ def test_decrypt_xor_case_9_special_characters() -> None:
     assert decrypted == original_data
 
 
-def test_decrypt_xor_case_11_roundtrip_multiple_times() -> None:
+def test_decrypt_xor_roundtrip_multiple_times() -> None:
     """
     Test case 7: Multiple encrypt/decrypt roundtrips should be consistent.
     """
@@ -124,7 +124,7 @@ def test_decrypt_xor_case_11_roundtrip_multiple_times() -> None:
     assert encrypted1 == encrypted2  # Should be deterministic
 
 
-def test_decrypt_xor_case_12_case_sensitive_hex() -> None:
+def test_decrypt_xor_case_sensitive_hex() -> None:
     """
     Test case 8: Hex decryption should handle both uppercase and lowercase.
     """
@@ -145,7 +145,7 @@ def test_decrypt_xor_case_12_case_sensitive_hex() -> None:
     assert decrypted_upper == original_data
 
 
-def test_decrypt_xor_case_3_type_validation() -> None:
+def test_decrypt_xor_type_validation() -> None:
     """
     Test case 9: Type validation for parameters.
     """
@@ -158,7 +158,7 @@ def test_decrypt_xor_case_3_type_validation() -> None:
         decrypt_xor("encrypted", 123)
 
 
-def test_decrypt_xor_case_4_value_validation() -> None:
+def test_decrypt_xor_value_validation() -> None:
     """
     Test case 10: Value validation for parameters.
     """
@@ -171,7 +171,7 @@ def test_decrypt_xor_case_4_value_validation() -> None:
         decrypt_xor("encrypted", "")
 
 
-def test_decrypt_xor_case_5_invalid_hex_format() -> None:
+def test_decrypt_xor_invalid_hex_format() -> None:
     """
     Test case 11: Invalid hex format should raise ValueError.
     """
@@ -184,7 +184,7 @@ def test_decrypt_xor_case_5_invalid_hex_format() -> None:
         decrypt_xor("gggg", "key")  # Invalid hex characters
 
 
-def test_decrypt_xor_case_10_empty_original_data() -> None:
+def test_decrypt_xor_empty_original_data() -> None:
     """
     Test case 12: Handle empty string encryption/decryption.
     """

--- a/pytest/unit/security_functions/encryption_helpers/test_encrypt_data_aes.py
+++ b/pytest/unit/security_functions/encryption_helpers/test_encrypt_data_aes.py
@@ -4,7 +4,7 @@ import pytest
 from security_functions.encryption_helpers.encrypt_data_aes import encrypt_data_aes
 
 
-def test_encrypt_data_aes_case_1_string_data_auto_key() -> None:
+def test_encrypt_data_aes_string_data_auto_key() -> None:
     """
     Test case 1: Encrypt string data with auto-generated key.
     """
@@ -27,7 +27,7 @@ def test_encrypt_data_aes_case_1_string_data_auto_key() -> None:
         pytest.fail("Encrypted data should be valid base64")
 
 
-def test_encrypt_data_aes_case_2_bytes_data_auto_key() -> None:
+def test_encrypt_data_aes_bytes_data_auto_key() -> None:
     """
     Test case 2: Encrypt bytes data with auto-generated key.
     """
@@ -44,7 +44,7 @@ def test_encrypt_data_aes_case_2_bytes_data_auto_key() -> None:
     assert len(key) > 0
 
 
-def test_encrypt_data_aes_case_3_string_data_custom_key() -> None:
+def test_encrypt_data_aes_string_data_custom_key() -> None:
     """
     Test case 3: Encrypt string data with custom key.
     """
@@ -64,7 +64,7 @@ def test_encrypt_data_aes_case_3_string_data_custom_key() -> None:
     assert len(encrypted) > 0
 
 
-def test_encrypt_data_aes_case_7_unicode_data() -> None:
+def test_encrypt_data_aes_unicode_data() -> None:
     """
     Test case 4: Handle Unicode characters in data.
     """
@@ -80,7 +80,7 @@ def test_encrypt_data_aes_case_7_unicode_data() -> None:
     assert len(encrypted) > 0
 
 
-def test_encrypt_data_aes_case_8_long_data() -> None:
+def test_encrypt_data_aes_long_data() -> None:
     """
     Test case 5: Encrypt long data string.
     """
@@ -96,7 +96,7 @@ def test_encrypt_data_aes_case_8_long_data() -> None:
     assert len(encrypted) > 0
 
 
-def test_encrypt_data_aes_case_9_different_data_different_results() -> None:
+def test_encrypt_data_aes_different_data_different_results() -> None:
     """
     Test case 6: Different data should produce different encrypted results.
     """
@@ -115,7 +115,7 @@ def test_encrypt_data_aes_case_9_different_data_different_results() -> None:
     assert encrypted1 != encrypted2
 
 
-def test_encrypt_data_aes_case_10_same_data_different_keys() -> None:
+def test_encrypt_data_aes_same_data_different_keys() -> None:
     """
     Test case 7: Same data with different keys should produce different results.
     """
@@ -134,7 +134,7 @@ def test_encrypt_data_aes_case_10_same_data_different_keys() -> None:
     assert encrypted1 != encrypted2
 
 
-def test_encrypt_data_aes_case_11_bytes_key_handling() -> None:
+def test_encrypt_data_aes_bytes_key_handling() -> None:
     """
     Test case 8: Handle bytes key input.
     """
@@ -153,7 +153,7 @@ def test_encrypt_data_aes_case_11_bytes_key_handling() -> None:
     assert len(encrypted) > 0
 
 
-def test_encrypt_data_aes_case_12_special_characters() -> None:
+def test_encrypt_data_aes_special_characters() -> None:
     """
     Test case 9: Handle special characters and symbols.
     """
@@ -169,7 +169,7 @@ def test_encrypt_data_aes_case_12_special_characters() -> None:
     assert len(encrypted) > 0
 
 
-def test_encrypt_data_aes_case_4_type_validation() -> None:
+def test_encrypt_data_aes_type_validation() -> None:
     """
     Test case 10: Type validation for parameters.
     """
@@ -182,7 +182,7 @@ def test_encrypt_data_aes_case_4_type_validation() -> None:
         encrypt_data_aes("data", key=123)
 
 
-def test_encrypt_data_aes_case_5_value_validation() -> None:
+def test_encrypt_data_aes_value_validation() -> None:
     """
     Test case 11: Value validation for parameters.
     """
@@ -195,7 +195,7 @@ def test_encrypt_data_aes_case_5_value_validation() -> None:
         encrypt_data_aes(b"")
 
 
-def test_encrypt_data_aes_case_6_invalid_key_format() -> None:
+def test_encrypt_data_aes_invalid_key_format() -> None:
     """
     Test case 12: Invalid key format should raise ValueError.
     """

--- a/pytest/unit/security_functions/encryption_helpers/test_encrypt_xor.py
+++ b/pytest/unit/security_functions/encryption_helpers/test_encrypt_xor.py
@@ -2,7 +2,7 @@ import pytest
 from security_functions.encryption_helpers.encrypt_xor import encrypt_xor
 
 
-def test_encrypt_xor_case_1_basic_encryption() -> None:
+def test_encrypt_xor_basic_encryption() -> None:
     """
     Test case 1: Basic XOR encryption with default parameters.
     """
@@ -22,7 +22,7 @@ def test_encrypt_xor_case_1_basic_encryption() -> None:
     assert all(c in "0123456789abcdef" for c in encrypted)
 
 
-def test_encrypt_xor_case_2_custom_key() -> None:
+def test_encrypt_xor_custom_key() -> None:
     """
     Test case 2: XOR encryption with custom key.
     """
@@ -40,7 +40,7 @@ def test_encrypt_xor_case_2_custom_key() -> None:
     assert all(c in "0123456789abcdef" for c in encrypted)
 
 
-def test_encrypt_xor_case_6_different_keys_different_results() -> None:
+def test_encrypt_xor_different_keys_different_results() -> None:
     """
     Test case 3: Different keys should produce different encrypted results.
     """
@@ -57,7 +57,7 @@ def test_encrypt_xor_case_6_different_keys_different_results() -> None:
     assert encrypted1 != encrypted2
 
 
-def test_encrypt_xor_case_7_random_key_generation() -> None:
+def test_encrypt_xor_random_key_generation() -> None:
     """
     Test case 4: Random key generation produces different keys.
     """
@@ -74,7 +74,7 @@ def test_encrypt_xor_case_7_random_key_generation() -> None:
     assert len(key2) > 0
 
 
-def test_encrypt_xor_case_8_unicode_data() -> None:
+def test_encrypt_xor_unicode_data() -> None:
     """
     Test case 5: Handle Unicode characters in data.
     """
@@ -91,7 +91,7 @@ def test_encrypt_xor_case_8_unicode_data() -> None:
     assert all(c in "0123456789abcdef" for c in encrypted)
 
 
-def test_encrypt_xor_case_9_long_data() -> None:
+def test_encrypt_xor_long_data() -> None:
     """
     Test case 6: Encrypt long data string.
     """
@@ -114,7 +114,7 @@ def test_encrypt_xor_case_9_long_data() -> None:
     assert all(c in "0123456789abcdef" for c in encrypted)
 
 
-def test_encrypt_xor_case_10_key_length_adaptation() -> None:
+def test_encrypt_xor_key_length_adaptation() -> None:
     """
     Test case 7: Verify key length adaptation based on data size.
     """
@@ -133,7 +133,7 @@ def test_encrypt_xor_case_10_key_length_adaptation() -> None:
     assert len(long_key) > 0
 
 
-def test_encrypt_xor_case_11_deterministic_with_same_key() -> None:
+def test_encrypt_xor_deterministic_with_same_key() -> None:
     """
     Test case 8: Same data and key should produce same encrypted result.
     """
@@ -149,7 +149,7 @@ def test_encrypt_xor_case_11_deterministic_with_same_key() -> None:
     assert encrypted1 == encrypted2
 
 
-def test_encrypt_xor_case_12_special_characters() -> None:
+def test_encrypt_xor_special_characters() -> None:
     """
     Test case 9: Handle special characters and symbols.
     """
@@ -167,7 +167,7 @@ def test_encrypt_xor_case_12_special_characters() -> None:
     assert all(c in "0123456789abcdef" for c in encrypted)
 
 
-def test_encrypt_xor_case_3_empty_data_raises_error() -> None:
+def test_encrypt_xor_empty_data_raises_error() -> None:
     """
     Test case 10: Empty data should raise ValueError.
     """
@@ -176,7 +176,7 @@ def test_encrypt_xor_case_3_empty_data_raises_error() -> None:
         encrypt_xor("")
 
 
-def test_encrypt_xor_case_4_type_validation() -> None:
+def test_encrypt_xor_type_validation() -> None:
     """
     Test case 11: Type validation for parameters.
     """
@@ -189,7 +189,7 @@ def test_encrypt_xor_case_4_type_validation() -> None:
         encrypt_xor("data", key=123)
 
 
-def test_encrypt_xor_case_5_empty_key_raises_error() -> None:
+def test_encrypt_xor_empty_key_raises_error() -> None:
     """
     Test case 12: Empty key should raise ValueError.
     """

--- a/pytest/unit/security_functions/password_hashing/test_hash_password_bcrypt.py
+++ b/pytest/unit/security_functions/password_hashing/test_hash_password_bcrypt.py
@@ -4,7 +4,7 @@ from security_functions.password_hashing.hash_password_bcrypt import (
 )
 
 
-def test_hash_password_bcrypt_case_1_normal_operation() -> None:
+def test_hash_password_bcrypt_normal_operation() -> None:
     """
     Test case 1: Normal operation with valid password.
     """
@@ -20,7 +20,7 @@ def test_hash_password_bcrypt_case_1_normal_operation() -> None:
     assert hashed.startswith("$2b$")  # bcrypt identifier
 
 
-def test_hash_password_bcrypt_case_2_custom_rounds() -> None:
+def test_hash_password_bcrypt_custom_rounds() -> None:
     """
     Test case 2: Using custom rounds parameter.
     """
@@ -37,7 +37,7 @@ def test_hash_password_bcrypt_case_2_custom_rounds() -> None:
     assert f"$2b${rounds:02d}$" in hashed  # Should contain the round number
 
 
-def test_hash_password_bcrypt_case_3_minimum_rounds() -> None:
+def test_hash_password_bcrypt_minimum_rounds() -> None:
     """
     Test case 3: Using minimum valid rounds.
     """
@@ -54,7 +54,7 @@ def test_hash_password_bcrypt_case_3_minimum_rounds() -> None:
     assert "$2b$04$" in hashed
 
 
-def test_hash_password_bcrypt_case_4_maximum_rounds() -> None:
+def test_hash_password_bcrypt_maximum_rounds() -> None:
     """
     Test case 4: Using maximum valid rounds (reduced for testing performance).
     """
@@ -71,7 +71,7 @@ def test_hash_password_bcrypt_case_4_maximum_rounds() -> None:
     assert "$2b$15$" in hashed
 
 
-def test_hash_password_bcrypt_case_7_different_passwords_different_hashes() -> None:
+def test_hash_password_bcrypt_different_passwords_different_hashes() -> None:
     """
     Test case 5: Different passwords should produce different hashes.
     """
@@ -87,7 +87,7 @@ def test_hash_password_bcrypt_case_7_different_passwords_different_hashes() -> N
     assert hashed1 != hashed2
 
 
-def test_hash_password_bcrypt_case_8_same_password_different_hashes() -> None:
+def test_hash_password_bcrypt_same_password_different_hashes() -> None:
     """
     Test case 6: Same password should produce different hashes due to salt.
     """
@@ -102,7 +102,7 @@ def test_hash_password_bcrypt_case_8_same_password_different_hashes() -> None:
     assert hashed1 != hashed2  # Different due to random salt
 
 
-def test_hash_password_bcrypt_case_9_unicode_password() -> None:
+def test_hash_password_bcrypt_unicode_password() -> None:
     """
     Test case 7: Handle Unicode characters in password.
     """
@@ -118,7 +118,7 @@ def test_hash_password_bcrypt_case_9_unicode_password() -> None:
     assert hashed.startswith("$2b$")
 
 
-def test_hash_password_bcrypt_case_10_long_password() -> None:
+def test_hash_password_bcrypt_long_password() -> None:
     """
     Test case 8: Handle very long password.
     """
@@ -134,7 +134,7 @@ def test_hash_password_bcrypt_case_10_long_password() -> None:
     assert hashed.startswith("$2b$")
 
 
-def test_hash_password_bcrypt_case_11_special_characters() -> None:
+def test_hash_password_bcrypt_special_characters() -> None:
     """
     Test case 9: Handle special characters and symbols.
     """
@@ -150,7 +150,7 @@ def test_hash_password_bcrypt_case_11_special_characters() -> None:
     assert hashed.startswith("$2b$")
 
 
-def test_hash_password_bcrypt_case_12_performance_high_rounds() -> None:
+def test_hash_password_bcrypt_performance_high_rounds() -> None:
     """
     Test case 10: Verify that higher rounds work (may be slower).
     """
@@ -173,7 +173,7 @@ def test_hash_password_bcrypt_case_12_performance_high_rounds() -> None:
     assert elapsed_time < 5.0  # Should complete within 5 seconds
 
 
-def test_hash_password_bcrypt_case_5_type_validation() -> None:
+def test_hash_password_bcrypt_type_validation() -> None:
     """
     Test case 11: Type validation for all parameters.
     """
@@ -186,7 +186,7 @@ def test_hash_password_bcrypt_case_5_type_validation() -> None:
         hash_password_bcrypt("password", rounds="invalid")
 
 
-def test_hash_password_bcrypt_case_6_value_validation() -> None:
+def test_hash_password_bcrypt_value_validation() -> None:
     """
     Test case 12: Value validation for parameters.
     """

--- a/pytest/unit/security_functions/password_hashing/test_hash_password_pbkdf2.py
+++ b/pytest/unit/security_functions/password_hashing/test_hash_password_pbkdf2.py
@@ -4,7 +4,7 @@ from security_functions.password_hashing.hash_password_pbkdf2 import (
 )
 
 
-def test_hash_password_pbkdf2_case_1_normal_operation() -> None:
+def test_hash_password_pbkdf2_normal_operation() -> None:
     """
     Test case 1: Normal operation with valid password.
     """
@@ -22,7 +22,7 @@ def test_hash_password_pbkdf2_case_1_normal_operation() -> None:
     assert all(c in "0123456789abcdef" for c in hashed)
 
 
-def test_hash_password_pbkdf2_case_2_custom_salt() -> None:
+def test_hash_password_pbkdf2_custom_salt() -> None:
     """
     Test case 2: Using custom salt.
     """
@@ -39,7 +39,7 @@ def test_hash_password_pbkdf2_case_2_custom_salt() -> None:
     assert len(hashed) == 64
 
 
-def test_hash_password_pbkdf2_case_3_custom_iterations() -> None:
+def test_hash_password_pbkdf2_custom_iterations() -> None:
     """
     Test case 3: Using custom iteration count.
     """
@@ -57,7 +57,7 @@ def test_hash_password_pbkdf2_case_3_custom_iterations() -> None:
     assert len(salt) == 32
 
 
-def test_hash_password_pbkdf2_case_6_deterministic_with_same_salt() -> None:
+def test_hash_password_pbkdf2_deterministic_with_same_salt() -> None:
     """
     Test case 4: Same password and salt should produce same hash.
     """
@@ -73,7 +73,7 @@ def test_hash_password_pbkdf2_case_6_deterministic_with_same_salt() -> None:
     assert hashed1 == hashed2
 
 
-def test_hash_password_pbkdf2_case_7_different_passwords_different_hashes() -> None:
+def test_hash_password_pbkdf2_different_passwords_different_hashes() -> None:
     """
     Test case 5: Different passwords should produce different hashes.
     """
@@ -90,7 +90,7 @@ def test_hash_password_pbkdf2_case_7_different_passwords_different_hashes() -> N
     assert hashed1 != hashed2
 
 
-def test_hash_password_pbkdf2_case_8_random_salt_generation() -> None:
+def test_hash_password_pbkdf2_random_salt_generation() -> None:
     """
     Test case 6: Random salt generation produces different salts.
     """
@@ -107,7 +107,7 @@ def test_hash_password_pbkdf2_case_8_random_salt_generation() -> None:
     assert len(salt2) == 32
 
 
-def test_hash_password_pbkdf2_case_9_unicode_password() -> None:
+def test_hash_password_pbkdf2_unicode_password() -> None:
     """
     Test case 7: Handle Unicode characters in password.
     """
@@ -124,7 +124,7 @@ def test_hash_password_pbkdf2_case_9_unicode_password() -> None:
     assert len(salt) == 32
 
 
-def test_hash_password_pbkdf2_case_10_boundary_iterations() -> None:
+def test_hash_password_pbkdf2_boundary_iterations() -> None:
     """
     Test case 8: Test boundary values for iterations.
     """
@@ -140,7 +140,7 @@ def test_hash_password_pbkdf2_case_10_boundary_iterations() -> None:
     assert len(hashed_high) == 64
 
 
-def test_hash_password_pbkdf2_case_4_type_validation() -> None:
+def test_hash_password_pbkdf2_type_validation() -> None:
     """
     Test case 9: Type validation for all parameters.
     """
@@ -157,7 +157,7 @@ def test_hash_password_pbkdf2_case_4_type_validation() -> None:
         hash_password_pbkdf2("password", iterations="invalid")
 
 
-def test_hash_password_pbkdf2_case_5_value_validation() -> None:
+def test_hash_password_pbkdf2_value_validation() -> None:
     """
     Test case 10: Value validation for parameters.
     """

--- a/pytest/unit/security_functions/password_hashing/test_verify_password_bcrypt.py
+++ b/pytest/unit/security_functions/password_hashing/test_verify_password_bcrypt.py
@@ -7,7 +7,7 @@ from security_functions.password_hashing.verify_password_bcrypt import (
 )
 
 
-def test_verify_password_bcrypt_case_1_correct_password() -> None:
+def test_verify_password_bcrypt_correct_password() -> None:
     """
     Test case 1: Verify correct password returns True.
     """
@@ -22,7 +22,7 @@ def test_verify_password_bcrypt_case_1_correct_password() -> None:
     assert result is True
 
 
-def test_verify_password_bcrypt_case_2_incorrect_password() -> None:
+def test_verify_password_bcrypt_incorrect_password() -> None:
     """
     Test case 2: Verify incorrect password returns False.
     """
@@ -38,7 +38,7 @@ def test_verify_password_bcrypt_case_2_incorrect_password() -> None:
     assert result is False
 
 
-def test_verify_password_bcrypt_case_3_different_rounds() -> None:
+def test_verify_password_bcrypt_different_rounds() -> None:
     """
     Test case 3: Verify password with different rounds.
     """
@@ -54,7 +54,7 @@ def test_verify_password_bcrypt_case_3_different_rounds() -> None:
     assert result is True
 
 
-def test_verify_password_bcrypt_case_7_case_sensitive() -> None:
+def test_verify_password_bcrypt_case_sensitive() -> None:
     """
     Test case 4: Password verification should be case sensitive.
     """
@@ -71,7 +71,7 @@ def test_verify_password_bcrypt_case_7_case_sensitive() -> None:
     assert wrong_case_result is False
 
 
-def test_verify_password_bcrypt_case_8_unicode_password() -> None:
+def test_verify_password_bcrypt_unicode_password() -> None:
     """
     Test case 5: Handle Unicode characters in password verification.
     """
@@ -88,7 +88,7 @@ def test_verify_password_bcrypt_case_8_unicode_password() -> None:
     assert wrong_result is False
 
 
-def test_verify_password_bcrypt_case_9_special_characters() -> None:
+def test_verify_password_bcrypt_special_characters() -> None:
     """
     Test case 6: Handle special characters in password verification.
     """
@@ -103,7 +103,7 @@ def test_verify_password_bcrypt_case_9_special_characters() -> None:
     assert result is True
 
 
-def test_verify_password_bcrypt_case_10_long_password() -> None:
+def test_verify_password_bcrypt_long_password() -> None:
     """
     Test case 7: Handle very long password verification.
     """
@@ -118,7 +118,7 @@ def test_verify_password_bcrypt_case_10_long_password() -> None:
     assert result is True
 
 
-def test_verify_password_bcrypt_case_12_timing_attack_resistance() -> None:
+def test_verify_password_bcrypt_timing_attack_resistance() -> None:
     """
     Test case 8: Verify that function handles invalid hashes gracefully.
     """
@@ -138,7 +138,7 @@ def test_verify_password_bcrypt_case_12_timing_attack_resistance() -> None:
         assert result is False  # Should return False, not raise exception
 
 
-def test_verify_password_bcrypt_case_4_type_validation() -> None:
+def test_verify_password_bcrypt_type_validation() -> None:
     """
     Test case 9: Type validation for all parameters.
     """
@@ -153,7 +153,7 @@ def test_verify_password_bcrypt_case_4_type_validation() -> None:
         verify_password_bcrypt("password", 123)
 
 
-def test_verify_password_bcrypt_case_5_value_validation() -> None:
+def test_verify_password_bcrypt_value_validation() -> None:
     """
     Test case 10: Value validation for parameters.
     """
@@ -168,7 +168,7 @@ def test_verify_password_bcrypt_case_5_value_validation() -> None:
         verify_password_bcrypt("password", "")
 
 
-def test_verify_password_bcrypt_case_6_invalid_hash_format() -> None:
+def test_verify_password_bcrypt_invalid_hash_format() -> None:
     """
     Test case 11: Invalid bcrypt hash format should raise ValueError.
     """
@@ -183,7 +183,7 @@ def test_verify_password_bcrypt_case_6_invalid_hash_format() -> None:
         verify_password_bcrypt("password", "$2b$12$short")
 
 
-def test_verify_password_bcrypt_case_11_malformed_hash() -> None:
+def test_verify_password_bcrypt_malformed_hash() -> None:
     """
     Test case 12: Malformed hash should raise ValueError.
     """

--- a/pytest/unit/security_functions/password_hashing/test_verify_password_pbkdf2.py
+++ b/pytest/unit/security_functions/password_hashing/test_verify_password_pbkdf2.py
@@ -7,7 +7,7 @@ from security_functions.password_hashing.verify_password_pbkdf2 import (
 )
 
 
-def test_verify_password_pbkdf2_case_1_correct_password() -> None:
+def test_verify_password_pbkdf2_correct_password() -> None:
     """
     Test case 1: Verify correct password returns True.
     """
@@ -22,7 +22,7 @@ def test_verify_password_pbkdf2_case_1_correct_password() -> None:
     assert result is True
 
 
-def test_verify_password_pbkdf2_case_2_incorrect_password() -> None:
+def test_verify_password_pbkdf2_incorrect_password() -> None:
     """
     Test case 2: Verify incorrect password returns False.
     """
@@ -38,7 +38,7 @@ def test_verify_password_pbkdf2_case_2_incorrect_password() -> None:
     assert result is False
 
 
-def test_verify_password_pbkdf2_case_3_custom_iterations() -> None:
+def test_verify_password_pbkdf2_custom_iterations() -> None:
     """
     Test case 3: Verify with custom iteration count.
     """
@@ -54,7 +54,7 @@ def test_verify_password_pbkdf2_case_3_custom_iterations() -> None:
     assert result is True
 
 
-def test_verify_password_pbkdf2_case_7_different_iterations() -> None:
+def test_verify_password_pbkdf2_different_iterations() -> None:
     """
     Test case 4: Verification fails with different iteration count.
     """
@@ -69,7 +69,7 @@ def test_verify_password_pbkdf2_case_7_different_iterations() -> None:
     assert result is False
 
 
-def test_verify_password_pbkdf2_case_8_unicode_password() -> None:
+def test_verify_password_pbkdf2_unicode_password() -> None:
     """
     Test case 5: Handle Unicode characters in password verification.
     """
@@ -84,7 +84,7 @@ def test_verify_password_pbkdf2_case_8_unicode_password() -> None:
     assert result is True
 
 
-def test_verify_password_pbkdf2_case_9_case_sensitive() -> None:
+def test_verify_password_pbkdf2_case_sensitive() -> None:
     """
     Test case 6: Password verification is case sensitive.
     """
@@ -102,7 +102,7 @@ def test_verify_password_pbkdf2_case_9_case_sensitive() -> None:
     assert result_wrong_case is False
 
 
-def test_verify_password_pbkdf2_case_10_edge_case_similar_passwords() -> None:
+def test_verify_password_pbkdf2_edge_case_similar_passwords() -> None:
     """
     Test case 7: Verification with very similar but different passwords.
     """
@@ -120,7 +120,7 @@ def test_verify_password_pbkdf2_case_10_edge_case_similar_passwords() -> None:
     assert result2 is False
 
 
-def test_verify_password_pbkdf2_case_4_type_validation() -> None:
+def test_verify_password_pbkdf2_type_validation() -> None:
     """
     Test case 8: Type validation for all parameters.
     """
@@ -144,7 +144,7 @@ def test_verify_password_pbkdf2_case_4_type_validation() -> None:
         verify_password_pbkdf2("password", hashed, salt, iterations="invalid")
 
 
-def test_verify_password_pbkdf2_case_5_value_validation() -> None:
+def test_verify_password_pbkdf2_value_validation() -> None:
     """
     Test case 9: Value validation for parameters.
     """
@@ -168,7 +168,7 @@ def test_verify_password_pbkdf2_case_5_value_validation() -> None:
         verify_password_pbkdf2("password", hashed, salt, iterations=500)
 
 
-def test_verify_password_pbkdf2_case_6_invalid_hex_format() -> None:
+def test_verify_password_pbkdf2_invalid_hex_format() -> None:
     """
     Test case 10: Invalid hex format in hashed_password.
     """

--- a/pytest/unit/security_functions/token_generation/test_generate_jwt_token.py
+++ b/pytest/unit/security_functions/token_generation/test_generate_jwt_token.py
@@ -6,7 +6,7 @@ import pytest
 from security_functions.token_generation.generate_jwt_token import generate_jwt_token
 
 
-def test_generate_jwt_token_case_1_basic_token() -> None:
+def test_generate_jwt_token_basic_token() -> None:
     """
     Test case 1: Generate basic JWT token with simple payload.
     """
@@ -36,7 +36,7 @@ def test_generate_jwt_token_case_1_basic_token() -> None:
     assert "exp" in decoded_payload
 
 
-def test_generate_jwt_token_case_2_custom_expiration() -> None:
+def test_generate_jwt_token_custom_expiration() -> None:
     """
     Test case 2: Generate JWT token with custom expiration time.
     """
@@ -67,7 +67,7 @@ def test_generate_jwt_token_case_2_custom_expiration() -> None:
     assert abs((exp_time - iat_time) - 7200) < 10  # Allow 10 second tolerance
 
 
-def test_generate_jwt_token_case_3_complex_payload() -> None:
+def test_generate_jwt_token_complex_payload() -> None:
     """
     Test case 3: Generate JWT token with complex payload.
     """
@@ -101,7 +101,7 @@ def test_generate_jwt_token_case_3_complex_payload() -> None:
     assert decoded_payload["metadata"]["login_count"] == 5
 
 
-def test_generate_jwt_token_case_6_header_verification() -> None:
+def test_generate_jwt_token_header_verification() -> None:
     """
     Test case 4: Verify JWT header is correct.
     """
@@ -126,7 +126,7 @@ def test_generate_jwt_token_case_6_header_verification() -> None:
     assert decoded_header["typ"] == "JWT"
 
 
-def test_generate_jwt_token_case_7_empty_payload() -> None:
+def test_generate_jwt_token_empty_payload() -> None:
     """
     Test case 5: Generate JWT token with empty payload.
     """
@@ -153,7 +153,7 @@ def test_generate_jwt_token_case_7_empty_payload() -> None:
     assert "exp" in decoded_payload
 
 
-def test_generate_jwt_token_case_8_different_secrets_different_signatures() -> None:
+def test_generate_jwt_token_different_secrets_different_signatures() -> None:
     """
     Test case 6: Different secrets should produce different signatures.
     """
@@ -176,7 +176,7 @@ def test_generate_jwt_token_case_8_different_secrets_different_signatures() -> N
     assert parts1[2] != parts2[2]
 
 
-def test_generate_jwt_token_case_9_unicode_payload() -> None:
+def test_generate_jwt_token_unicode_payload() -> None:
     """
     Test case 7: Handle Unicode characters in payload.
     """
@@ -208,7 +208,7 @@ def test_generate_jwt_token_case_9_unicode_payload() -> None:
     assert decoded_payload["unicode_key_🔑"] == "unicode_value_🎯"
 
 
-def test_generate_jwt_token_case_10_timestamp_validation() -> None:
+def test_generate_jwt_token_timestamp_validation() -> None:
     """
     Test case 8: Verify iat and exp timestamps are reasonable.
     """
@@ -239,7 +239,7 @@ def test_generate_jwt_token_case_10_timestamp_validation() -> None:
     assert abs((exp - iat) - 3600) < 10  # Allow 10 second tolerance
 
 
-def test_generate_jwt_token_case_4_type_validation() -> None:
+def test_generate_jwt_token_type_validation() -> None:
     """
     Test case 9: Type validation for all parameters.
     """
@@ -256,7 +256,7 @@ def test_generate_jwt_token_case_4_type_validation() -> None:
         generate_jwt_token({}, "secret", "invalid")
 
 
-def test_generate_jwt_token_case_5_value_validation() -> None:
+def test_generate_jwt_token_value_validation() -> None:
     """
     Test case 10: Value validation for parameters.
     """

--- a/pytest/unit/security_functions/token_generation/test_generate_secure_token.py
+++ b/pytest/unit/security_functions/token_generation/test_generate_secure_token.py
@@ -6,7 +6,7 @@ from security_functions.token_generation.generate_secure_token import (
 )
 
 
-def test_generate_secure_token_case_1_default_parameters() -> None:
+def test_generate_secure_token_default_parameters() -> None:
     """
     Test case 1: Generate token with default parameters.
     """
@@ -19,7 +19,7 @@ def test_generate_secure_token_case_1_default_parameters() -> None:
     assert token.isalnum()  # Only letters and digits by default
 
 
-def test_generate_secure_token_case_2_custom_length() -> None:
+def test_generate_secure_token_custom_length() -> None:
     """
     Test case 2: Generate token with custom length.
     """
@@ -34,7 +34,7 @@ def test_generate_secure_token_case_2_custom_length() -> None:
     assert len(token) == length
 
 
-def test_generate_secure_token_case_3_letters_only() -> None:
+def test_generate_secure_token_letters_only() -> None:
     """
     Test case 3: Generate token with letters only.
     """
@@ -49,7 +49,7 @@ def test_generate_secure_token_case_3_letters_only() -> None:
     assert any(c.isupper() for c in token)  # Has uppercase
 
 
-def test_generate_secure_token_case_4_digits_only() -> None:
+def test_generate_secure_token_digits_only() -> None:
     """
     Test case 4: Generate token with digits only.
     """
@@ -62,7 +62,7 @@ def test_generate_secure_token_case_4_digits_only() -> None:
     assert token.isdigit()  # Only digits
 
 
-def test_generate_secure_token_case_5_with_symbols() -> None:
+def test_generate_secure_token_with_symbols() -> None:
     """
     Test case 5: Generate token including symbols.
     """
@@ -80,7 +80,7 @@ def test_generate_secure_token_case_5_with_symbols() -> None:
     assert has_letter or has_digit
 
 
-def test_generate_secure_token_case_8_randomness() -> None:
+def test_generate_secure_token_randomness() -> None:
     """
     Test case 6: Generated tokens should be different (randomness).
     """
@@ -95,7 +95,7 @@ def test_generate_secure_token_case_8_randomness() -> None:
     assert token1 != token3
 
 
-def test_generate_secure_token_case_9_symbols_only() -> None:
+def test_generate_secure_token_symbols_only() -> None:
     """
     Test case 7: Generate token with symbols only.
     """
@@ -110,7 +110,7 @@ def test_generate_secure_token_case_9_symbols_only() -> None:
     assert all(c in "!@#$%^&*-_=+[]{}|;:,.<>?" for c in token)
 
 
-def test_generate_secure_token_case_10_boundary_lengths() -> None:
+def test_generate_secure_token_boundary_lengths() -> None:
     """
     Test case 8: Test boundary values for length.
     """
@@ -123,7 +123,7 @@ def test_generate_secure_token_case_10_boundary_lengths() -> None:
     assert len(token_large) == 1000
 
 
-def test_generate_secure_token_case_11_all_character_types() -> None:
+def test_generate_secure_token_all_character_types() -> None:
     """
     Test case 9: Generate token with all character types enabled.
     """
@@ -143,7 +143,7 @@ def test_generate_secure_token_case_11_all_character_types() -> None:
     assert all(c in valid_chars for c in token)
 
 
-def test_generate_secure_token_case_6_type_validation() -> None:
+def test_generate_secure_token_type_validation() -> None:
     """
     Test case 10: Type validation for all parameters.
     """
@@ -164,7 +164,7 @@ def test_generate_secure_token_case_6_type_validation() -> None:
         generate_secure_token(include_symbols="invalid")
 
 
-def test_generate_secure_token_case_7_value_validation() -> None:
+def test_generate_secure_token_value_validation() -> None:
     """
     Test case 11: Value validation for parameters.
     """

--- a/pytest/unit/security_functions/token_generation/test_generate_url_safe_token.py
+++ b/pytest/unit/security_functions/token_generation/test_generate_url_safe_token.py
@@ -4,7 +4,7 @@ from security_functions.token_generation.generate_url_safe_token import (
 )
 
 
-def test_generate_url_safe_token_case_1_default_length() -> None:
+def test_generate_url_safe_token_default_length() -> None:
     """
     Test case 1: Generate token with default length.
     """
@@ -17,7 +17,7 @@ def test_generate_url_safe_token_case_1_default_length() -> None:
     assert all(c.isalnum() or c in "-_" for c in token)  # URL-safe characters only
 
 
-def test_generate_url_safe_token_case_2_custom_length() -> None:
+def test_generate_url_safe_token_custom_length() -> None:
     """
     Test case 2: Generate token with custom length.
     """
@@ -33,7 +33,7 @@ def test_generate_url_safe_token_case_2_custom_length() -> None:
     assert all(c.isalnum() or c in "-_" for c in token)
 
 
-def test_generate_url_safe_token_case_3_short_length() -> None:
+def test_generate_url_safe_token_short_length() -> None:
     """
     Test case 3: Generate token with short length.
     """
@@ -49,7 +49,7 @@ def test_generate_url_safe_token_case_3_short_length() -> None:
     assert all(c.isalnum() or c in "-_" for c in token)
 
 
-def test_generate_url_safe_token_case_4_long_length() -> None:
+def test_generate_url_safe_token_long_length() -> None:
     """
     Test case 4: Generate token with long length.
     """
@@ -65,7 +65,7 @@ def test_generate_url_safe_token_case_4_long_length() -> None:
     assert all(c.isalnum() or c in "-_" for c in token)
 
 
-def test_generate_url_safe_token_case_7_randomness() -> None:
+def test_generate_url_safe_token_randomness() -> None:
     """
     Test case 5: Generated tokens should be different (randomness).
     """
@@ -80,7 +80,7 @@ def test_generate_url_safe_token_case_7_randomness() -> None:
     assert token1 != token3
 
 
-def test_generate_url_safe_token_case_8_url_safe_characters() -> None:
+def test_generate_url_safe_token_url_safe_characters() -> None:
     """
     Test case 6: Verify only URL-safe characters are used.
     """
@@ -97,7 +97,7 @@ def test_generate_url_safe_token_case_8_url_safe_characters() -> None:
     assert token_chars.issubset(allowed_chars)
 
 
-def test_generate_url_safe_token_case_9_no_padding() -> None:
+def test_generate_url_safe_token_no_padding() -> None:
     """
     Test case 7: Verify that no base64 padding characters are present.
     """
@@ -109,7 +109,7 @@ def test_generate_url_safe_token_case_9_no_padding() -> None:
     assert "=" not in token  # No padding characters
 
 
-def test_generate_url_safe_token_case_10_minimum_length() -> None:
+def test_generate_url_safe_token_minimum_length() -> None:
     """
     Test case 8: Test minimum valid length.
     """
@@ -122,7 +122,7 @@ def test_generate_url_safe_token_case_10_minimum_length() -> None:
     assert all(c.isalnum() or c in "-_" for c in token)
 
 
-def test_generate_url_safe_token_case_11_consistent_character_set() -> None:
+def test_generate_url_safe_token_consistent_character_set() -> None:
     """
     Test case 9: Verify consistent character set across multiple generations.
     """
@@ -141,7 +141,7 @@ def test_generate_url_safe_token_case_11_consistent_character_set() -> None:
     assert all_chars.issubset(allowed_chars)
 
 
-def test_generate_url_safe_token_case_12_base64_properties() -> None:
+def test_generate_url_safe_token_base64_properties() -> None:
     """
     Test case 10: Verify properties inherited from base64 encoding.
     """
@@ -157,7 +157,7 @@ def test_generate_url_safe_token_case_12_base64_properties() -> None:
     assert not any(char in forbidden_chars for char in token)
 
 
-def test_generate_url_safe_token_case_5_type_validation() -> None:
+def test_generate_url_safe_token_type_validation() -> None:
     """
     Test case 11: Type validation for length parameter.
     """
@@ -166,7 +166,7 @@ def test_generate_url_safe_token_case_5_type_validation() -> None:
         generate_url_safe_token(length="invalid")
 
 
-def test_generate_url_safe_token_case_6_value_validation() -> None:
+def test_generate_url_safe_token_value_validation() -> None:
     """
     Test case 12: Value validation for length parameter.
     """

--- a/pytest/unit/security_functions/token_generation/test_verify_jwt_token.py
+++ b/pytest/unit/security_functions/token_generation/test_verify_jwt_token.py
@@ -7,7 +7,7 @@ from security_functions.token_generation.generate_jwt_token import generate_jwt_
 from security_functions.token_generation.verify_jwt_token import verify_jwt_token
 
 
-def test_verify_jwt_token_case_1_valid_token() -> None:
+def test_verify_jwt_token_valid_token() -> None:
     """
     Test case 1: Verify valid JWT token returns correct payload.
     """
@@ -26,7 +26,7 @@ def test_verify_jwt_token_case_1_valid_token() -> None:
     assert "exp" in decoded_payload
 
 
-def test_verify_jwt_token_case_11_complex_payload() -> None:
+def test_verify_jwt_token_complex_payload() -> None:
     """
     Test case 2: Verify token with complex payload structure.
     """
@@ -50,7 +50,7 @@ def test_verify_jwt_token_case_11_complex_payload() -> None:
     assert decoded_payload["metadata"]["login_count"] == 5
 
 
-def test_verify_jwt_token_case_12_token_without_expiration() -> None:
+def test_verify_jwt_token_token_without_expiration() -> None:
     """
     Test case 3: Token without expiration should verify successfully.
     """
@@ -91,7 +91,7 @@ def test_verify_jwt_token_case_12_token_without_expiration() -> None:
     assert "exp" not in decoded_payload
 
 
-def test_verify_jwt_token_case_2_wrong_secret() -> None:
+def test_verify_jwt_token_wrong_secret() -> None:
     """
     Test case 4: Wrong secret should raise ValueError.
     """
@@ -106,7 +106,7 @@ def test_verify_jwt_token_case_2_wrong_secret() -> None:
         verify_jwt_token(token, wrong_secret)
 
 
-def test_verify_jwt_token_case_3_malformed_token() -> None:
+def test_verify_jwt_token_malformed_token() -> None:
     """
     Test case 5: Malformed token should raise ValueError.
     """
@@ -123,7 +123,7 @@ def test_verify_jwt_token_case_3_malformed_token() -> None:
         verify_jwt_token("too.many.parts.here", "secret")
 
 
-def test_verify_jwt_token_case_4_type_validation() -> None:
+def test_verify_jwt_token_type_validation() -> None:
     """
     Test case 6: Type validation for all parameters.
     """
@@ -138,7 +138,7 @@ def test_verify_jwt_token_case_4_type_validation() -> None:
         verify_jwt_token(token, 123)
 
 
-def test_verify_jwt_token_case_5_value_validation() -> None:
+def test_verify_jwt_token_value_validation() -> None:
     """
     Test case 7: Value validation for parameters.
     """
@@ -152,7 +152,7 @@ def test_verify_jwt_token_case_5_value_validation() -> None:
         verify_jwt_token(valid_token, "")
 
 
-def test_verify_jwt_token_case_6_invalid_base64() -> None:
+def test_verify_jwt_token_invalid_base64() -> None:
     """
     Test case 8: Invalid base64 encoding should raise ValueError.
     """
@@ -164,7 +164,7 @@ def test_verify_jwt_token_case_6_invalid_base64() -> None:
         verify_jwt_token(invalid_token, "secret")
 
 
-def test_verify_jwt_token_case_7_invalid_json() -> None:
+def test_verify_jwt_token_invalid_json() -> None:
     """
     Test case 9: Invalid JSON in token should raise ValueError.
     """
@@ -177,7 +177,7 @@ def test_verify_jwt_token_case_7_invalid_json() -> None:
         verify_jwt_token(invalid_token, "secret")
 
 
-def test_verify_jwt_token_case_8_unsupported_algorithm() -> None:
+def test_verify_jwt_token_unsupported_algorithm() -> None:
     """
     Test case 10: Unsupported algorithm should raise ValueError.
     """
@@ -201,7 +201,7 @@ def test_verify_jwt_token_case_8_unsupported_algorithm() -> None:
         verify_jwt_token(invalid_token, "secret")
 
 
-def test_verify_jwt_token_case_9_expired_token() -> None:
+def test_verify_jwt_token_expired_token() -> None:
     """
     Test case 11: Expired token should raise ValueError.
     """
@@ -240,7 +240,7 @@ def test_verify_jwt_token_case_9_expired_token() -> None:
         verify_jwt_token(expired_token, secret)
 
 
-def test_verify_jwt_token_case_10_invalid_expiration_format() -> None:
+def test_verify_jwt_token_invalid_expiration_format() -> None:
     """
     Test case 12: Invalid expiration time format should raise ValueError.
     """

--- a/pytest/unit/ssh_functions/test_ssh_copy_file.py
+++ b/pytest/unit/ssh_functions/test_ssh_copy_file.py
@@ -4,7 +4,7 @@ import pytest
 from ssh_functions.ssh_copy_file import ssh_copy_file
 
 
-def test_ssh_copy_file_case_1_normal_operation() -> None:
+def test_ssh_copy_file_normal_operation() -> None:
     """
     Test case 1: Normal operation with valid inputs.
     """
@@ -18,7 +18,7 @@ def test_ssh_copy_file_case_1_normal_operation() -> None:
         assert result == {"stdout": "", "stderr": "", "exit_code": 0}
 
 
-def test_ssh_copy_file_case_2_edge_case_empty_file() -> None:
+def test_ssh_copy_file_edge_case_empty_file() -> None:
     """
     Test case 2: Edge case with empty local file path.
     """
@@ -30,7 +30,7 @@ def test_ssh_copy_file_case_2_edge_case_empty_file() -> None:
         assert result["exit_code"] == 0
 
 
-def test_ssh_copy_file_case_5_boundary_conditions() -> None:
+def test_ssh_copy_file_boundary_conditions() -> None:
     """
     Test case 3: Boundary conditions for port.
     """
@@ -44,7 +44,7 @@ def test_ssh_copy_file_case_5_boundary_conditions() -> None:
         assert result_max["exit_code"] == 0
 
 
-def test_ssh_copy_file_case_3_type_error_local_path() -> None:
+def test_ssh_copy_file_type_error_local_path() -> None:
     """
     Test case 4: TypeError for invalid local_path type.
     """
@@ -52,7 +52,7 @@ def test_ssh_copy_file_case_3_type_error_local_path() -> None:
         ssh_copy_file(123, "/tmp/file.txt", "host")
 
 
-def test_ssh_copy_file_case_4_value_error_port() -> None:
+def test_ssh_copy_file_value_error_port() -> None:
     """
     Test case 5: ValueError for invalid port value.
     """
@@ -60,7 +60,7 @@ def test_ssh_copy_file_case_4_value_error_port() -> None:
         ssh_copy_file("file.txt", "/tmp/file.txt", "host", port=70000)
 
 
-def test_ssh_copy_file_case_6_timeout_error() -> None:
+def test_ssh_copy_file_timeout_error() -> None:
     """
     Test case 6: RuntimeError for timeout.
     """

--- a/pytest/unit/ssh_functions/test_ssh_execute_command.py
+++ b/pytest/unit/ssh_functions/test_ssh_execute_command.py
@@ -5,7 +5,7 @@ import pytest
 from ssh_functions.ssh_execute_command import ssh_execute_command
 
 
-def test_ssh_execute_command_case_1_normal_operation() -> None:
+def test_ssh_execute_command_normal_operation() -> None:
     """
     Test case 1: Normal operation with valid inputs.
     """
@@ -19,7 +19,7 @@ def test_ssh_execute_command_case_1_normal_operation() -> None:
         assert result == {"stdout": "output", "stderr": "", "exit_code": 0}
 
 
-def test_ssh_execute_command_case_2_edge_case_empty_command() -> None:
+def test_ssh_execute_command_edge_case_empty_command() -> None:
     """
     Test case 2: Edge case with empty command.
     """
@@ -31,7 +31,7 @@ def test_ssh_execute_command_case_2_edge_case_empty_command() -> None:
         assert result == {"stdout": "", "stderr": "", "exit_code": 0}
 
 
-def test_ssh_execute_command_case_5_boundary_conditions() -> None:
+def test_ssh_execute_command_boundary_conditions() -> None:
     """
     Test case 3: Boundary conditions for port.
     """
@@ -45,7 +45,7 @@ def test_ssh_execute_command_case_5_boundary_conditions() -> None:
         assert result_max["exit_code"] == 0
 
 
-def test_ssh_execute_command_case_3_type_error_host() -> None:
+def test_ssh_execute_command_type_error_host() -> None:
     """
     Test case 4: TypeError for invalid host type.
     """
@@ -53,7 +53,7 @@ def test_ssh_execute_command_case_3_type_error_host() -> None:
         ssh_execute_command(123, "ls")
 
 
-def test_ssh_execute_command_case_4_value_error_port() -> None:
+def test_ssh_execute_command_value_error_port() -> None:
     """
     Test case 5: ValueError for invalid port value.
     """
@@ -61,7 +61,7 @@ def test_ssh_execute_command_case_4_value_error_port() -> None:
         ssh_execute_command("host", "ls", port=70000)
 
 
-def test_ssh_execute_command_case_6_timeout_error() -> None:
+def test_ssh_execute_command_timeout_error() -> None:
     """
     Test case 6: RuntimeError for timeout.
     """
@@ -70,7 +70,7 @@ def test_ssh_execute_command_case_6_timeout_error() -> None:
             ssh_execute_command("host", "ls")
 
 
-def test_ssh_execute_command_case_7_timeout_expired() -> None:
+def test_ssh_execute_command_timeout_expired() -> None:
     """
     Test case 7: subprocess.TimeoutExpired raises RuntimeError with timeout-specific message.
     """

--- a/pytest/unit/ssh_functions/test_ssh_execute_script.py
+++ b/pytest/unit/ssh_functions/test_ssh_execute_script.py
@@ -4,7 +4,7 @@ import pytest
 from ssh_functions.ssh_execute_script import ssh_execute_script
 
 
-def test_ssh_execute_script_case_1_normal_operation() -> None:
+def test_ssh_execute_script_normal_operation() -> None:
     """
     Test case 1: Normal operation with valid inputs.
     """
@@ -20,7 +20,7 @@ def test_ssh_execute_script_case_1_normal_operation() -> None:
             assert result == {"stdout": "result", "stderr": "", "exit_code": 0}
 
 
-def test_ssh_execute_script_case_2_edge_case_empty_script() -> None:
+def test_ssh_execute_script_edge_case_empty_script() -> None:
     """
     Test case 2: Edge case with empty script file.
     """
@@ -34,7 +34,7 @@ def test_ssh_execute_script_case_2_edge_case_empty_script() -> None:
             assert result["exit_code"] == 0
 
 
-def test_ssh_execute_script_case_3_type_error_host() -> None:
+def test_ssh_execute_script_type_error_host() -> None:
     """
     Test case 3: TypeError for invalid host type.
     """
@@ -42,7 +42,7 @@ def test_ssh_execute_script_case_3_type_error_host() -> None:
         ssh_execute_script(123, "myscript.sh")
 
 
-def test_ssh_execute_script_case_4_value_error_port() -> None:
+def test_ssh_execute_script_value_error_port() -> None:
     """
     Test case 4: ValueError for invalid port value.
     """
@@ -50,7 +50,7 @@ def test_ssh_execute_script_case_4_value_error_port() -> None:
         ssh_execute_script("host", "myscript.sh", port=70000)
 
 
-def test_ssh_execute_script_case_5_file_not_found() -> None:
+def test_ssh_execute_script_file_not_found() -> None:
     """
     Test case 5: ValueError for missing script file.
     """
@@ -58,7 +58,7 @@ def test_ssh_execute_script_case_5_file_not_found() -> None:
         ssh_execute_script("host", "notfound.sh")
 
 
-def test_ssh_execute_script_case_6_timeout_error() -> None:
+def test_ssh_execute_script_timeout_error() -> None:
     """
     Test case 6: RuntimeError for timeout.
     """

--- a/pytest/unit/testing_functions/assertion_helpers/test_assert_almost_equal.py
+++ b/pytest/unit/testing_functions/assertion_helpers/test_assert_almost_equal.py
@@ -4,7 +4,7 @@ from testing_functions.assertion_helpers.assert_almost_equal import (
 )
 
 
-def test_assert_almost_equal_case_1_exactly_equal() -> None:
+def test_assert_almost_equal_exactly_equal() -> None:
     """
     Test case 1: Assert exactly equal values.
     """
@@ -12,7 +12,7 @@ def test_assert_almost_equal_case_1_exactly_equal() -> None:
     assert_almost_equal(1.0, 1.0)
 
 
-def test_assert_almost_equal_case_2_within_tolerance() -> None:
+def test_assert_almost_equal_within_tolerance() -> None:
     """
     Test case 2: Assert values within tolerance.
     """
@@ -20,7 +20,7 @@ def test_assert_almost_equal_case_2_within_tolerance() -> None:
     assert_almost_equal(0.1 + 0.2, 0.3, 1e-9)
 
 
-def test_assert_almost_equal_case_3_custom_tolerance() -> None:
+def test_assert_almost_equal_custom_tolerance() -> None:
     """
     Test case 4: Assert values with custom tolerance.
     """
@@ -28,7 +28,7 @@ def test_assert_almost_equal_case_3_custom_tolerance() -> None:
     assert_almost_equal(1.001, 1.002, 0.01)
 
 
-def test_assert_almost_equal_case_4_integers() -> None:
+def test_assert_almost_equal_integers() -> None:
     """
     Test case 5: Assert with integer values.
     """
@@ -36,7 +36,7 @@ def test_assert_almost_equal_case_4_integers() -> None:
     assert_almost_equal(5, 5)
 
 
-def test_assert_almost_equal_case_5_type_error_actual() -> None:
+def test_assert_almost_equal_type_error_actual() -> None:
     """
     Test case 6: TypeError for invalid actual type.
     """
@@ -45,7 +45,7 @@ def test_assert_almost_equal_case_5_type_error_actual() -> None:
         assert_almost_equal("1.0", 1.0)
 
 
-def test_assert_almost_equal_case_6_type_error_expected() -> None:
+def test_assert_almost_equal_type_error_expected() -> None:
     """
     Test case 7: TypeError for invalid expected type.
     """
@@ -54,7 +54,7 @@ def test_assert_almost_equal_case_6_type_error_expected() -> None:
         assert_almost_equal(1.0, "1.0")
 
 
-def test_assert_almost_equal_case_7_type_error_tolerance() -> None:
+def test_assert_almost_equal_type_error_tolerance() -> None:
     """
     Test case 8: TypeError for invalid tolerance type.
     """
@@ -63,7 +63,7 @@ def test_assert_almost_equal_case_7_type_error_tolerance() -> None:
         assert_almost_equal(1.0, 1.0, "0.1")
 
 
-def test_assert_almost_equal_case_8_value_error_negative_tolerance() -> None:
+def test_assert_almost_equal_value_error_negative_tolerance() -> None:
     """
     Test case 9: ValueError for negative tolerance.
     """
@@ -72,7 +72,7 @@ def test_assert_almost_equal_case_8_value_error_negative_tolerance() -> None:
         assert_almost_equal(1.0, 1.0, -0.1)
 
 
-def test_assert_almost_equal_case_9_assertion_error_exceeds_tolerance() -> None:
+def test_assert_almost_equal_assertion_error_exceeds_tolerance() -> None:
     """
     Test case 10: AssertionError when difference exceeds tolerance.
     """

--- a/pytest/unit/testing_functions/assertion_helpers/test_assert_dict_contains.py
+++ b/pytest/unit/testing_functions/assertion_helpers/test_assert_dict_contains.py
@@ -4,7 +4,7 @@ from testing_functions.assertion_helpers.assert_dict_contains import (
 )
 
 
-def test_assert_dict_contains_case_1_exact_match() -> None:
+def test_assert_dict_contains_exact_match() -> None:
     """
     Test case 1: Assert dict contains exact match.
     """
@@ -12,7 +12,7 @@ def test_assert_dict_contains_case_1_exact_match() -> None:
     assert_dict_contains({'a': 1, 'b': 2}, {'a': 1, 'b': 2})
 
 
-def test_assert_dict_contains_case_2_subset() -> None:
+def test_assert_dict_contains_subset() -> None:
     """
     Test case 2: Assert dict contains subset.
     """
@@ -20,7 +20,7 @@ def test_assert_dict_contains_case_2_subset() -> None:
     assert_dict_contains({'a': 1, 'b': 2, 'c': 3}, {'a': 1, 'b': 2})
 
 
-def test_assert_dict_contains_case_3_single_key() -> None:
+def test_assert_dict_contains_single_key() -> None:
     """
     Test case 3: Assert dict contains single key.
     """
@@ -28,7 +28,7 @@ def test_assert_dict_contains_case_3_single_key() -> None:
     assert_dict_contains({'x': 'y', 'z': 'w'}, {'x': 'y'})
 
 
-def test_assert_dict_contains_case_4_empty_subset() -> None:
+def test_assert_dict_contains_empty_subset() -> None:
     """
     Test case 4: Assert dict contains empty subset.
     """
@@ -36,7 +36,7 @@ def test_assert_dict_contains_case_4_empty_subset() -> None:
     assert_dict_contains({'a': 1}, {})
 
 
-def test_assert_dict_contains_case_5_nested_values() -> None:
+def test_assert_dict_contains_nested_values() -> None:
     """
     Test case 5: Assert dict contains with nested values.
     """
@@ -44,7 +44,7 @@ def test_assert_dict_contains_case_5_nested_values() -> None:
     assert_dict_contains({'a': [1, 2], 'b': {'x': 1}}, {'a': [1, 2]})
 
 
-def test_assert_dict_contains_case_6_type_error_actual_dict() -> None:
+def test_assert_dict_contains_type_error_actual_dict() -> None:
     """
     Test case 6: TypeError for invalid actual_dict type.
     """
@@ -53,7 +53,7 @@ def test_assert_dict_contains_case_6_type_error_actual_dict() -> None:
         assert_dict_contains("not a dict", {'a': 1})
 
 
-def test_assert_dict_contains_case_7_type_error_expected_subset() -> None:
+def test_assert_dict_contains_type_error_expected_subset() -> None:
     """
     Test case 7: TypeError for invalid expected_subset type.
     """
@@ -62,7 +62,7 @@ def test_assert_dict_contains_case_7_type_error_expected_subset() -> None:
         assert_dict_contains({'a': 1}, "not a dict")
 
 
-def test_assert_dict_contains_case_8_assertion_error_missing_key() -> None:
+def test_assert_dict_contains_assertion_error_missing_key() -> None:
     """
     Test case 8: AssertionError for missing key.
     """
@@ -71,7 +71,7 @@ def test_assert_dict_contains_case_8_assertion_error_missing_key() -> None:
         assert_dict_contains({'a': 1}, {'b': 2})
 
 
-def test_assert_dict_contains_case_9_assertion_error_value_mismatch() -> None:
+def test_assert_dict_contains_assertion_error_value_mismatch() -> None:
     """
     Test case 9: AssertionError for value mismatch.
     """

--- a/pytest/unit/testing_functions/assertion_helpers/test_assert_in_range.py
+++ b/pytest/unit/testing_functions/assertion_helpers/test_assert_in_range.py
@@ -2,7 +2,7 @@ import pytest
 from testing_functions.assertion_helpers.assert_in_range import assert_in_range
 
 
-def test_assert_in_range_case_1_value_in_range() -> None:
+def test_assert_in_range_value_in_range() -> None:
     """
     Test case 1: Assert value within range.
     """
@@ -10,7 +10,7 @@ def test_assert_in_range_case_1_value_in_range() -> None:
     assert_in_range(5, 1, 10)
 
 
-def test_assert_in_range_case_2_value_at_min() -> None:
+def test_assert_in_range_value_at_min() -> None:
     """
     Test case 2: Assert value at minimum boundary.
     """
@@ -18,7 +18,7 @@ def test_assert_in_range_case_2_value_at_min() -> None:
     assert_in_range(1, 1, 10)
 
 
-def test_assert_in_range_case_3_value_at_max() -> None:
+def test_assert_in_range_value_at_max() -> None:
     """
     Test case 3: Assert value at maximum boundary.
     """
@@ -26,7 +26,7 @@ def test_assert_in_range_case_3_value_at_max() -> None:
     assert_in_range(10, 1, 10)
 
 
-def test_assert_in_range_case_4_same_min_max() -> None:
+def test_assert_in_range_same_min_max() -> None:
     """
     Test case 4: Assert value when min equals max.
     """
@@ -34,7 +34,7 @@ def test_assert_in_range_case_4_same_min_max() -> None:
     assert_in_range(5, 5, 5)
 
 
-def test_assert_in_range_case_5_negative_range() -> None:
+def test_assert_in_range_negative_range() -> None:
     """
     Test case 5: Assert value in negative range.
     """
@@ -42,7 +42,7 @@ def test_assert_in_range_case_5_negative_range() -> None:
     assert_in_range(-5, -10, -1)
 
 
-def test_assert_in_range_case_6_type_error_value() -> None:
+def test_assert_in_range_type_error_value() -> None:
     """
     Test case 6: TypeError for invalid value type.
     """
@@ -51,7 +51,7 @@ def test_assert_in_range_case_6_type_error_value() -> None:
         assert_in_range("5", 1, 10)
 
 
-def test_assert_in_range_case_7_type_error_min_value() -> None:
+def test_assert_in_range_type_error_min_value() -> None:
     """
     Test case 7: TypeError for invalid min_value type.
     """
@@ -60,7 +60,7 @@ def test_assert_in_range_case_7_type_error_min_value() -> None:
         assert_in_range(5, "1", 10)
 
 
-def test_assert_in_range_case_8_type_error_max_value() -> None:
+def test_assert_in_range_type_error_max_value() -> None:
     """
     Test case 8: TypeError for invalid max_value type.
     """
@@ -69,7 +69,7 @@ def test_assert_in_range_case_8_type_error_max_value() -> None:
         assert_in_range(5, 1, "10")
 
 
-def test_assert_in_range_case_9_value_error_min_greater_than_max() -> None:
+def test_assert_in_range_value_error_min_greater_than_max() -> None:
     """
     Test case 9: ValueError when min_value > max_value.
     """
@@ -78,7 +78,7 @@ def test_assert_in_range_case_9_value_error_min_greater_than_max() -> None:
         assert_in_range(5, 10, 1)
 
 
-def test_assert_in_range_case_10_assertion_error_below_range() -> None:
+def test_assert_in_range_assertion_error_below_range() -> None:
     """
     Test case 10: AssertionError when value below range.
     """
@@ -87,7 +87,7 @@ def test_assert_in_range_case_10_assertion_error_below_range() -> None:
         assert_in_range(0, 1, 10)
 
 
-def test_assert_in_range_case_11_assertion_error_above_range() -> None:
+def test_assert_in_range_assertion_error_above_range() -> None:
     """
     Test case 11: AssertionError when value above range.
     """

--- a/pytest/unit/testing_functions/assertion_helpers/test_assert_list_equal_unordered.py
+++ b/pytest/unit/testing_functions/assertion_helpers/test_assert_list_equal_unordered.py
@@ -4,7 +4,7 @@ from testing_functions.assertion_helpers.assert_list_equal_unordered import (
 )
 
 
-def test_assert_list_equal_unordered_case_1_equal_ordered() -> None:
+def test_assert_list_equal_unordered_equal_ordered() -> None:
     """
     Test case 1: Assert lists that are equal and ordered.
     """
@@ -12,7 +12,7 @@ def test_assert_list_equal_unordered_case_1_equal_ordered() -> None:
     assert_list_equal_unordered([1, 2, 3], [1, 2, 3])
 
 
-def test_assert_list_equal_unordered_case_2_equal_unordered() -> None:
+def test_assert_list_equal_unordered_equal_unordered() -> None:
     """
     Test case 2: Assert lists that are equal but unordered.
     """
@@ -20,7 +20,7 @@ def test_assert_list_equal_unordered_case_2_equal_unordered() -> None:
     assert_list_equal_unordered([1, 2, 3], [3, 2, 1])
 
 
-def test_assert_list_equal_unordered_case_3_string_lists() -> None:
+def test_assert_list_equal_unordered_string_lists() -> None:
     """
     Test case 3: Assert string lists ignoring order.
     """
@@ -28,7 +28,7 @@ def test_assert_list_equal_unordered_case_3_string_lists() -> None:
     assert_list_equal_unordered(['a', 'b', 'c'], ['c', 'b', 'a'])
 
 
-def test_assert_list_equal_unordered_case_4_empty_lists() -> None:
+def test_assert_list_equal_unordered_empty_lists() -> None:
     """
     Test case 4: Assert empty lists.
     """
@@ -36,7 +36,7 @@ def test_assert_list_equal_unordered_case_4_empty_lists() -> None:
     assert_list_equal_unordered([], [])
 
 
-def test_assert_list_equal_unordered_case_5_single_element() -> None:
+def test_assert_list_equal_unordered_single_element() -> None:
     """
     Test case 5: Assert single element lists.
     """
@@ -44,7 +44,7 @@ def test_assert_list_equal_unordered_case_5_single_element() -> None:
     assert_list_equal_unordered([42], [42])
 
 
-def test_assert_list_equal_unordered_case_6_duplicates() -> None:
+def test_assert_list_equal_unordered_duplicates() -> None:
     """
     Test case 6: Assert lists with duplicate elements.
     """
@@ -52,7 +52,7 @@ def test_assert_list_equal_unordered_case_6_duplicates() -> None:
     assert_list_equal_unordered([1, 2, 2, 3], [3, 2, 1, 2])
 
 
-def test_assert_list_equal_unordered_case_7_type_error_actual() -> None:
+def test_assert_list_equal_unordered_type_error_actual() -> None:
     """
     Test case 7: TypeError for invalid actual type.
     """
@@ -61,7 +61,7 @@ def test_assert_list_equal_unordered_case_7_type_error_actual() -> None:
         assert_list_equal_unordered("not a list", [1, 2, 3])
 
 
-def test_assert_list_equal_unordered_case_8_type_error_expected() -> None:
+def test_assert_list_equal_unordered_type_error_expected() -> None:
     """
     Test case 8: TypeError for invalid expected type.
     """
@@ -70,7 +70,7 @@ def test_assert_list_equal_unordered_case_8_type_error_expected() -> None:
         assert_list_equal_unordered([1, 2, 3], "not a list")
 
 
-def test_assert_list_equal_unordered_case_9_assertion_error_different_lengths() -> None:
+def test_assert_list_equal_unordered_assertion_error_different_lengths() -> None:
     """
     Test case 9: AssertionError for different lengths.
     """
@@ -79,7 +79,7 @@ def test_assert_list_equal_unordered_case_9_assertion_error_different_lengths() 
         assert_list_equal_unordered([1, 2], [1, 2, 3])
 
 
-def test_assert_list_equal_unordered_case_10_assertion_error_different_elements() -> None:
+def test_assert_list_equal_unordered_assertion_error_different_elements() -> None:
     """
     Test case 10: AssertionError for different elements.
     """

--- a/pytest/unit/testing_functions/assertion_helpers/test_assert_raises_with_message.py
+++ b/pytest/unit/testing_functions/assertion_helpers/test_assert_raises_with_message.py
@@ -4,7 +4,7 @@ from testing_functions.assertion_helpers.assert_raises_with_message import (
 )
 
 
-def test_assert_raises_with_message_case_1_correct_exception_and_message() -> None:
+def test_assert_raises_with_message_correct_exception_and_message() -> None:
     """
     Test case 1: Assert correct exception and message.
     """
@@ -16,7 +16,7 @@ def test_assert_raises_with_message_case_1_correct_exception_and_message() -> No
     assert_raises_with_message(failing_func, ValueError, "Invalid")
 
 
-def test_assert_raises_with_message_case_2_full_message_match() -> None:
+def test_assert_raises_with_message_full_message_match() -> None:
     """
     Test case 2: Assert with full message match.
     """
@@ -28,7 +28,7 @@ def test_assert_raises_with_message_case_2_full_message_match() -> None:
     assert_raises_with_message(failing_func, TypeError, "Expected int, got str")
 
 
-def test_assert_raises_with_message_case_3_with_args() -> None:
+def test_assert_raises_with_message_with_args() -> None:
     """
     Test case 3: Assert exception with function args.
     """
@@ -40,7 +40,7 @@ def test_assert_raises_with_message_case_3_with_args() -> None:
     assert_raises_with_message(failing_func, ValueError, "Sum", 1, 2)
 
 
-def test_assert_raises_with_message_case_4_with_kwargs() -> None:
+def test_assert_raises_with_message_with_kwargs() -> None:
     """
     Test case 4: Assert exception with function kwargs.
     """
@@ -52,7 +52,7 @@ def test_assert_raises_with_message_case_4_with_kwargs() -> None:
     assert_raises_with_message(failing_func, RuntimeError, "not allowed", value=42)
 
 
-def test_assert_raises_with_message_case_5_type_error_func() -> None:
+def test_assert_raises_with_message_type_error_func() -> None:
     """
     Test case 5: TypeError for non-callable func.
     """
@@ -61,7 +61,7 @@ def test_assert_raises_with_message_case_5_type_error_func() -> None:
         assert_raises_with_message("not callable", ValueError, "message")
 
 
-def test_assert_raises_with_message_case_6_type_error_exception_type() -> None:
+def test_assert_raises_with_message_type_error_exception_type() -> None:
     """
     Test case 6: TypeError for invalid exception_type.
     """
@@ -74,7 +74,7 @@ def test_assert_raises_with_message_case_6_type_error_exception_type() -> None:
         assert_raises_with_message(dummy_func, "ValueError", "message")
 
 
-def test_assert_raises_with_message_case_7_type_error_message_pattern() -> None:
+def test_assert_raises_with_message_type_error_message_pattern() -> None:
     """
     Test case 7: TypeError for invalid message_pattern type.
     """
@@ -87,7 +87,7 @@ def test_assert_raises_with_message_case_7_type_error_message_pattern() -> None:
         assert_raises_with_message(dummy_func, ValueError, 123)
 
 
-def test_assert_raises_with_message_case_8_assertion_error_no_exception() -> None:
+def test_assert_raises_with_message_assertion_error_no_exception() -> None:
     """
     Test case 8: AssertionError when no exception raised.
     """
@@ -100,7 +100,7 @@ def test_assert_raises_with_message_case_8_assertion_error_no_exception() -> Non
         assert_raises_with_message(passing_func, ValueError, "message")
 
 
-def test_assert_raises_with_message_case_9_assertion_error_wrong_exception() -> None:
+def test_assert_raises_with_message_assertion_error_wrong_exception() -> None:
     """
     Test case 9: AssertionError when wrong exception type raised.
     """
@@ -113,7 +113,7 @@ def test_assert_raises_with_message_case_9_assertion_error_wrong_exception() -> 
         assert_raises_with_message(failing_func, ValueError, "message")
 
 
-def test_assert_raises_with_message_case_10_assertion_error_message_mismatch() -> None:
+def test_assert_raises_with_message_assertion_error_message_mismatch() -> None:
     """
     Test case 10: AssertionError when message doesn't match.
     """

--- a/pytest/unit/testing_functions/assertion_helpers/test_assert_type_match.py
+++ b/pytest/unit/testing_functions/assertion_helpers/test_assert_type_match.py
@@ -2,7 +2,7 @@ import pytest
 from testing_functions.assertion_helpers.assert_type_match import assert_type_match
 
 
-def test_assert_type_match_case_1_int_type() -> None:
+def test_assert_type_match_int_type() -> None:
     """
     Test case 1: Assert integer type match.
     """
@@ -10,7 +10,7 @@ def test_assert_type_match_case_1_int_type() -> None:
     assert_type_match(5, int)
 
 
-def test_assert_type_match_case_2_str_type() -> None:
+def test_assert_type_match_str_type() -> None:
     """
     Test case 2: Assert string type match.
     """
@@ -18,7 +18,7 @@ def test_assert_type_match_case_2_str_type() -> None:
     assert_type_match("hello", str)
 
 
-def test_assert_type_match_case_3_list_type() -> None:
+def test_assert_type_match_list_type() -> None:
     """
     Test case 3: Assert list type match.
     """
@@ -26,7 +26,7 @@ def test_assert_type_match_case_3_list_type() -> None:
     assert_type_match([1, 2, 3], list)
 
 
-def test_assert_type_match_case_4_dict_type() -> None:
+def test_assert_type_match_dict_type() -> None:
     """
     Test case 4: Assert dict type match.
     """
@@ -34,7 +34,7 @@ def test_assert_type_match_case_4_dict_type() -> None:
     assert_type_match({'a': 1}, dict)
 
 
-def test_assert_type_match_case_5_float_type() -> None:
+def test_assert_type_match_float_type() -> None:
     """
     Test case 5: Assert float type match.
     """
@@ -42,7 +42,7 @@ def test_assert_type_match_case_5_float_type() -> None:
     assert_type_match(3.14, float)
 
 
-def test_assert_type_match_case_6_type_error_expected_type() -> None:
+def test_assert_type_match_type_error_expected_type() -> None:
     """
     Test case 6: TypeError for invalid expected_type.
     """
@@ -51,7 +51,7 @@ def test_assert_type_match_case_6_type_error_expected_type() -> None:
         assert_type_match(5, "int")
 
 
-def test_assert_type_match_case_7_assertion_error_type_mismatch() -> None:
+def test_assert_type_match_assertion_error_type_mismatch() -> None:
     """
     Test case 7: AssertionError for type mismatch.
     """
@@ -60,7 +60,7 @@ def test_assert_type_match_case_7_assertion_error_type_mismatch() -> None:
         assert_type_match("5", int)
 
 
-def test_assert_type_match_case_8_assertion_error_int_float_mismatch() -> None:
+def test_assert_type_match_assertion_error_int_float_mismatch() -> None:
     """
     Test case 8: AssertionError for int/float mismatch.
     """

--- a/pytest/unit/testing_functions/benchmark_helpers/test_benchmark_function.py
+++ b/pytest/unit/testing_functions/benchmark_helpers/test_benchmark_function.py
@@ -4,7 +4,7 @@ import pytest
 from testing_functions.benchmark_helpers.benchmark_function import benchmark_function
 
 
-def test_benchmark_function_case_1_simple_function() -> None:
+def test_benchmark_function_simple_function() -> None:
     """
     Test case 1: Benchmark simple function.
     """
@@ -24,7 +24,7 @@ def test_benchmark_function_case_1_simple_function() -> None:
     assert result['avg_time'] >= 0
 
 
-def test_benchmark_function_case_2_with_sleep() -> None:
+def test_benchmark_function_with_sleep() -> None:
     """
     Test case 2: Benchmark function with sleep.
     """
@@ -40,7 +40,7 @@ def test_benchmark_function_case_2_with_sleep() -> None:
     assert result['avg_time'] >= 0.01
 
 
-def test_benchmark_function_case_3_single_iteration() -> None:
+def test_benchmark_function_single_iteration() -> None:
     """
     Test case 3: Benchmark with single iteration.
     """
@@ -56,7 +56,7 @@ def test_benchmark_function_case_3_single_iteration() -> None:
     assert result['avg_time'] == result['total_time']
 
 
-def test_benchmark_function_case_4_with_args() -> None:
+def test_benchmark_function_with_args() -> None:
     """
     Test case 4: Benchmark function with arguments.
     """
@@ -71,7 +71,7 @@ def test_benchmark_function_case_4_with_args() -> None:
     assert result['avg_time'] >= 0
 
 
-def test_benchmark_function_case_5_with_kwargs() -> None:
+def test_benchmark_function_with_kwargs() -> None:
     """
     Test case 5: Benchmark function with kwargs.
     """
@@ -86,7 +86,7 @@ def test_benchmark_function_case_5_with_kwargs() -> None:
     assert result['avg_time'] >= 0
 
 
-def test_benchmark_function_case_6_type_error_func() -> None:
+def test_benchmark_function_type_error_func() -> None:
     """
     Test case 6: TypeError for non-callable func.
     """
@@ -95,7 +95,7 @@ def test_benchmark_function_case_6_type_error_func() -> None:
         benchmark_function("not callable", iterations=10)
 
 
-def test_benchmark_function_case_7_type_error_iterations() -> None:
+def test_benchmark_function_type_error_iterations() -> None:
     """
     Test case 7: TypeError for invalid iterations type.
     """
@@ -108,7 +108,7 @@ def test_benchmark_function_case_7_type_error_iterations() -> None:
         benchmark_function(test_func, iterations="10")
 
 
-def test_benchmark_function_case_8_value_error_zero_iterations() -> None:
+def test_benchmark_function_value_error_zero_iterations() -> None:
     """
     Test case 8: ValueError for zero iterations.
     """
@@ -121,7 +121,7 @@ def test_benchmark_function_case_8_value_error_zero_iterations() -> None:
         benchmark_function(test_func, iterations=0)
 
 
-def test_benchmark_function_case_9_value_error_negative_iterations() -> None:
+def test_benchmark_function_value_error_negative_iterations() -> None:
     """
     Test case 9: ValueError for negative iterations.
     """

--- a/pytest/unit/testing_functions/benchmark_helpers/test_compare_functions.py
+++ b/pytest/unit/testing_functions/benchmark_helpers/test_compare_functions.py
@@ -2,7 +2,7 @@ import pytest
 from testing_functions.benchmark_helpers.compare_functions import compare_functions
 
 
-def test_compare_functions_case_1_equal_functions() -> None:
+def test_compare_functions_equal_functions() -> None:
     """
     Test case 1: Compare two similar functions.
     """
@@ -24,7 +24,7 @@ def test_compare_functions_case_1_equal_functions() -> None:
     assert result['faster_function'] in ['func1', 'func2']
 
 
-def test_compare_functions_case_2_different_args() -> None:
+def test_compare_functions_different_args() -> None:
     """
     Test case 2: Compare functions with different arguments.
     """
@@ -43,7 +43,7 @@ def test_compare_functions_case_2_different_args() -> None:
     assert result['func2_avg_time'] >= 0
 
 
-def test_compare_functions_case_3_speedup_calculation() -> None:
+def test_compare_functions_speedup_calculation() -> None:
     """
     Test case 3: Verify speedup calculation.
     """
@@ -62,7 +62,7 @@ def test_compare_functions_case_3_speedup_calculation() -> None:
     assert result['speedup'] > 0
 
 
-def test_compare_functions_case_4_single_iteration() -> None:
+def test_compare_functions_single_iteration() -> None:
     """
     Test case 4: Compare with single iteration.
     """
@@ -81,7 +81,7 @@ def test_compare_functions_case_4_single_iteration() -> None:
     assert result['func2_total_time'] == result['func2_avg_time']
 
 
-def test_compare_functions_case_5_type_error_func1() -> None:
+def test_compare_functions_type_error_func1() -> None:
     """
     Test case 5: TypeError for non-callable func1.
     """
@@ -94,7 +94,7 @@ def test_compare_functions_case_5_type_error_func1() -> None:
         compare_functions("not callable", func2)
 
 
-def test_compare_functions_case_6_type_error_func2() -> None:
+def test_compare_functions_type_error_func2() -> None:
     """
     Test case 6: TypeError for non-callable func2.
     """
@@ -107,7 +107,7 @@ def test_compare_functions_case_6_type_error_func2() -> None:
         compare_functions(func1, "not callable")
 
 
-def test_compare_functions_case_7_type_error_args1() -> None:
+def test_compare_functions_type_error_args1() -> None:
     """
     Test case 7: TypeError for invalid args1 type.
     """
@@ -123,7 +123,7 @@ def test_compare_functions_case_7_type_error_args1() -> None:
         compare_functions(func1, func2, [1, 2], ())
 
 
-def test_compare_functions_case_8_type_error_args2() -> None:
+def test_compare_functions_type_error_args2() -> None:
     """
     Test case 8: TypeError for invalid args2 type.
     """
@@ -139,7 +139,7 @@ def test_compare_functions_case_8_type_error_args2() -> None:
         compare_functions(func1, func2, (), [1, 2])
 
 
-def test_compare_functions_case_9_type_error_iterations() -> None:
+def test_compare_functions_type_error_iterations() -> None:
     """
     Test case 9: TypeError for invalid iterations type.
     """
@@ -155,7 +155,7 @@ def test_compare_functions_case_9_type_error_iterations() -> None:
         compare_functions(func1, func2, (), (), iterations="10")
 
 
-def test_compare_functions_case_10_value_error_iterations() -> None:
+def test_compare_functions_value_error_iterations() -> None:
     """
     Test case 10: ValueError for invalid iterations value.
     """

--- a/pytest/unit/testing_functions/benchmark_helpers/test_measure_memory_usage.py
+++ b/pytest/unit/testing_functions/benchmark_helpers/test_measure_memory_usage.py
@@ -4,7 +4,7 @@ from testing_functions.benchmark_helpers.measure_memory_usage import (
 )
 
 
-def test_measure_memory_usage_case_1_simple_function() -> None:
+def test_measure_memory_usage_simple_function() -> None:
     """
     Test case 1: Measure memory for simple function.
     """
@@ -22,7 +22,7 @@ def test_measure_memory_usage_case_1_simple_function() -> None:
     assert result['result'] == 42
 
 
-def test_measure_memory_usage_case_2_list_creation() -> None:
+def test_measure_memory_usage_list_creation() -> None:
     """
     Test case 2: Measure memory for list creation.
     """
@@ -38,7 +38,7 @@ def test_measure_memory_usage_case_2_list_creation() -> None:
     assert len(result['result']) == 1000
 
 
-def test_measure_memory_usage_case_3_dict_creation() -> None:
+def test_measure_memory_usage_dict_creation() -> None:
     """
     Test case 3: Measure memory for dict creation.
     """
@@ -54,7 +54,7 @@ def test_measure_memory_usage_case_3_dict_creation() -> None:
     assert len(result['result']) == 500
 
 
-def test_measure_memory_usage_case_4_with_args() -> None:
+def test_measure_memory_usage_with_args() -> None:
     """
     Test case 4: Measure memory with function args.
     """
@@ -70,7 +70,7 @@ def test_measure_memory_usage_case_4_with_args() -> None:
     assert result['peak_bytes'] >= 0
 
 
-def test_measure_memory_usage_case_5_with_kwargs() -> None:
+def test_measure_memory_usage_with_kwargs() -> None:
     """
     Test case 5: Measure memory with function kwargs.
     """
@@ -85,7 +85,7 @@ def test_measure_memory_usage_case_5_with_kwargs() -> None:
     assert len(result['result']) == 50
 
 
-def test_measure_memory_usage_case_6_type_error_func() -> None:
+def test_measure_memory_usage_type_error_func() -> None:
     """
     Test case 6: TypeError for non-callable func.
     """

--- a/pytest/unit/testing_functions/fixture_factories/test_create_temp_dir_fixture.py
+++ b/pytest/unit/testing_functions/fixture_factories/test_create_temp_dir_fixture.py
@@ -6,7 +6,7 @@ from testing_functions.fixture_factories.create_temp_dir_fixture import (
 )
 
 
-def test_create_temp_dir_fixture_case_1_empty_directory() -> None:
+def test_create_temp_dir_fixture_empty_directory() -> None:
     """
     Test case 1: Create empty temp directory.
     """
@@ -20,7 +20,7 @@ def test_create_temp_dir_fixture_case_1_empty_directory() -> None:
     assert not temp_dir.exists()
 
 
-def test_create_temp_dir_fixture_case_2_with_single_file() -> None:
+def test_create_temp_dir_fixture_with_single_file() -> None:
     """
     Test case 2: Create temp directory with single file.
     """
@@ -34,7 +34,7 @@ def test_create_temp_dir_fixture_case_2_with_single_file() -> None:
         assert file_path.read_text() == "content"
 
 
-def test_create_temp_dir_fixture_case_3_with_multiple_files() -> None:
+def test_create_temp_dir_fixture_with_multiple_files() -> None:
     """
     Test case 3: Create temp directory with multiple files.
     """
@@ -52,7 +52,7 @@ def test_create_temp_dir_fixture_case_3_with_multiple_files() -> None:
         assert (temp_dir / "file3.txt").read_text() == "content3"
 
 
-def test_create_temp_dir_fixture_case_4_with_subdirectories() -> None:
+def test_create_temp_dir_fixture_with_subdirectories() -> None:
     """
     Test case 4: Create temp directory with subdirectories.
     """
@@ -68,7 +68,7 @@ def test_create_temp_dir_fixture_case_4_with_subdirectories() -> None:
         assert (temp_dir / "dir2" / "file2.txt").exists()
 
 
-def test_create_temp_dir_fixture_case_5_directory_cleanup() -> None:
+def test_create_temp_dir_fixture_directory_cleanup() -> None:
     """
     Test case 5: Verify directory is deleted after context.
     """
@@ -85,7 +85,7 @@ def test_create_temp_dir_fixture_case_5_directory_cleanup() -> None:
     assert not dir_path.exists()
 
 
-def test_create_temp_dir_fixture_case_6_nested_directories() -> None:
+def test_create_temp_dir_fixture_nested_directories() -> None:
     """
     Test case 6: Create temp directory with nested structure.
     """
@@ -101,7 +101,7 @@ def test_create_temp_dir_fixture_case_6_nested_directories() -> None:
         assert file_path.read_text() == "deep content"
 
 
-def test_create_temp_dir_fixture_case_7_type_error_files() -> None:
+def test_create_temp_dir_fixture_type_error_files() -> None:
     """
     Test case 7: TypeError for invalid files type.
     """

--- a/pytest/unit/testing_functions/fixture_factories/test_create_temp_file_fixture.py
+++ b/pytest/unit/testing_functions/fixture_factories/test_create_temp_file_fixture.py
@@ -6,7 +6,7 @@ from testing_functions.fixture_factories.create_temp_file_fixture import (
 )
 
 
-def test_create_temp_file_fixture_case_1_default_parameters() -> None:
+def test_create_temp_file_fixture_default_parameters() -> None:
     """
     Test case 1: Create temp file with default parameters.
     """
@@ -20,7 +20,7 @@ def test_create_temp_file_fixture_case_1_default_parameters() -> None:
     assert not temp_file.exists()
 
 
-def test_create_temp_file_fixture_case_2_with_content() -> None:
+def test_create_temp_file_fixture_with_content() -> None:
     """
     Test case 2: Create temp file with content.
     """
@@ -32,7 +32,7 @@ def test_create_temp_file_fixture_case_2_with_content() -> None:
         assert temp_file.read_text() == content
 
 
-def test_create_temp_file_fixture_case_3_custom_suffix() -> None:
+def test_create_temp_file_fixture_custom_suffix() -> None:
     """
     Test case 3: Create temp file with custom suffix.
     """
@@ -41,7 +41,7 @@ def test_create_temp_file_fixture_case_3_custom_suffix() -> None:
         assert temp_file.suffix == ".py"
 
 
-def test_create_temp_file_fixture_case_4_multiline_content() -> None:
+def test_create_temp_file_fixture_multiline_content() -> None:
     """
     Test case 4: Create temp file with multiline content.
     """
@@ -55,7 +55,7 @@ def test_create_temp_file_fixture_case_4_multiline_content() -> None:
         assert len(lines) == 3
 
 
-def test_create_temp_file_fixture_case_5_file_cleanup() -> None:
+def test_create_temp_file_fixture_file_cleanup() -> None:
     """
     Test case 5: Verify file is deleted after context.
     """
@@ -71,7 +71,7 @@ def test_create_temp_file_fixture_case_5_file_cleanup() -> None:
     assert not file_path.exists()
 
 
-def test_create_temp_file_fixture_case_6_type_error_content() -> None:
+def test_create_temp_file_fixture_type_error_content() -> None:
     """
     Test case 6: TypeError for invalid content type.
     """
@@ -81,7 +81,7 @@ def test_create_temp_file_fixture_case_6_type_error_content() -> None:
             pass
 
 
-def test_create_temp_file_fixture_case_7_type_error_suffix() -> None:
+def test_create_temp_file_fixture_type_error_suffix() -> None:
     """
     Test case 7: TypeError for invalid suffix type.
     """

--- a/pytest/unit/testing_functions/fixture_factories/test_mock_datetime_fixture.py
+++ b/pytest/unit/testing_functions/fixture_factories/test_mock_datetime_fixture.py
@@ -6,7 +6,7 @@ from testing_functions.fixture_factories.mock_datetime_fixture import (
 )
 
 
-def test_mock_datetime_fixture_case_1_default_parameters() -> None:
+def test_mock_datetime_fixture_default_parameters() -> None:
     """
     Test case 1: Mock datetime with default parameters.
     """
@@ -18,7 +18,7 @@ def test_mock_datetime_fixture_case_1_default_parameters() -> None:
         assert mock_dt.day == 1
 
 
-def test_mock_datetime_fixture_case_2_custom_date() -> None:
+def test_mock_datetime_fixture_custom_date() -> None:
     """
     Test case 2: Mock datetime with custom date.
     """
@@ -29,7 +29,7 @@ def test_mock_datetime_fixture_case_2_custom_date() -> None:
         assert mock_dt.day == 25
 
 
-def test_mock_datetime_fixture_case_3_custom_time() -> None:
+def test_mock_datetime_fixture_custom_time() -> None:
     """
     Test case 3: Mock datetime with custom time.
     """
@@ -40,7 +40,7 @@ def test_mock_datetime_fixture_case_3_custom_time() -> None:
         assert mock_dt.second == 45
 
 
-def test_mock_datetime_fixture_case_4_midnight() -> None:
+def test_mock_datetime_fixture_midnight() -> None:
     """
     Test case 4: Mock datetime at midnight.
     """
@@ -51,7 +51,7 @@ def test_mock_datetime_fixture_case_4_midnight() -> None:
         assert mock_dt.second == 0
 
 
-def test_mock_datetime_fixture_case_5_end_of_day() -> None:
+def test_mock_datetime_fixture_end_of_day() -> None:
     """
     Test case 5: Mock datetime at end of day.
     """
@@ -64,7 +64,7 @@ def test_mock_datetime_fixture_case_5_end_of_day() -> None:
         assert mock_dt.second == 59
 
 
-def test_mock_datetime_fixture_case_6_type_error_year() -> None:
+def test_mock_datetime_fixture_type_error_year() -> None:
     """
     Test case 6: TypeError for invalid year type.
     """
@@ -74,7 +74,7 @@ def test_mock_datetime_fixture_case_6_type_error_year() -> None:
             pass
 
 
-def test_mock_datetime_fixture_case_7_type_error_month() -> None:
+def test_mock_datetime_fixture_type_error_month() -> None:
     """
     Test case 7: TypeError for invalid month type.
     """
@@ -84,7 +84,7 @@ def test_mock_datetime_fixture_case_7_type_error_month() -> None:
             pass
 
 
-def test_mock_datetime_fixture_case_8_type_error_day() -> None:
+def test_mock_datetime_fixture_type_error_day() -> None:
     """
     Test case 8: TypeError for invalid day type.
     """
@@ -94,7 +94,7 @@ def test_mock_datetime_fixture_case_8_type_error_day() -> None:
             pass
 
 
-def test_mock_datetime_fixture_case_9_type_error_hour() -> None:
+def test_mock_datetime_fixture_type_error_hour() -> None:
     """
     Test case 9: TypeError for invalid hour type.
     """
@@ -104,7 +104,7 @@ def test_mock_datetime_fixture_case_9_type_error_hour() -> None:
             pass
 
 
-def test_mock_datetime_fixture_case_10_type_error_minute() -> None:
+def test_mock_datetime_fixture_type_error_minute() -> None:
     """
     Test case 10: TypeError for invalid minute type.
     """
@@ -114,7 +114,7 @@ def test_mock_datetime_fixture_case_10_type_error_minute() -> None:
             pass
 
 
-def test_mock_datetime_fixture_case_11_type_error_second() -> None:
+def test_mock_datetime_fixture_type_error_second() -> None:
     """
     Test case 11: TypeError for invalid second type.
     """

--- a/pytest/unit/testing_functions/mock_helpers/test_create_mock_object.py
+++ b/pytest/unit/testing_functions/mock_helpers/test_create_mock_object.py
@@ -2,7 +2,7 @@ import pytest
 from testing_functions.mock_helpers.create_mock_object import create_mock_object
 
 
-def test_create_mock_object_case_1_single_attribute() -> None:
+def test_create_mock_object_single_attribute() -> None:
     """
     Test case 1: Create mock with single attribute.
     """
@@ -13,7 +13,7 @@ def test_create_mock_object_case_1_single_attribute() -> None:
     assert mock.name == "test"
 
 
-def test_create_mock_object_case_2_multiple_attributes() -> None:
+def test_create_mock_object_multiple_attributes() -> None:
     """
     Test case 2: Create mock with multiple attributes.
     """
@@ -26,7 +26,7 @@ def test_create_mock_object_case_2_multiple_attributes() -> None:
     assert mock.active is True
 
 
-def test_create_mock_object_case_3_complex_attributes() -> None:
+def test_create_mock_object_complex_attributes() -> None:
     """
     Test case 3: Create mock with complex attributes.
     """
@@ -43,7 +43,7 @@ def test_create_mock_object_case_3_complex_attributes() -> None:
     assert mock.callback(5) == 10
 
 
-def test_create_mock_object_case_4_no_attributes() -> None:
+def test_create_mock_object_no_attributes() -> None:
     """
     Test case 4: Create mock with no attributes.
     """
@@ -54,7 +54,7 @@ def test_create_mock_object_case_4_no_attributes() -> None:
     assert hasattr(mock, '_mock_name')  # Mock object exists
 
 
-def test_create_mock_object_case_5_nested_objects() -> None:
+def test_create_mock_object_nested_objects() -> None:
     """
     Test case 5: Create mock with nested object attributes.
     """
@@ -66,7 +66,7 @@ def test_create_mock_object_case_5_nested_objects() -> None:
     assert mock.nested.id == 1
 
 
-def test_create_mock_object_case_6_override_attribute() -> None:
+def test_create_mock_object_override_attribute() -> None:
     """
     Test case 6: Create mock and later modify attribute.
     """

--- a/pytest/unit/testing_functions/mock_helpers/test_mock_api_response.py
+++ b/pytest/unit/testing_functions/mock_helpers/test_mock_api_response.py
@@ -2,7 +2,7 @@ import pytest
 from testing_functions.mock_helpers.mock_api_response import mock_api_response
 
 
-def test_mock_api_response_case_1_default_parameters() -> None:
+def test_mock_api_response_default_parameters() -> None:
     """
     Test case 1: Create mock API response with defaults.
     """
@@ -15,7 +15,7 @@ def test_mock_api_response_case_1_default_parameters() -> None:
     assert response.json() is None
 
 
-def test_mock_api_response_case_2_custom_status_code() -> None:
+def test_mock_api_response_custom_status_code() -> None:
     """
     Test case 2: Create mock with custom status code.
     """
@@ -26,7 +26,7 @@ def test_mock_api_response_case_2_custom_status_code() -> None:
     assert response.status_code == 404
 
 
-def test_mock_api_response_case_3_with_data() -> None:
+def test_mock_api_response_with_data() -> None:
     """
     Test case 3: Create mock with JSON data.
     """
@@ -41,7 +41,7 @@ def test_mock_api_response_case_3_with_data() -> None:
     assert "key" in response.json()
 
 
-def test_mock_api_response_case_4_with_headers() -> None:
+def test_mock_api_response_with_headers() -> None:
     """
     Test case 4: Create mock with custom headers.
     """
@@ -55,7 +55,7 @@ def test_mock_api_response_case_4_with_headers() -> None:
     assert response.headers == headers
 
 
-def test_mock_api_response_case_5_text_attribute() -> None:
+def test_mock_api_response_text_attribute() -> None:
     """
     Test case 5: Verify text attribute.
     """
@@ -69,7 +69,7 @@ def test_mock_api_response_case_5_text_attribute() -> None:
     assert "message" in response.text
 
 
-def test_mock_api_response_case_6_error_status_codes() -> None:
+def test_mock_api_response_error_status_codes() -> None:
     """
     Test case 6: Create mock with various error codes.
     """
@@ -82,7 +82,7 @@ def test_mock_api_response_case_6_error_status_codes() -> None:
     assert response_500.status_code == 500
 
 
-def test_mock_api_response_case_7_type_error_status_code() -> None:
+def test_mock_api_response_type_error_status_code() -> None:
     """
     Test case 7: TypeError for invalid status_code type.
     """
@@ -91,7 +91,7 @@ def test_mock_api_response_case_7_type_error_status_code() -> None:
         mock_api_response("200")
 
 
-def test_mock_api_response_case_8_type_error_headers() -> None:
+def test_mock_api_response_type_error_headers() -> None:
     """
     Test case 8: TypeError for invalid headers type.
     """
@@ -100,7 +100,7 @@ def test_mock_api_response_case_8_type_error_headers() -> None:
         mock_api_response(200, None, "headers")
 
 
-def test_mock_api_response_case_9_value_error_invalid_status_code() -> None:
+def test_mock_api_response_value_error_invalid_status_code() -> None:
     """
     Test case 9: ValueError for invalid status code.
     """
@@ -109,7 +109,7 @@ def test_mock_api_response_case_9_value_error_invalid_status_code() -> None:
         mock_api_response(99)
 
 
-def test_mock_api_response_case_10_value_error_status_code_too_high() -> None:
+def test_mock_api_response_value_error_status_code_too_high() -> None:
     """
     Test case 10: ValueError for status code too high.
     """

--- a/pytest/unit/testing_functions/mock_helpers/test_mock_file_system.py
+++ b/pytest/unit/testing_functions/mock_helpers/test_mock_file_system.py
@@ -2,7 +2,7 @@ import pytest
 from testing_functions.mock_helpers.mock_file_system import mock_file_system
 
 
-def test_mock_file_system_case_1_single_file() -> None:
+def test_mock_file_system_single_file() -> None:
     """
     Test case 1: Create mock filesystem with single file.
     """
@@ -17,7 +17,7 @@ def test_mock_file_system_case_1_single_file() -> None:
     assert fs.exists("/test.txt") is True
 
 
-def test_mock_file_system_case_2_multiple_files() -> None:
+def test_mock_file_system_multiple_files() -> None:
     """
     Test case 2: Create mock filesystem with multiple files.
     """
@@ -37,7 +37,7 @@ def test_mock_file_system_case_2_multiple_files() -> None:
     assert fs.read("/dir/file3.txt") == "content3"
 
 
-def test_mock_file_system_case_3_file_exists() -> None:
+def test_mock_file_system_file_exists() -> None:
     """
     Test case 3: Test exists method.
     """
@@ -52,7 +52,7 @@ def test_mock_file_system_case_3_file_exists() -> None:
     assert fs.exists("/nonexisting.txt") is False
 
 
-def test_mock_file_system_case_4_listdir() -> None:
+def test_mock_file_system_listdir() -> None:
     """
     Test case 4: Test listdir method.
     """
@@ -73,7 +73,7 @@ def test_mock_file_system_case_4_listdir() -> None:
     assert "/dir/file2.txt" in result
 
 
-def test_mock_file_system_case_5_empty_filesystem() -> None:
+def test_mock_file_system_empty_filesystem() -> None:
     """
     Test case 5: Create empty mock filesystem.
     """
@@ -87,7 +87,7 @@ def test_mock_file_system_case_5_empty_filesystem() -> None:
     assert fs.exists("/any.txt") is False
 
 
-def test_mock_file_system_case_6_files_attribute() -> None:
+def test_mock_file_system_files_attribute() -> None:
     """
     Test case 6: Access files attribute.
     """
@@ -101,7 +101,7 @@ def test_mock_file_system_case_6_files_attribute() -> None:
     assert fs.files == files
 
 
-def test_mock_file_system_case_7_read_nonexistent_file() -> None:
+def test_mock_file_system_read_nonexistent_file() -> None:
     """
     Test case 7: FileNotFoundError when reading nonexistent file.
     """
@@ -116,7 +116,7 @@ def test_mock_file_system_case_7_read_nonexistent_file() -> None:
         fs.read("/nonexistent.txt")
 
 
-def test_mock_file_system_case_8_type_error_files() -> None:
+def test_mock_file_system_type_error_files() -> None:
     """
     Test case 8: TypeError for invalid files type.
     """

--- a/pytest/unit/testing_functions/test_data_generators/test_generate_random_date.py
+++ b/pytest/unit/testing_functions/test_data_generators/test_generate_random_date.py
@@ -6,7 +6,7 @@ from testing_functions.test_data_generators.generate_random_date import (
 )
 
 
-def test_generate_random_date_case_1_default_parameters() -> None:
+def test_generate_random_date_default_parameters() -> None:
     """
     Test case 1: Generate random date with default parameters.
     """
@@ -18,7 +18,7 @@ def test_generate_random_date_case_1_default_parameters() -> None:
     assert 2000 <= result.year <= 2025
 
 
-def test_generate_random_date_case_2_custom_year_range() -> None:
+def test_generate_random_date_custom_year_range() -> None:
     """
     Test case 2: Generate random date with custom year range.
     """
@@ -29,7 +29,7 @@ def test_generate_random_date_case_2_custom_year_range() -> None:
     assert 2020 <= result.year <= 2021
 
 
-def test_generate_random_date_case_3_same_start_end_year() -> None:
+def test_generate_random_date_same_start_end_year() -> None:
     """
     Test case 3: Generate random date when start_year equals end_year.
     """
@@ -40,7 +40,7 @@ def test_generate_random_date_case_3_same_start_end_year() -> None:
     assert result.year == 2022
 
 
-def test_generate_random_date_case_4_wide_range() -> None:
+def test_generate_random_date_wide_range() -> None:
     """
     Test case 4: Generate random date with wide year range.
     """
@@ -51,7 +51,7 @@ def test_generate_random_date_case_4_wide_range() -> None:
     assert 1900 <= result.year <= 2100
 
 
-def test_generate_random_date_case_5_type_error_start_year() -> None:
+def test_generate_random_date_type_error_start_year() -> None:
     """
     Test case 5: TypeError for invalid start_year type.
     """
@@ -60,7 +60,7 @@ def test_generate_random_date_case_5_type_error_start_year() -> None:
         generate_random_date("2000", 2025)
 
 
-def test_generate_random_date_case_6_type_error_end_year() -> None:
+def test_generate_random_date_type_error_end_year() -> None:
     """
     Test case 6: TypeError for invalid end_year type.
     """
@@ -69,7 +69,7 @@ def test_generate_random_date_case_6_type_error_end_year() -> None:
         generate_random_date(2000, "2025")
 
 
-def test_generate_random_date_case_7_value_error_start_greater_than_end() -> None:
+def test_generate_random_date_value_error_start_greater_than_end() -> None:
     """
     Test case 7: ValueError when start_year > end_year.
     """

--- a/pytest/unit/testing_functions/test_data_generators/test_generate_random_datetime.py
+++ b/pytest/unit/testing_functions/test_data_generators/test_generate_random_datetime.py
@@ -6,7 +6,7 @@ from testing_functions.test_data_generators.generate_random_datetime import (
 )
 
 
-def test_generate_random_datetime_case_1_default_parameters() -> None:
+def test_generate_random_datetime_default_parameters() -> None:
     """
     Test case 1: Generate random datetime with default parameters.
     """
@@ -21,7 +21,7 @@ def test_generate_random_datetime_case_1_default_parameters() -> None:
     assert 0 <= result.second <= 59
 
 
-def test_generate_random_datetime_case_2_custom_year_range() -> None:
+def test_generate_random_datetime_custom_year_range() -> None:
     """
     Test case 2: Generate random datetime with custom year range.
     """
@@ -32,7 +32,7 @@ def test_generate_random_datetime_case_2_custom_year_range() -> None:
     assert 2020 <= result.year <= 2021
 
 
-def test_generate_random_datetime_case_3_same_start_end_year() -> None:
+def test_generate_random_datetime_same_start_end_year() -> None:
     """
     Test case 3: Generate random datetime when start_year equals end_year.
     """
@@ -43,7 +43,7 @@ def test_generate_random_datetime_case_3_same_start_end_year() -> None:
     assert result.year == 2022
 
 
-def test_generate_random_datetime_case_4_has_time_component() -> None:
+def test_generate_random_datetime_has_time_component() -> None:
     """
     Test case 4: Verify datetime has time component (not just date).
     """
@@ -55,7 +55,7 @@ def test_generate_random_datetime_case_4_has_time_component() -> None:
     assert has_time
 
 
-def test_generate_random_datetime_case_5_type_error_start_year() -> None:
+def test_generate_random_datetime_type_error_start_year() -> None:
     """
     Test case 5: TypeError for invalid start_year type.
     """
@@ -64,7 +64,7 @@ def test_generate_random_datetime_case_5_type_error_start_year() -> None:
         generate_random_datetime("2000", 2025)
 
 
-def test_generate_random_datetime_case_6_type_error_end_year() -> None:
+def test_generate_random_datetime_type_error_end_year() -> None:
     """
     Test case 6: TypeError for invalid end_year type.
     """
@@ -73,7 +73,7 @@ def test_generate_random_datetime_case_6_type_error_end_year() -> None:
         generate_random_datetime(2000, "2025")
 
 
-def test_generate_random_datetime_case_7_value_error_start_greater_than_end() -> None:
+def test_generate_random_datetime_value_error_start_greater_than_end() -> None:
     """
     Test case 7: ValueError when start_year > end_year.
     """

--- a/pytest/unit/testing_functions/test_data_generators/test_generate_random_dict.py
+++ b/pytest/unit/testing_functions/test_data_generators/test_generate_random_dict.py
@@ -4,7 +4,7 @@ from testing_functions.test_data_generators.generate_random_dict import (
 )
 
 
-def test_generate_random_dict_case_1_default_parameters() -> None:
+def test_generate_random_dict_default_parameters() -> None:
     """
     Test case 1: Generate random dict with default parameters.
     """
@@ -18,7 +18,7 @@ def test_generate_random_dict_case_1_default_parameters() -> None:
     assert all(isinstance(v, int) for v in result.values())
 
 
-def test_generate_random_dict_case_2_custom_num_keys() -> None:
+def test_generate_random_dict_custom_num_keys() -> None:
     """
     Test case 2: Generate random dict with custom number of keys.
     """
@@ -29,7 +29,7 @@ def test_generate_random_dict_case_2_custom_num_keys() -> None:
     assert len(result) == 3
 
 
-def test_generate_random_dict_case_3_custom_key_prefix() -> None:
+def test_generate_random_dict_custom_key_prefix() -> None:
     """
     Test case 3: Generate random dict with custom key prefix.
     """
@@ -40,7 +40,7 @@ def test_generate_random_dict_case_3_custom_key_prefix() -> None:
     assert all(k.startswith("test_") for k in result.keys())
 
 
-def test_generate_random_dict_case_4_float_values() -> None:
+def test_generate_random_dict_float_values() -> None:
     """
     Test case 4: Generate random dict with float values.
     """
@@ -51,7 +51,7 @@ def test_generate_random_dict_case_4_float_values() -> None:
     assert all(isinstance(v, float) for v in result.values())
 
 
-def test_generate_random_dict_case_5_string_values() -> None:
+def test_generate_random_dict_string_values() -> None:
     """
     Test case 5: Generate random dict with string values.
     """
@@ -62,7 +62,7 @@ def test_generate_random_dict_case_5_string_values() -> None:
     assert all(isinstance(v, str) for v in result.values())
 
 
-def test_generate_random_dict_case_6_empty_dict() -> None:
+def test_generate_random_dict_empty_dict() -> None:
     """
     Test case 6: Generate empty dict.
     """
@@ -73,7 +73,7 @@ def test_generate_random_dict_case_6_empty_dict() -> None:
     assert result == {}
 
 
-def test_generate_random_dict_case_7_type_error_num_keys() -> None:
+def test_generate_random_dict_type_error_num_keys() -> None:
     """
     Test case 7: TypeError for invalid num_keys type.
     """
@@ -82,7 +82,7 @@ def test_generate_random_dict_case_7_type_error_num_keys() -> None:
         generate_random_dict("5")
 
 
-def test_generate_random_dict_case_8_type_error_key_prefix() -> None:
+def test_generate_random_dict_type_error_key_prefix() -> None:
     """
     Test case 8: TypeError for invalid key_prefix type.
     """
@@ -91,7 +91,7 @@ def test_generate_random_dict_case_8_type_error_key_prefix() -> None:
         generate_random_dict(5, 123)
 
 
-def test_generate_random_dict_case_9_type_error_value_type() -> None:
+def test_generate_random_dict_type_error_value_type() -> None:
     """
     Test case 9: TypeError for invalid value_type type.
     """
@@ -100,7 +100,7 @@ def test_generate_random_dict_case_9_type_error_value_type() -> None:
         generate_random_dict(5, "key", 123)
 
 
-def test_generate_random_dict_case_10_value_error_negative_num_keys() -> None:
+def test_generate_random_dict_value_error_negative_num_keys() -> None:
     """
     Test case 10: ValueError for negative num_keys.
     """
@@ -109,7 +109,7 @@ def test_generate_random_dict_case_10_value_error_negative_num_keys() -> None:
         generate_random_dict(-1)
 
 
-def test_generate_random_dict_case_11_value_error_invalid_value_type() -> None:
+def test_generate_random_dict_value_error_invalid_value_type() -> None:
     """
     Test case 11: ValueError for invalid value_type value.
     """

--- a/pytest/unit/testing_functions/test_data_generators/test_generate_random_email.py
+++ b/pytest/unit/testing_functions/test_data_generators/test_generate_random_email.py
@@ -4,7 +4,7 @@ from testing_functions.test_data_generators.generate_random_email import (
 )
 
 
-def test_generate_random_email_case_1_default_parameters() -> None:
+def test_generate_random_email_default_parameters() -> None:
     """
     Test case 1: Generate random email with default parameters.
     """
@@ -17,7 +17,7 @@ def test_generate_random_email_case_1_default_parameters() -> None:
     assert len(result.split('@')[0]) == 10
 
 
-def test_generate_random_email_case_2_custom_domain() -> None:
+def test_generate_random_email_custom_domain() -> None:
     """
     Test case 2: Generate random email with custom domain.
     """
@@ -28,7 +28,7 @@ def test_generate_random_email_case_2_custom_domain() -> None:
     assert '@test.org' in result
 
 
-def test_generate_random_email_case_3_custom_username_length() -> None:
+def test_generate_random_email_custom_username_length() -> None:
     """
     Test case 3: Generate random email with custom username length.
     """
@@ -40,7 +40,7 @@ def test_generate_random_email_case_3_custom_username_length() -> None:
     assert len(username) == 5
 
 
-def test_generate_random_email_case_4_valid_format() -> None:
+def test_generate_random_email_valid_format() -> None:
     """
     Test case 4: Verify email has valid format.
     """
@@ -54,7 +54,7 @@ def test_generate_random_email_case_4_valid_format() -> None:
     assert len(parts[1]) > 0
 
 
-def test_generate_random_email_case_5_type_error_domain() -> None:
+def test_generate_random_email_type_error_domain() -> None:
     """
     Test case 5: TypeError for invalid domain type.
     """
@@ -63,7 +63,7 @@ def test_generate_random_email_case_5_type_error_domain() -> None:
         generate_random_email(123)
 
 
-def test_generate_random_email_case_6_type_error_username_length() -> None:
+def test_generate_random_email_type_error_username_length() -> None:
     """
     Test case 6: TypeError for invalid username_length type.
     """
@@ -72,7 +72,7 @@ def test_generate_random_email_case_6_type_error_username_length() -> None:
         generate_random_email("example.com", "10")
 
 
-def test_generate_random_email_case_7_value_error_empty_domain() -> None:
+def test_generate_random_email_value_error_empty_domain() -> None:
     """
     Test case 7: ValueError for empty domain.
     """
@@ -81,7 +81,7 @@ def test_generate_random_email_case_7_value_error_empty_domain() -> None:
         generate_random_email("")
 
 
-def test_generate_random_email_case_8_value_error_zero_username_length() -> None:
+def test_generate_random_email_value_error_zero_username_length() -> None:
     """
     Test case 8: ValueError for zero username_length.
     """
@@ -90,7 +90,7 @@ def test_generate_random_email_case_8_value_error_zero_username_length() -> None
         generate_random_email("example.com", 0)
 
 
-def test_generate_random_email_case_9_value_error_negative_username_length() -> None:
+def test_generate_random_email_value_error_negative_username_length() -> None:
     """
     Test case 9: ValueError for negative username_length.
     """

--- a/pytest/unit/testing_functions/test_data_generators/test_generate_random_float.py
+++ b/pytest/unit/testing_functions/test_data_generators/test_generate_random_float.py
@@ -4,7 +4,7 @@ from testing_functions.test_data_generators.generate_random_float import (
 )
 
 
-def test_generate_random_float_case_1_default_parameters() -> None:
+def test_generate_random_float_default_parameters() -> None:
     """
     Test case 1: Generate random float with default parameters.
     """
@@ -16,7 +16,7 @@ def test_generate_random_float_case_1_default_parameters() -> None:
     assert 0.0 <= result <= 1.0
 
 
-def test_generate_random_float_case_2_custom_range() -> None:
+def test_generate_random_float_custom_range() -> None:
     """
     Test case 2: Generate random float with custom range.
     """
@@ -27,7 +27,7 @@ def test_generate_random_float_case_2_custom_range() -> None:
     assert 5.0 <= result <= 10.0
 
 
-def test_generate_random_float_case_3_custom_precision() -> None:
+def test_generate_random_float_custom_precision() -> None:
     """
     Test case 3: Generate random float with custom precision.
     """
@@ -41,7 +41,7 @@ def test_generate_random_float_case_3_custom_precision() -> None:
         assert decimal_places <= 4
 
 
-def test_generate_random_float_case_4_zero_precision() -> None:
+def test_generate_random_float_zero_precision() -> None:
     """
     Test case 4: Generate random float with zero precision.
     """
@@ -52,7 +52,7 @@ def test_generate_random_float_case_4_zero_precision() -> None:
     assert result == int(result)
 
 
-def test_generate_random_float_case_5_type_error_min_value() -> None:
+def test_generate_random_float_type_error_min_value() -> None:
     """
     Test case 5: TypeError for invalid min_value type.
     """
@@ -61,7 +61,7 @@ def test_generate_random_float_case_5_type_error_min_value() -> None:
         generate_random_float("0.0", 1.0)
 
 
-def test_generate_random_float_case_6_type_error_max_value() -> None:
+def test_generate_random_float_type_error_max_value() -> None:
     """
     Test case 6: TypeError for invalid max_value type.
     """
@@ -70,7 +70,7 @@ def test_generate_random_float_case_6_type_error_max_value() -> None:
         generate_random_float(0.0, "1.0")
 
 
-def test_generate_random_float_case_7_type_error_precision() -> None:
+def test_generate_random_float_type_error_precision() -> None:
     """
     Test case 7: TypeError for invalid precision type.
     """
@@ -79,7 +79,7 @@ def test_generate_random_float_case_7_type_error_precision() -> None:
         generate_random_float(0.0, 1.0, "2")
 
 
-def test_generate_random_float_case_8_value_error_min_greater_than_max() -> None:
+def test_generate_random_float_value_error_min_greater_than_max() -> None:
     """
     Test case 8: ValueError when min_value > max_value.
     """
@@ -88,7 +88,7 @@ def test_generate_random_float_case_8_value_error_min_greater_than_max() -> None
         generate_random_float(10.0, 5.0)
 
 
-def test_generate_random_float_case_9_value_error_negative_precision() -> None:
+def test_generate_random_float_value_error_negative_precision() -> None:
     """
     Test case 9: ValueError for negative precision.
     """

--- a/pytest/unit/testing_functions/test_data_generators/test_generate_random_int.py
+++ b/pytest/unit/testing_functions/test_data_generators/test_generate_random_int.py
@@ -4,7 +4,7 @@ from testing_functions.test_data_generators.generate_random_int import (
 )
 
 
-def test_generate_random_int_case_1_default_parameters() -> None:
+def test_generate_random_int_default_parameters() -> None:
     """
     Test case 1: Generate random int with default parameters.
     """
@@ -16,7 +16,7 @@ def test_generate_random_int_case_1_default_parameters() -> None:
     assert 0 <= result <= 100
 
 
-def test_generate_random_int_case_2_custom_range() -> None:
+def test_generate_random_int_custom_range() -> None:
     """
     Test case 2: Generate random int with custom range.
     """
@@ -27,7 +27,7 @@ def test_generate_random_int_case_2_custom_range() -> None:
     assert 10 <= result <= 20
 
 
-def test_generate_random_int_case_3_same_min_max() -> None:
+def test_generate_random_int_same_min_max() -> None:
     """
     Test case 3: Generate random int when min equals max.
     """
@@ -38,7 +38,7 @@ def test_generate_random_int_case_3_same_min_max() -> None:
     assert result == 5
 
 
-def test_generate_random_int_case_4_negative_range() -> None:
+def test_generate_random_int_negative_range() -> None:
     """
     Test case 4: Generate random int with negative range.
     """
@@ -49,7 +49,7 @@ def test_generate_random_int_case_4_negative_range() -> None:
     assert -10 <= result <= -5
 
 
-def test_generate_random_int_case_5_type_error_min_value() -> None:
+def test_generate_random_int_type_error_min_value() -> None:
     """
     Test case 5: TypeError for invalid min_value type.
     """
@@ -58,7 +58,7 @@ def test_generate_random_int_case_5_type_error_min_value() -> None:
         generate_random_int("0", 10)
 
 
-def test_generate_random_int_case_6_type_error_max_value() -> None:
+def test_generate_random_int_type_error_max_value() -> None:
     """
     Test case 6: TypeError for invalid max_value type.
     """
@@ -67,7 +67,7 @@ def test_generate_random_int_case_6_type_error_max_value() -> None:
         generate_random_int(0, "10")
 
 
-def test_generate_random_int_case_7_value_error_min_greater_than_max() -> None:
+def test_generate_random_int_value_error_min_greater_than_max() -> None:
     """
     Test case 7: ValueError when min_value > max_value.
     """

--- a/pytest/unit/testing_functions/test_data_generators/test_generate_random_list.py
+++ b/pytest/unit/testing_functions/test_data_generators/test_generate_random_list.py
@@ -4,7 +4,7 @@ from testing_functions.test_data_generators.generate_random_list import (
 )
 
 
-def test_generate_random_list_case_1_default_parameters() -> None:
+def test_generate_random_list_default_parameters() -> None:
     """
     Test case 1: Generate random list with default parameters.
     """
@@ -17,7 +17,7 @@ def test_generate_random_list_case_1_default_parameters() -> None:
     assert all(isinstance(x, int) for x in result)
 
 
-def test_generate_random_list_case_2_custom_length() -> None:
+def test_generate_random_list_custom_length() -> None:
     """
     Test case 2: Generate random list with custom length.
     """
@@ -28,7 +28,7 @@ def test_generate_random_list_case_2_custom_length() -> None:
     assert len(result) == 5
 
 
-def test_generate_random_list_case_3_float_type() -> None:
+def test_generate_random_list_float_type() -> None:
     """
     Test case 3: Generate random list of floats.
     """
@@ -39,7 +39,7 @@ def test_generate_random_list_case_3_float_type() -> None:
     assert all(isinstance(x, float) for x in result)
 
 
-def test_generate_random_list_case_4_string_type() -> None:
+def test_generate_random_list_string_type() -> None:
     """
     Test case 4: Generate random list of strings.
     """
@@ -50,7 +50,7 @@ def test_generate_random_list_case_4_string_type() -> None:
     assert all(isinstance(x, str) for x in result)
 
 
-def test_generate_random_list_case_5_custom_range() -> None:
+def test_generate_random_list_custom_range() -> None:
     """
     Test case 5: Generate random list with custom value range.
     """
@@ -61,7 +61,7 @@ def test_generate_random_list_case_5_custom_range() -> None:
     assert all(1 <= x <= 10 for x in result)
 
 
-def test_generate_random_list_case_6_empty_list() -> None:
+def test_generate_random_list_empty_list() -> None:
     """
     Test case 6: Generate empty list.
     """
@@ -72,7 +72,7 @@ def test_generate_random_list_case_6_empty_list() -> None:
     assert result == []
 
 
-def test_generate_random_list_case_7_type_error_length() -> None:
+def test_generate_random_list_type_error_length() -> None:
     """
     Test case 7: TypeError for invalid length type.
     """
@@ -81,7 +81,7 @@ def test_generate_random_list_case_7_type_error_length() -> None:
         generate_random_list("10")
 
 
-def test_generate_random_list_case_8_type_error_element_type() -> None:
+def test_generate_random_list_type_error_element_type() -> None:
     """
     Test case 8: TypeError for invalid element_type.
     """
@@ -90,7 +90,7 @@ def test_generate_random_list_case_8_type_error_element_type() -> None:
         generate_random_list(10, 123)
 
 
-def test_generate_random_list_case_9_value_error_negative_length() -> None:
+def test_generate_random_list_value_error_negative_length() -> None:
     """
     Test case 9: ValueError for negative length.
     """
@@ -99,7 +99,7 @@ def test_generate_random_list_case_9_value_error_negative_length() -> None:
         generate_random_list(-1)
 
 
-def test_generate_random_list_case_10_value_error_invalid_element_type() -> None:
+def test_generate_random_list_value_error_invalid_element_type() -> None:
     """
     Test case 10: ValueError for invalid element_type value.
     """

--- a/pytest/unit/testing_functions/test_data_generators/test_generate_random_string.py
+++ b/pytest/unit/testing_functions/test_data_generators/test_generate_random_string.py
@@ -6,7 +6,7 @@ from testing_functions.test_data_generators.generate_random_string import (
 )
 
 
-def test_generate_random_string_case_1_default_parameters() -> None:
+def test_generate_random_string_default_parameters() -> None:
     """
     Test case 1: Generate random string with default parameters.
     """
@@ -19,7 +19,7 @@ def test_generate_random_string_case_1_default_parameters() -> None:
     assert all(c in string.ascii_letters + string.digits for c in result)
 
 
-def test_generate_random_string_case_2_custom_length() -> None:
+def test_generate_random_string_custom_length() -> None:
     """
     Test case 2: Generate random string with custom length.
     """
@@ -33,7 +33,7 @@ def test_generate_random_string_case_2_custom_length() -> None:
     assert len(result) == 20
 
 
-def test_generate_random_string_case_3_custom_charset() -> None:
+def test_generate_random_string_custom_charset() -> None:
     """
     Test case 3: Generate random string with custom character set.
     """
@@ -47,7 +47,7 @@ def test_generate_random_string_case_3_custom_charset() -> None:
     assert all(c in charset for c in result)
 
 
-def test_generate_random_string_case_4_single_character() -> None:
+def test_generate_random_string_single_character() -> None:
     """
     Test case 4: Generate random string with length 1.
     """
@@ -58,7 +58,7 @@ def test_generate_random_string_case_4_single_character() -> None:
     assert len(result) == 1
 
 
-def test_generate_random_string_case_5_type_error_length() -> None:
+def test_generate_random_string_type_error_length() -> None:
     """
     Test case 5: TypeError for invalid length type.
     """
@@ -67,7 +67,7 @@ def test_generate_random_string_case_5_type_error_length() -> None:
         generate_random_string("10")
 
 
-def test_generate_random_string_case_6_type_error_charset() -> None:
+def test_generate_random_string_type_error_charset() -> None:
     """
     Test case 6: TypeError for invalid charset type.
     """
@@ -76,7 +76,7 @@ def test_generate_random_string_case_6_type_error_charset() -> None:
         generate_random_string(10, 123)
 
 
-def test_generate_random_string_case_7_value_error_negative_length() -> None:
+def test_generate_random_string_value_error_negative_length() -> None:
     """
     Test case 7: ValueError for negative length.
     """
@@ -85,7 +85,7 @@ def test_generate_random_string_case_7_value_error_negative_length() -> None:
         generate_random_string(-1)
 
 
-def test_generate_random_string_case_8_value_error_zero_length() -> None:
+def test_generate_random_string_value_error_zero_length() -> None:
     """
     Test case 8: ValueError for zero length.
     """
@@ -94,7 +94,7 @@ def test_generate_random_string_case_8_value_error_zero_length() -> None:
         generate_random_string(0)
 
 
-def test_generate_random_string_case_9_value_error_empty_charset() -> None:
+def test_generate_random_string_value_error_empty_charset() -> None:
     """
     Test case 9: ValueError for empty charset.
     """

--- a/pytest/unit/testing_functions/test_data_generators/test_generate_random_url.py
+++ b/pytest/unit/testing_functions/test_data_generators/test_generate_random_url.py
@@ -4,7 +4,7 @@ from testing_functions.test_data_generators.generate_random_url import (
 )
 
 
-def test_generate_random_url_case_1_default_parameters() -> None:
+def test_generate_random_url_default_parameters() -> None:
     """
     Test case 1: Generate random URL with default parameters.
     """
@@ -17,7 +17,7 @@ def test_generate_random_url_case_1_default_parameters() -> None:
     assert result.count('/') >= 3
 
 
-def test_generate_random_url_case_2_custom_protocol() -> None:
+def test_generate_random_url_custom_protocol() -> None:
     """
     Test case 2: Generate random URL with custom protocol.
     """
@@ -28,7 +28,7 @@ def test_generate_random_url_case_2_custom_protocol() -> None:
     assert result.startswith('http://')
 
 
-def test_generate_random_url_case_3_custom_domain() -> None:
+def test_generate_random_url_custom_domain() -> None:
     """
     Test case 3: Generate random URL with custom domain.
     """
@@ -39,7 +39,7 @@ def test_generate_random_url_case_3_custom_domain() -> None:
     assert 'test.org' in result
 
 
-def test_generate_random_url_case_4_zero_path_length() -> None:
+def test_generate_random_url_zero_path_length() -> None:
     """
     Test case 4: Generate random URL with zero path segments.
     """
@@ -50,7 +50,7 @@ def test_generate_random_url_case_4_zero_path_length() -> None:
     assert result == "https://example.com"
 
 
-def test_generate_random_url_case_5_custom_path_length() -> None:
+def test_generate_random_url_custom_path_length() -> None:
     """
     Test case 5: Generate random URL with custom path length.
     """
@@ -62,7 +62,7 @@ def test_generate_random_url_case_5_custom_path_length() -> None:
     assert path.count('/') == 4  # 5 segments means 4 slashes
 
 
-def test_generate_random_url_case_6_type_error_protocol() -> None:
+def test_generate_random_url_type_error_protocol() -> None:
     """
     Test case 6: TypeError for invalid protocol type.
     """
@@ -71,7 +71,7 @@ def test_generate_random_url_case_6_type_error_protocol() -> None:
         generate_random_url(123)
 
 
-def test_generate_random_url_case_7_type_error_domain() -> None:
+def test_generate_random_url_type_error_domain() -> None:
     """
     Test case 7: TypeError for invalid domain type.
     """
@@ -80,7 +80,7 @@ def test_generate_random_url_case_7_type_error_domain() -> None:
         generate_random_url("https", 123)
 
 
-def test_generate_random_url_case_8_type_error_path_length() -> None:
+def test_generate_random_url_type_error_path_length() -> None:
     """
     Test case 8: TypeError for invalid path_length type.
     """
@@ -89,7 +89,7 @@ def test_generate_random_url_case_8_type_error_path_length() -> None:
         generate_random_url("https", "example.com", "3")
 
 
-def test_generate_random_url_case_9_value_error_empty_protocol() -> None:
+def test_generate_random_url_value_error_empty_protocol() -> None:
     """
     Test case 9: ValueError for empty protocol.
     """
@@ -98,7 +98,7 @@ def test_generate_random_url_case_9_value_error_empty_protocol() -> None:
         generate_random_url("")
 
 
-def test_generate_random_url_case_10_value_error_empty_domain() -> None:
+def test_generate_random_url_value_error_empty_domain() -> None:
     """
     Test case 10: ValueError for empty domain.
     """
@@ -107,7 +107,7 @@ def test_generate_random_url_case_10_value_error_empty_domain() -> None:
         generate_random_url("https", "")
 
 
-def test_generate_random_url_case_11_value_error_negative_path_length() -> None:
+def test_generate_random_url_value_error_negative_path_length() -> None:
     """
     Test case 11: ValueError for negative path_length.
     """

--- a/pytest/unit/web_scraping_functions/html_parsing/test_extract_links.py
+++ b/pytest/unit/web_scraping_functions/html_parsing/test_extract_links.py
@@ -3,7 +3,7 @@ from bs4 import BeautifulSoup
 from web_scraping_functions.html_parsing.extract_links import extract_links
 
 
-def test_extract_links_case_1_simple_links() -> None:
+def test_extract_links_simple_links() -> None:
     """
     Test case 1: Extract simple links.
     """
@@ -18,7 +18,7 @@ def test_extract_links_case_1_simple_links() -> None:
     assert result == ['/page1', '/page2']
 
 
-def test_extract_links_case_2_absolute_urls() -> None:
+def test_extract_links_absolute_urls() -> None:
     """
     Test case 2: Convert to absolute URLs.
     """
@@ -33,7 +33,7 @@ def test_extract_links_case_2_absolute_urls() -> None:
     assert result == ['https://example.com/page1', 'https://example.com/page2']
 
 
-def test_extract_links_case_3_mixed_urls() -> None:
+def test_extract_links_mixed_urls() -> None:
     """
     Test case 3: Extract mixed relative and absolute URLs.
     """
@@ -48,7 +48,7 @@ def test_extract_links_case_3_mixed_urls() -> None:
     assert result == ['https://example.com/local', 'https://other.com']
 
 
-def test_extract_links_case_4_relative_paths() -> None:
+def test_extract_links_relative_paths() -> None:
     """
     Test case 4: Extract relative paths without leading slash.
     """
@@ -63,7 +63,7 @@ def test_extract_links_case_4_relative_paths() -> None:
     assert result == ['https://example.com/page1', 'https://example.com/page2']
 
 
-def test_extract_links_case_5_no_links() -> None:
+def test_extract_links_no_links() -> None:
     """
     Test case 5: Extract from HTML with no links.
     """
@@ -78,7 +78,7 @@ def test_extract_links_case_5_no_links() -> None:
     assert result == []
 
 
-def test_extract_links_case_6_type_error_element() -> None:
+def test_extract_links_type_error_element() -> None:
     """
     Test case 6: TypeError for invalid element type.
     """
@@ -87,7 +87,7 @@ def test_extract_links_case_6_type_error_element() -> None:
         extract_links("not a soup")
 
 
-def test_extract_links_case_7_type_error_absolute() -> None:
+def test_extract_links_type_error_absolute() -> None:
     """
     Test case 7: TypeError for invalid absolute type.
     """
@@ -100,7 +100,7 @@ def test_extract_links_case_7_type_error_absolute() -> None:
         extract_links(soup, absolute="yes")
 
 
-def test_extract_links_case_8_type_error_base_url() -> None:
+def test_extract_links_type_error_base_url() -> None:
     """
     Test case 8: TypeError for invalid base_url type.
     """
@@ -113,7 +113,7 @@ def test_extract_links_case_8_type_error_base_url() -> None:
         extract_links(soup, base_url=123)
 
 
-def test_extract_links_case_9_value_error_missing_base_url() -> None:
+def test_extract_links_value_error_missing_base_url() -> None:
     """
     Test case 9: ValueError when absolute is True but base_url is None.
     """

--- a/pytest/unit/web_scraping_functions/html_parsing/test_extract_tables.py
+++ b/pytest/unit/web_scraping_functions/html_parsing/test_extract_tables.py
@@ -3,7 +3,7 @@ from bs4 import BeautifulSoup
 from web_scraping_functions.html_parsing.extract_tables import extract_tables
 
 
-def test_extract_tables_case_1_simple_table() -> None:
+def test_extract_tables_simple_table() -> None:
     """
     Test case 1: Extract simple table.
     """
@@ -22,7 +22,7 @@ def test_extract_tables_case_1_simple_table() -> None:
     assert result[0] == [['Name', 'Age'], ['Alice', '30']]
 
 
-def test_extract_tables_case_2_multiple_tables() -> None:
+def test_extract_tables_multiple_tables() -> None:
     """
     Test case 2: Extract multiple tables.
     """
@@ -42,7 +42,7 @@ def test_extract_tables_case_2_multiple_tables() -> None:
     assert result[1] == [['B']]
 
 
-def test_extract_tables_case_3_mixed_th_td() -> None:
+def test_extract_tables_mixed_th_td() -> None:
     """
     Test case 3: Extract table with mixed th and td.
     """
@@ -61,7 +61,7 @@ def test_extract_tables_case_3_mixed_th_td() -> None:
     assert result[0][1] == ['Data1', 'Data2']
 
 
-def test_extract_tables_case_4_empty_cells() -> None:
+def test_extract_tables_empty_cells() -> None:
     """
     Test case 4: Extract table with empty cells.
     """
@@ -80,7 +80,7 @@ def test_extract_tables_case_4_empty_cells() -> None:
     assert result[0][1] == ['', 'B']
 
 
-def test_extract_tables_case_5_no_tables() -> None:
+def test_extract_tables_no_tables() -> None:
     """
     Test case 5: Extract from HTML with no tables.
     """
@@ -95,7 +95,7 @@ def test_extract_tables_case_5_no_tables() -> None:
     assert result == []
 
 
-def test_extract_tables_case_6_whitespace_handling() -> None:
+def test_extract_tables_whitespace_handling() -> None:
     """
     Test case 6: Verify whitespace is stripped from cells.
     """
@@ -112,7 +112,7 @@ def test_extract_tables_case_6_whitespace_handling() -> None:
     assert result[0][0] == ['Padded', 'Text']
 
 
-def test_extract_tables_case_7_type_error_element() -> None:
+def test_extract_tables_type_error_element() -> None:
     """
     Test case 7: TypeError for invalid element type.
     """
@@ -121,7 +121,7 @@ def test_extract_tables_case_7_type_error_element() -> None:
         extract_tables("not a soup")
 
 
-def test_extract_tables_case_8_type_error_header_row() -> None:
+def test_extract_tables_type_error_header_row() -> None:
     """
     Test case 8: TypeError for invalid header_row type.
     """

--- a/pytest/unit/web_scraping_functions/html_parsing/test_extract_text.py
+++ b/pytest/unit/web_scraping_functions/html_parsing/test_extract_text.py
@@ -3,7 +3,7 @@ from bs4 import BeautifulSoup
 from web_scraping_functions.html_parsing.extract_text import extract_text
 
 
-def test_extract_text_case_1_simple_text() -> None:
+def test_extract_text_simple_text() -> None:
     """
     Test case 1: Extract text from simple element.
     """
@@ -18,7 +18,7 @@ def test_extract_text_case_1_simple_text() -> None:
     assert result == "Hello World"
 
 
-def test_extract_text_case_2_nested_elements() -> None:
+def test_extract_text_nested_elements() -> None:
     """
     Test case 2: Extract text from nested elements.
     """
@@ -33,7 +33,7 @@ def test_extract_text_case_2_nested_elements() -> None:
     assert result == "Hello Beautiful World"
 
 
-def test_extract_text_case_3_with_whitespace() -> None:
+def test_extract_text_with_whitespace() -> None:
     """
     Test case 3: Extract text with whitespace handling.
     """
@@ -48,7 +48,7 @@ def test_extract_text_case_3_with_whitespace() -> None:
     assert result == "Hello World"
 
 
-def test_extract_text_case_4_no_strip() -> None:
+def test_extract_text_no_strip() -> None:
     """
     Test case 4: Extract text without stripping.
     """
@@ -63,7 +63,7 @@ def test_extract_text_case_4_no_strip() -> None:
     assert "  Hello  " in result
 
 
-def test_extract_text_case_5_custom_separator() -> None:
+def test_extract_text_custom_separator() -> None:
     """
     Test case 5: Extract text with custom separator.
     """
@@ -78,7 +78,7 @@ def test_extract_text_case_5_custom_separator() -> None:
     assert "Hello" in result and "World" in result
 
 
-def test_extract_text_case_6_type_error_element() -> None:
+def test_extract_text_type_error_element() -> None:
     """
     Test case 6: TypeError for invalid element type.
     """
@@ -87,7 +87,7 @@ def test_extract_text_case_6_type_error_element() -> None:
         extract_text("not a soup object")
 
 
-def test_extract_text_case_7_type_error_strip() -> None:
+def test_extract_text_type_error_strip() -> None:
     """
     Test case 7: TypeError for invalid strip type.
     """
@@ -100,7 +100,7 @@ def test_extract_text_case_7_type_error_strip() -> None:
         extract_text(soup, strip="yes")
 
 
-def test_extract_text_case_8_type_error_separator() -> None:
+def test_extract_text_type_error_separator() -> None:
     """
     Test case 8: TypeError for invalid separator type.
     """

--- a/pytest/unit/web_scraping_functions/html_parsing/test_find_elements_by_class.py
+++ b/pytest/unit/web_scraping_functions/html_parsing/test_find_elements_by_class.py
@@ -5,7 +5,7 @@ from web_scraping_functions.html_parsing.find_elements_by_class import (
 )
 
 
-def test_find_elements_by_class_case_1_single_class() -> None:
+def test_find_elements_by_class_single_class() -> None:
     """
     Test case 1: Find elements by single class.
     """
@@ -22,7 +22,7 @@ def test_find_elements_by_class_case_1_single_class() -> None:
     assert result[1].text == "B"
 
 
-def test_find_elements_by_class_case_2_with_limit() -> None:
+def test_find_elements_by_class_with_limit() -> None:
     """
     Test case 2: Find elements with limit.
     """
@@ -37,7 +37,7 @@ def test_find_elements_by_class_case_2_with_limit() -> None:
     assert len(result) == 2
 
 
-def test_find_elements_by_class_case_3_no_matches() -> None:
+def test_find_elements_by_class_no_matches() -> None:
     """
     Test case 3: Find elements with no matches.
     """
@@ -52,7 +52,7 @@ def test_find_elements_by_class_case_3_no_matches() -> None:
     assert result == []
 
 
-def test_find_elements_by_class_case_4_nested_elements() -> None:
+def test_find_elements_by_class_nested_elements() -> None:
     """
     Test case 4: Find nested elements by class.
     """
@@ -68,7 +68,7 @@ def test_find_elements_by_class_case_4_nested_elements() -> None:
     assert result[0].text == "Content"
 
 
-def test_find_elements_by_class_case_5_multiple_classes() -> None:
+def test_find_elements_by_class_multiple_classes() -> None:
     """
     Test case 5: Find elements with multiple classes on same element.
     """
@@ -83,7 +83,7 @@ def test_find_elements_by_class_case_5_multiple_classes() -> None:
     assert len(result) == 2
 
 
-def test_find_elements_by_class_case_6_type_error_element() -> None:
+def test_find_elements_by_class_type_error_element() -> None:
     """
     Test case 6: TypeError for invalid element type.
     """
@@ -92,7 +92,7 @@ def test_find_elements_by_class_case_6_type_error_element() -> None:
         find_elements_by_class("not a soup", "item")
 
 
-def test_find_elements_by_class_case_7_type_error_class_name() -> None:
+def test_find_elements_by_class_type_error_class_name() -> None:
     """
     Test case 7: TypeError for invalid class_name type.
     """
@@ -105,7 +105,7 @@ def test_find_elements_by_class_case_7_type_error_class_name() -> None:
         find_elements_by_class(soup, 123)
 
 
-def test_find_elements_by_class_case_8_type_error_limit() -> None:
+def test_find_elements_by_class_type_error_limit() -> None:
     """
     Test case 8: TypeError for invalid limit type.
     """
@@ -118,7 +118,7 @@ def test_find_elements_by_class_case_8_type_error_limit() -> None:
         find_elements_by_class(soup, "item", limit="5")
 
 
-def test_find_elements_by_class_case_9_value_error_empty_class_name() -> None:
+def test_find_elements_by_class_value_error_empty_class_name() -> None:
     """
     Test case 9: ValueError for empty class_name.
     """
@@ -131,7 +131,7 @@ def test_find_elements_by_class_case_9_value_error_empty_class_name() -> None:
         find_elements_by_class(soup, "")
 
 
-def test_find_elements_by_class_case_10_value_error_negative_limit() -> None:
+def test_find_elements_by_class_value_error_negative_limit() -> None:
     """
     Test case 10: ValueError for non-positive limit.
     """

--- a/pytest/unit/web_scraping_functions/html_parsing/test_find_elements_by_id.py
+++ b/pytest/unit/web_scraping_functions/html_parsing/test_find_elements_by_id.py
@@ -5,7 +5,7 @@ from web_scraping_functions.html_parsing.find_elements_by_id import (
 )
 
 
-def test_find_elements_by_id_case_1_simple_id() -> None:
+def test_find_elements_by_id_simple_id() -> None:
     """
     Test case 1: Find element by ID.
     """
@@ -21,7 +21,7 @@ def test_find_elements_by_id_case_1_simple_id() -> None:
     assert result.text == "Content"
 
 
-def test_find_elements_by_id_case_2_no_match() -> None:
+def test_find_elements_by_id_no_match() -> None:
     """
     Test case 2: Return None when ID not found.
     """
@@ -36,7 +36,7 @@ def test_find_elements_by_id_case_2_no_match() -> None:
     assert result is None
 
 
-def test_find_elements_by_id_case_3_nested_element() -> None:
+def test_find_elements_by_id_nested_element() -> None:
     """
     Test case 3: Find nested element by ID.
     """
@@ -52,7 +52,7 @@ def test_find_elements_by_id_case_3_nested_element() -> None:
     assert result.text == "Text"
 
 
-def test_find_elements_by_id_case_4_first_match() -> None:
+def test_find_elements_by_id_first_match() -> None:
     """
     Test case 4: Return first element when duplicate IDs exist (invalid HTML).
     """
@@ -68,7 +68,7 @@ def test_find_elements_by_id_case_4_first_match() -> None:
     assert result.text == "First"
 
 
-def test_find_elements_by_id_case_5_type_error_element() -> None:
+def test_find_elements_by_id_type_error_element() -> None:
     """
     Test case 5: TypeError for invalid element type.
     """
@@ -77,7 +77,7 @@ def test_find_elements_by_id_case_5_type_error_element() -> None:
         find_elements_by_id("not a soup", "main")
 
 
-def test_find_elements_by_id_case_6_type_error_element_id() -> None:
+def test_find_elements_by_id_type_error_element_id() -> None:
     """
     Test case 6: TypeError for invalid element_id type.
     """
@@ -90,7 +90,7 @@ def test_find_elements_by_id_case_6_type_error_element_id() -> None:
         find_elements_by_id(soup, 123)
 
 
-def test_find_elements_by_id_case_7_value_error_empty_id() -> None:
+def test_find_elements_by_id_value_error_empty_id() -> None:
     """
     Test case 7: ValueError for empty element_id.
     """
@@ -103,7 +103,7 @@ def test_find_elements_by_id_case_7_value_error_empty_id() -> None:
         find_elements_by_id(soup, "")
 
 
-def test_find_elements_by_id_case_8_value_error_whitespace_id() -> None:
+def test_find_elements_by_id_value_error_whitespace_id() -> None:
     """
     Test case 8: ValueError for whitespace-only element_id.
     """

--- a/pytest/unit/web_scraping_functions/html_parsing/test_parse_html.py
+++ b/pytest/unit/web_scraping_functions/html_parsing/test_parse_html.py
@@ -3,7 +3,7 @@ from bs4 import BeautifulSoup
 from web_scraping_functions.html_parsing.parse_html import parse_html
 
 
-def test_parse_html_case_1_simple_html() -> None:
+def test_parse_html_simple_html() -> None:
     """
     Test case 1: Parse simple HTML content.
     """
@@ -18,7 +18,7 @@ def test_parse_html_case_1_simple_html() -> None:
     assert result.find('p').text == "Hello World"
 
 
-def test_parse_html_case_2_with_lxml_parser() -> None:
+def test_parse_html_with_lxml_parser() -> None:
     """
     Test case 2: Parse HTML with lxml parser.
     """
@@ -33,7 +33,7 @@ def test_parse_html_case_2_with_lxml_parser() -> None:
     assert result.find('div').text == "Content"
 
 
-def test_parse_html_case_3_complex_structure() -> None:
+def test_parse_html_complex_structure() -> None:
     """
     Test case 3: Parse HTML with complex structure.
     """
@@ -48,7 +48,7 @@ def test_parse_html_case_3_complex_structure() -> None:
     assert result.find('div', class_='main') is not None
 
 
-def test_parse_html_case_4_default_parser() -> None:
+def test_parse_html_default_parser() -> None:
     """
     Test case 4: Verify default parser is html.parser.
     """
@@ -62,7 +62,7 @@ def test_parse_html_case_4_default_parser() -> None:
     assert result.name == '[document]'
 
 
-def test_parse_html_case_5_type_error_html() -> None:
+def test_parse_html_type_error_html() -> None:
     """
     Test case 5: TypeError for invalid html type.
     """
@@ -71,7 +71,7 @@ def test_parse_html_case_5_type_error_html() -> None:
         parse_html(123)
 
 
-def test_parse_html_case_6_type_error_parser() -> None:
+def test_parse_html_type_error_parser() -> None:
     """
     Test case 6: TypeError for invalid parser type.
     """
@@ -83,7 +83,7 @@ def test_parse_html_case_6_type_error_parser() -> None:
         parse_html(html, parser=123)
 
 
-def test_parse_html_case_7_value_error_empty_html() -> None:
+def test_parse_html_value_error_empty_html() -> None:
     """
     Test case 7: ValueError for empty HTML.
     """
@@ -92,7 +92,7 @@ def test_parse_html_case_7_value_error_empty_html() -> None:
         parse_html("")
 
 
-def test_parse_html_case_8_value_error_whitespace_only() -> None:
+def test_parse_html_value_error_whitespace_only() -> None:
     """
     Test case 8: ValueError for whitespace-only HTML.
     """
@@ -101,7 +101,7 @@ def test_parse_html_case_8_value_error_whitespace_only() -> None:
         parse_html("   \n  \t  ")
 
 
-def test_parse_html_case_9_value_error_invalid_parser() -> None:
+def test_parse_html_value_error_invalid_parser() -> None:
     """
     Test case 9: ValueError for invalid parser name.
     """

--- a/pytest/unit/web_scraping_functions/pagination/test_extract_next_page.py
+++ b/pytest/unit/web_scraping_functions/pagination/test_extract_next_page.py
@@ -3,7 +3,7 @@ from bs4 import BeautifulSoup
 from web_scraping_functions.pagination.extract_next_page import extract_next_page
 
 
-def test_extract_next_page_case_1_simple_next_link() -> None:
+def test_extract_next_page_simple_next_link() -> None:
     """
     Test case 1: Extract next page link.
     """
@@ -18,7 +18,7 @@ def test_extract_next_page_case_1_simple_next_link() -> None:
     assert result == "/page2"
 
 
-def test_extract_next_page_case_2_relative_url() -> None:
+def test_extract_next_page_relative_url() -> None:
     """
     Test case 2: Extract relative URL.
     """
@@ -33,7 +33,7 @@ def test_extract_next_page_case_2_relative_url() -> None:
     assert result == "/page2"
 
 
-def test_extract_next_page_case_3_no_match() -> None:
+def test_extract_next_page_no_match() -> None:
     """
     Test case 3: Return None when no match found.
     """
@@ -48,7 +48,7 @@ def test_extract_next_page_case_3_no_match() -> None:
     assert result is None
 
 
-def test_extract_next_page_case_4_no_href() -> None:
+def test_extract_next_page_no_href() -> None:
     """
     Test case 4: Return None when element has no href.
     """
@@ -63,7 +63,7 @@ def test_extract_next_page_case_4_no_href() -> None:
     assert result is None
 
 
-def test_extract_next_page_case_5_attribute_selector() -> None:
+def test_extract_next_page_attribute_selector() -> None:
     """
     Test case 5: Extract using attribute selector.
     """
@@ -78,7 +78,7 @@ def test_extract_next_page_case_5_attribute_selector() -> None:
     assert result == "/page2"
 
 
-def test_extract_next_page_case_6_type_error_element() -> None:
+def test_extract_next_page_type_error_element() -> None:
     """
     Test case 6: TypeError for invalid element type.
     """
@@ -87,7 +87,7 @@ def test_extract_next_page_case_6_type_error_element() -> None:
         extract_next_page("not a soup", selector=".next")
 
 
-def test_extract_next_page_case_7_type_error_selector() -> None:
+def test_extract_next_page_type_error_selector() -> None:
     """
     Test case 7: TypeError for invalid selector type.
     """
@@ -100,7 +100,7 @@ def test_extract_next_page_case_7_type_error_selector() -> None:
         extract_next_page(soup, selector=123)
 
 
-def test_extract_next_page_case_8_value_error_empty_selector() -> None:
+def test_extract_next_page_value_error_empty_selector() -> None:
     """
     Test case 8: ValueError for empty selector.
     """

--- a/pytest/unit/web_scraping_functions/pagination/test_paginate_links.py
+++ b/pytest/unit/web_scraping_functions/pagination/test_paginate_links.py
@@ -2,7 +2,7 @@ import pytest
 from web_scraping_functions.pagination.paginate_links import paginate_links
 
 
-def test_paginate_links_case_1_simple_pagination() -> None:
+def test_paginate_links_simple_pagination() -> None:
     """
     Test case 1: Generate simple pagination URLs.
     """
@@ -20,7 +20,7 @@ def test_paginate_links_case_1_simple_pagination() -> None:
     ]
 
 
-def test_paginate_links_case_2_custom_param() -> None:
+def test_paginate_links_custom_param() -> None:
     """
     Test case 2: Generate pagination with custom parameter name.
     """
@@ -37,7 +37,7 @@ def test_paginate_links_case_2_custom_param() -> None:
     ]
 
 
-def test_paginate_links_case_3_existing_query_params() -> None:
+def test_paginate_links_existing_query_params() -> None:
     """
     Test case 3: Add pagination to URL with existing query parameters.
     """
@@ -54,7 +54,7 @@ def test_paginate_links_case_3_existing_query_params() -> None:
     ]
 
 
-def test_paginate_links_case_4_single_page() -> None:
+def test_paginate_links_single_page() -> None:
     """
     Test case 4: Generate single page URL.
     """
@@ -68,7 +68,7 @@ def test_paginate_links_case_4_single_page() -> None:
     assert result == ["https://example.com/page?page=5"]
 
 
-def test_paginate_links_case_5_start_page_one() -> None:
+def test_paginate_links_start_page_one() -> None:
     """
     Test case 5: Generate pagination starting from 1.
     """
@@ -83,7 +83,7 @@ def test_paginate_links_case_5_start_page_one() -> None:
     assert "page=1" in result[0]
 
 
-def test_paginate_links_case_6_type_error_base_url() -> None:
+def test_paginate_links_type_error_base_url() -> None:
     """
     Test case 6: TypeError for invalid base_url type.
     """
@@ -92,7 +92,7 @@ def test_paginate_links_case_6_type_error_base_url() -> None:
         paginate_links(123, start_page=1, end_page=3)
 
 
-def test_paginate_links_case_7_type_error_start_page() -> None:
+def test_paginate_links_type_error_start_page() -> None:
     """
     Test case 7: TypeError for invalid start_page type.
     """
@@ -101,7 +101,7 @@ def test_paginate_links_case_7_type_error_start_page() -> None:
         paginate_links("https://example.com", start_page="1", end_page=3)
 
 
-def test_paginate_links_case_8_type_error_end_page() -> None:
+def test_paginate_links_type_error_end_page() -> None:
     """
     Test case 8: TypeError for invalid end_page type.
     """
@@ -110,7 +110,7 @@ def test_paginate_links_case_8_type_error_end_page() -> None:
         paginate_links("https://example.com", start_page=1, end_page="3")
 
 
-def test_paginate_links_case_9_type_error_page_param() -> None:
+def test_paginate_links_type_error_page_param() -> None:
     """
     Test case 9: TypeError for invalid page_param type.
     """
@@ -119,7 +119,7 @@ def test_paginate_links_case_9_type_error_page_param() -> None:
         paginate_links("https://example.com", start_page=1, end_page=3, page_param=123)
 
 
-def test_paginate_links_case_10_value_error_empty_url() -> None:
+def test_paginate_links_value_error_empty_url() -> None:
     """
     Test case 10: ValueError for empty base_url.
     """
@@ -128,7 +128,7 @@ def test_paginate_links_case_10_value_error_empty_url() -> None:
         paginate_links("", start_page=1, end_page=3)
 
 
-def test_paginate_links_case_11_value_error_zero_start_page() -> None:
+def test_paginate_links_value_error_zero_start_page() -> None:
     """
     Test case 11: ValueError for zero start_page (must be positive).
     """
@@ -137,7 +137,7 @@ def test_paginate_links_case_11_value_error_zero_start_page() -> None:
         paginate_links("https://example.com", start_page=0, end_page=3)
 
 
-def test_paginate_links_case_12_value_error_invalid_range() -> None:
+def test_paginate_links_value_error_invalid_range() -> None:
     """
     Test case 12: ValueError when start_page > end_page.
     """

--- a/pytest/unit/web_scraping_functions/pagination/test_paginate_with_callback.py
+++ b/pytest/unit/web_scraping_functions/pagination/test_paginate_with_callback.py
@@ -4,7 +4,7 @@ from web_scraping_functions.pagination.paginate_with_callback import (
 )
 
 
-def test_paginate_with_callback_case_1_simple_pagination() -> None:
+def test_paginate_with_callback_simple_pagination() -> None:
     """
     Test case 1: Paginate with callback collecting results.
     """
@@ -30,7 +30,7 @@ def test_paginate_with_callback_case_1_simple_pagination() -> None:
     assert len(collected_data) == 3
 
 
-def test_paginate_with_callback_case_2_max_pages_limit() -> None:
+def test_paginate_with_callback_max_pages_limit() -> None:
     """
     Test case 2: Respect max_pages limit.
     """
@@ -52,7 +52,7 @@ def test_paginate_with_callback_case_2_max_pages_limit() -> None:
     assert len(results) == 3
 
 
-def test_paginate_with_callback_case_3_callback_stops_pagination() -> None:
+def test_paginate_with_callback_callback_stops_pagination() -> None:
     """
     Test case 3: Stop pagination when callback returns None.
     """
@@ -74,7 +74,7 @@ def test_paginate_with_callback_case_3_callback_stops_pagination() -> None:
     assert len(results) == 2
 
 
-def test_paginate_with_callback_case_4_collect_different_data() -> None:
+def test_paginate_with_callback_collect_different_data() -> None:
     """
     Test case 4: Collect different data types.
     """
@@ -97,7 +97,7 @@ def test_paginate_with_callback_case_4_collect_different_data() -> None:
     assert results[0] == ["item1"]
 
 
-def test_paginate_with_callback_case_5_type_error_start_url() -> None:
+def test_paginate_with_callback_type_error_start_url() -> None:
     """
     Test case 5: TypeError for invalid start_url type.
     """
@@ -110,7 +110,7 @@ def test_paginate_with_callback_case_5_type_error_start_url() -> None:
         paginate_with_callback(123, callback=callback)  # type: ignore
 
 
-def test_paginate_with_callback_case_6_type_error_callback() -> None:
+def test_paginate_with_callback_type_error_callback() -> None:
     """
     Test case 6: TypeError for invalid callback type.
     """
@@ -119,7 +119,7 @@ def test_paginate_with_callback_case_6_type_error_callback() -> None:
         paginate_with_callback("https://example.com", callback="not callable")  # type: ignore
 
 
-def test_paginate_with_callback_case_7_type_error_max_pages() -> None:
+def test_paginate_with_callback_type_error_max_pages() -> None:
     """
     Test case 7: TypeError for invalid max_pages type.
     """
@@ -136,7 +136,7 @@ def test_paginate_with_callback_case_7_type_error_max_pages() -> None:
         )
 
 
-def test_paginate_with_callback_case_8_value_error_empty_start_url() -> None:
+def test_paginate_with_callback_value_error_empty_start_url() -> None:
     """
     Test case 8: ValueError for empty start_url.
     """
@@ -149,7 +149,7 @@ def test_paginate_with_callback_case_8_value_error_empty_start_url() -> None:
         paginate_with_callback("", callback=callback)
 
 
-def test_paginate_with_callback_case_9_value_error_non_positive_max_pages() -> None:
+def test_paginate_with_callback_value_error_non_positive_max_pages() -> None:
     """
     Test case 9: ValueError for non-positive max_pages.
     """

--- a/pytest/unit/web_scraping_functions/rate_limiting/test_create_rate_limiter.py
+++ b/pytest/unit/web_scraping_functions/rate_limiting/test_create_rate_limiter.py
@@ -5,7 +5,7 @@ from web_scraping_functions.rate_limiting.create_rate_limiter import (
 )
 
 
-def test_create_rate_limiter_case_1_basic_rate_limiting() -> None:
+def test_create_rate_limiter_basic_rate_limiting() -> None:
     """
     Test case 1: Basic rate limiting with wait method.
     """
@@ -22,7 +22,7 @@ def test_create_rate_limiter_case_1_basic_rate_limiting() -> None:
     assert elapsed >= 0.1  # At least 0.1 seconds between calls
 
 
-def test_create_rate_limiter_case_2_multiple_waits() -> None:
+def test_create_rate_limiter_multiple_waits() -> None:
     """
     Test case 2: Multiple wait calls respect rate limit.
     """
@@ -39,7 +39,7 @@ def test_create_rate_limiter_case_2_multiple_waits() -> None:
     assert elapsed >= 0.4  # At least 0.4 seconds for 3 calls at 5/sec
 
 
-def test_create_rate_limiter_case_3_fast_rate() -> None:
+def test_create_rate_limiter_fast_rate() -> None:
     """
     Test case 3: Fast rate limiting (100 calls per second).
     """
@@ -56,7 +56,7 @@ def test_create_rate_limiter_case_3_fast_rate() -> None:
     assert elapsed >= 0.01  # At least 0.01 seconds between calls
 
 
-def test_create_rate_limiter_case_4_slow_rate() -> None:
+def test_create_rate_limiter_slow_rate() -> None:
     """
     Test case 4: Slow rate limiting (1 call per second).
     """
@@ -73,7 +73,7 @@ def test_create_rate_limiter_case_4_slow_rate() -> None:
     assert elapsed >= 1.0  # At least 1 second between calls
 
 
-def test_create_rate_limiter_case_5_calls_per_second_attribute() -> None:
+def test_create_rate_limiter_calls_per_second_attribute() -> None:
     """
     Test case 5: Verify rate limiter has calls_per_second attribute.
     """
@@ -85,7 +85,7 @@ def test_create_rate_limiter_case_5_calls_per_second_attribute() -> None:
     assert limiter.calls_per_second == 5
 
 
-def test_create_rate_limiter_case_6_type_error_calls_per_second() -> None:
+def test_create_rate_limiter_type_error_calls_per_second() -> None:
     """
     Test case 6: TypeError for invalid calls_per_second type.
     """
@@ -94,7 +94,7 @@ def test_create_rate_limiter_case_6_type_error_calls_per_second() -> None:
         create_rate_limiter(calls_per_second="5")
 
 
-def test_create_rate_limiter_case_7_value_error_zero_rate() -> None:
+def test_create_rate_limiter_value_error_zero_rate() -> None:
     """
     Test case 7: ValueError for zero calls_per_second.
     """
@@ -103,7 +103,7 @@ def test_create_rate_limiter_case_7_value_error_zero_rate() -> None:
         create_rate_limiter(calls_per_second=0)
 
 
-def test_create_rate_limiter_case_8_value_error_negative_rate() -> None:
+def test_create_rate_limiter_value_error_negative_rate() -> None:
     """
     Test case 8: ValueError for negative calls_per_second.
     """
@@ -112,7 +112,7 @@ def test_create_rate_limiter_case_8_value_error_negative_rate() -> None:
         create_rate_limiter(calls_per_second=-5)
 
 
-def test_create_rate_limiter_case_9_fractional_rate() -> None:
+def test_create_rate_limiter_fractional_rate() -> None:
     """
     Test case 9: Support fractional calls per second.
     """

--- a/pytest/unit/web_scraping_functions/rate_limiting/test_rate_limited_scraper.py
+++ b/pytest/unit/web_scraping_functions/rate_limiting/test_rate_limited_scraper.py
@@ -6,7 +6,7 @@ from web_scraping_functions.rate_limiting.rate_limited_scraper import (
 )
 
 
-def test_rate_limited_scraper_case_1_basic_rate_limiting() -> None:
+def test_rate_limited_scraper_basic_rate_limiting() -> None:
     """
     Test case 1: Apply basic rate limiting to function.
     """
@@ -27,7 +27,7 @@ def test_rate_limited_scraper_case_1_basic_rate_limiting() -> None:
     assert elapsed >= 0.1  # At least 0.1 seconds between calls (1/10)
 
 
-def test_rate_limited_scraper_case_2_preserves_function_signature() -> None:
+def test_rate_limited_scraper_preserves_function_signature() -> None:
     """
     Test case 2: Decorator preserves function metadata.
     """
@@ -42,7 +42,7 @@ def test_rate_limited_scraper_case_2_preserves_function_signature() -> None:
     assert "Scrape a URL" in my_scraper.__doc__
 
 
-def test_rate_limited_scraper_case_3_different_rates() -> None:
+def test_rate_limited_scraper_different_rates() -> None:
     """
     Test case 3: Apply different rate limits.
     """
@@ -61,7 +61,7 @@ def test_rate_limited_scraper_case_3_different_rates() -> None:
     assert elapsed >= 0.5  # At least 0.5 seconds between calls (1/2)
 
 
-def test_rate_limited_scraper_case_4_with_kwargs() -> None:
+def test_rate_limited_scraper_with_kwargs() -> None:
     """
     Test case 4: Function with keyword arguments.
     """
@@ -77,7 +77,7 @@ def test_rate_limited_scraper_case_4_with_kwargs() -> None:
     assert result == "https://example.com-60"
 
 
-def test_rate_limited_scraper_case_5_type_error_calls_per_second() -> None:
+def test_rate_limited_scraper_type_error_calls_per_second() -> None:
     """
     Test case 5: TypeError for invalid calls_per_second type.
     """
@@ -88,7 +88,7 @@ def test_rate_limited_scraper_case_5_type_error_calls_per_second() -> None:
             return url
 
 
-def test_rate_limited_scraper_case_6_value_error_non_positive_rate() -> None:
+def test_rate_limited_scraper_value_error_non_positive_rate() -> None:
     """
     Test case 6: ValueError for non-positive calls_per_second.
     """
@@ -99,7 +99,7 @@ def test_rate_limited_scraper_case_6_value_error_non_positive_rate() -> None:
             return url
 
 
-def test_rate_limited_scraper_case_7_value_error_negative_rate() -> None:
+def test_rate_limited_scraper_value_error_negative_rate() -> None:
     """
     Test case 7: ValueError for negative calls_per_second.
     """
@@ -110,7 +110,7 @@ def test_rate_limited_scraper_case_7_value_error_negative_rate() -> None:
             return url
 
 
-def test_rate_limited_scraper_case_8_exception_propagation() -> None:
+def test_rate_limited_scraper_exception_propagation() -> None:
     """
     Test case 8: Exceptions from wrapped function are propagated.
     """

--- a/pytest/unit/web_scraping_functions/rotation/test_get_random_proxy.py
+++ b/pytest/unit/web_scraping_functions/rotation/test_get_random_proxy.py
@@ -2,7 +2,7 @@ import pytest
 from web_scraping_functions.rotation.get_random_proxy import get_random_proxy
 
 
-def test_get_random_proxy_case_1_returns_from_list() -> None:
+def test_get_random_proxy_returns_from_list() -> None:
     """
     Test case 1: Return a proxy from the list.
     """
@@ -18,7 +18,7 @@ def test_get_random_proxy_case_1_returns_from_list() -> None:
     assert result["http"] in proxies
 
 
-def test_get_random_proxy_case_2_single_proxy() -> None:
+def test_get_random_proxy_single_proxy() -> None:
     """
     Test case 2: Return the only proxy from single-element list.
     """
@@ -32,7 +32,7 @@ def test_get_random_proxy_case_2_single_proxy() -> None:
     assert result == {"http": "only_proxy", "https": "only_proxy"}
 
 
-def test_get_random_proxy_case_3_randomness() -> None:
+def test_get_random_proxy_randomness() -> None:
     """
     Test case 3: Verify random selection over multiple calls.
     """
@@ -46,7 +46,7 @@ def test_get_random_proxy_case_3_randomness() -> None:
     assert len(results) >= 2
 
 
-def test_get_random_proxy_case_4_list_not_modified() -> None:
+def test_get_random_proxy_list_not_modified() -> None:
     """
     Test case 4: Original list is not modified.
     """
@@ -61,7 +61,7 @@ def test_get_random_proxy_case_4_list_not_modified() -> None:
     assert proxies == original_proxies
 
 
-def test_get_random_proxy_case_5_type_error_proxies() -> None:
+def test_get_random_proxy_type_error_proxies() -> None:
     """
     Test case 5: TypeError for invalid proxies type.
     """
@@ -70,7 +70,7 @@ def test_get_random_proxy_case_5_type_error_proxies() -> None:
         get_random_proxy("not a list")
 
 
-def test_get_random_proxy_case_6_value_error_empty_list() -> None:
+def test_get_random_proxy_value_error_empty_list() -> None:
     """
     Test case 6: ValueError for empty proxy list.
     """
@@ -79,7 +79,7 @@ def test_get_random_proxy_case_6_value_error_empty_list() -> None:
         get_random_proxy([])
 
 
-def test_get_random_proxy_case_7_proxy_formats() -> None:
+def test_get_random_proxy_proxy_formats() -> None:
     """
     Test case 7: Handle different proxy formats.
     """

--- a/pytest/unit/web_scraping_functions/rotation/test_get_random_user_agent.py
+++ b/pytest/unit/web_scraping_functions/rotation/test_get_random_user_agent.py
@@ -4,7 +4,7 @@ from web_scraping_functions.rotation.get_random_user_agent import (
 )
 
 
-def test_get_random_user_agent_case_1_returns_from_list() -> None:
+def test_get_random_user_agent_returns_from_list() -> None:
     """
     Test case 1: Return a user agent from the list.
     """
@@ -18,7 +18,7 @@ def test_get_random_user_agent_case_1_returns_from_list() -> None:
     assert result in user_agents
 
 
-def test_get_random_user_agent_case_2_single_user_agent() -> None:
+def test_get_random_user_agent_single_user_agent() -> None:
     """
     Test case 2: Return the only user agent from single-element list.
     """
@@ -32,7 +32,7 @@ def test_get_random_user_agent_case_2_single_user_agent() -> None:
     assert result == "Mozilla/5.0"
 
 
-def test_get_random_user_agent_case_3_randomness() -> None:
+def test_get_random_user_agent_randomness() -> None:
     """
     Test case 3: Verify random selection over multiple calls.
     """
@@ -46,7 +46,7 @@ def test_get_random_user_agent_case_3_randomness() -> None:
     assert len(results) >= 2
 
 
-def test_get_random_user_agent_case_4_default_user_agents() -> None:
+def test_get_random_user_agent_default_user_agents() -> None:
     """
     Test case 4: Use default user agents when None provided.
     """
@@ -59,7 +59,7 @@ def test_get_random_user_agent_case_4_default_user_agents() -> None:
     assert "Mozilla" in result
 
 
-def test_get_random_user_agent_case_5_list_not_modified() -> None:
+def test_get_random_user_agent_list_not_modified() -> None:
     """
     Test case 5: Original list is not modified.
     """
@@ -74,7 +74,7 @@ def test_get_random_user_agent_case_5_list_not_modified() -> None:
     assert user_agents == original_uas
 
 
-def test_get_random_user_agent_case_6_type_error_user_agents() -> None:
+def test_get_random_user_agent_type_error_user_agents() -> None:
     """
     Test case 6: TypeError for invalid user_agents type.
     """
@@ -83,7 +83,7 @@ def test_get_random_user_agent_case_6_type_error_user_agents() -> None:
         get_random_user_agent("not a list")
 
 
-def test_get_random_user_agent_case_7_value_error_empty_list() -> None:
+def test_get_random_user_agent_value_error_empty_list() -> None:
     """
     Test case 7: ValueError for empty user agent list.
     """
@@ -92,7 +92,7 @@ def test_get_random_user_agent_case_7_value_error_empty_list() -> None:
         get_random_user_agent([])
 
 
-def test_get_random_user_agent_case_8_realistic_user_agents() -> None:
+def test_get_random_user_agent_realistic_user_agents() -> None:
     """
     Test case 9: Handle realistic user agent strings.
     """

--- a/pytest/unit/web_scraping_functions/rotation/test_rotate_proxy.py
+++ b/pytest/unit/web_scraping_functions/rotation/test_rotate_proxy.py
@@ -2,7 +2,7 @@ import pytest
 from web_scraping_functions.rotation.rotate_proxy import rotate_proxy
 
 
-def test_rotate_proxy_case_1_basic_rotation() -> None:
+def test_rotate_proxy_basic_rotation() -> None:
     """
     Test case 1: Basic proxy rotation through list.
     """
@@ -23,7 +23,7 @@ def test_rotate_proxy_case_1_basic_rotation() -> None:
     assert result4 == {"http": "proxy1", "https": "proxy1"}  # Cycles back
 
 
-def test_rotate_proxy_case_2_single_proxy() -> None:
+def test_rotate_proxy_single_proxy() -> None:
     """
     Test case 2: Rotation with single proxy.
     """
@@ -40,7 +40,7 @@ def test_rotate_proxy_case_2_single_proxy() -> None:
     assert result2 == {"http": "only_proxy", "https": "only_proxy"}
 
 
-def test_rotate_proxy_case_3_infinite_cycling() -> None:
+def test_rotate_proxy_infinite_cycling() -> None:
     """
     Test case 3: Verify infinite cycling.
     """
@@ -56,7 +56,7 @@ def test_rotate_proxy_case_3_infinite_cycling() -> None:
     assert results == expected
 
 
-def test_rotate_proxy_case_4_list_not_modified() -> None:
+def test_rotate_proxy_list_not_modified() -> None:
     """
     Test case 4: Original list is not modified.
     """
@@ -73,7 +73,7 @@ def test_rotate_proxy_case_4_list_not_modified() -> None:
     assert proxies == original_proxies
 
 
-def test_rotate_proxy_case_5_type_error_proxies() -> None:
+def test_rotate_proxy_type_error_proxies() -> None:
     """
     Test case 5: TypeError for invalid proxies type.
     """
@@ -83,7 +83,7 @@ def test_rotate_proxy_case_5_type_error_proxies() -> None:
         next(rotator)
 
 
-def test_rotate_proxy_case_6_value_error_empty_list() -> None:
+def test_rotate_proxy_value_error_empty_list() -> None:
     """
     Test case 6: ValueError for empty proxy list.
     """
@@ -93,7 +93,7 @@ def test_rotate_proxy_case_6_value_error_empty_list() -> None:
         next(rotator)
 
 
-def test_rotate_proxy_case_7_mixed_proxy_formats() -> None:
+def test_rotate_proxy_mixed_proxy_formats() -> None:
     """
     Test case 7: Support different proxy string formats.
     """

--- a/pytest/unit/web_scraping_functions/rotation/test_rotate_user_agent.py
+++ b/pytest/unit/web_scraping_functions/rotation/test_rotate_user_agent.py
@@ -2,7 +2,7 @@ import pytest
 from web_scraping_functions.rotation.rotate_user_agent import rotate_user_agent
 
 
-def test_rotate_user_agent_case_1_basic_rotation() -> None:
+def test_rotate_user_agent_basic_rotation() -> None:
     """
     Test case 1: Basic user agent rotation.
     """
@@ -23,7 +23,7 @@ def test_rotate_user_agent_case_1_basic_rotation() -> None:
     assert result4 == "UA1"  # Cycles back
 
 
-def test_rotate_user_agent_case_2_single_user_agent() -> None:
+def test_rotate_user_agent_single_user_agent() -> None:
     """
     Test case 2: Rotation with single user agent.
     """
@@ -40,7 +40,7 @@ def test_rotate_user_agent_case_2_single_user_agent() -> None:
     assert result2 == "Mozilla/5.0"
 
 
-def test_rotate_user_agent_case_3_infinite_cycling() -> None:
+def test_rotate_user_agent_infinite_cycling() -> None:
     """
     Test case 3: Verify infinite cycling.
     """
@@ -55,7 +55,7 @@ def test_rotate_user_agent_case_3_infinite_cycling() -> None:
     assert results == ["UA1", "UA2"] * 4
 
 
-def test_rotate_user_agent_case_4_list_not_modified() -> None:
+def test_rotate_user_agent_list_not_modified() -> None:
     """
     Test case 4: Original list is not modified.
     """
@@ -72,7 +72,7 @@ def test_rotate_user_agent_case_4_list_not_modified() -> None:
     assert user_agents == original_uas
 
 
-def test_rotate_user_agent_case_5_type_error_user_agents() -> None:
+def test_rotate_user_agent_type_error_user_agents() -> None:
     """
     Test case 5: TypeError for invalid user_agents type.
     """
@@ -82,7 +82,7 @@ def test_rotate_user_agent_case_5_type_error_user_agents() -> None:
         next(rotator)
 
 
-def test_rotate_user_agent_case_6_value_error_empty_list() -> None:
+def test_rotate_user_agent_value_error_empty_list() -> None:
     """
     Test case 6: ValueError for empty user agent list.
     """
@@ -92,7 +92,7 @@ def test_rotate_user_agent_case_6_value_error_empty_list() -> None:
         next(rotator)
 
 
-def test_rotate_user_agent_case_7_realistic_user_agents() -> None:
+def test_rotate_user_agent_realistic_user_agents() -> None:
     """
     Test case 8: Rotation with realistic user agent strings.
     """

--- a/pytest/unit/web_scraping_functions/selectors/test_extract_attribute.py
+++ b/pytest/unit/web_scraping_functions/selectors/test_extract_attribute.py
@@ -3,7 +3,7 @@ from bs4 import BeautifulSoup
 from web_scraping_functions.selectors.extract_attribute import extract_attribute
 
 
-def test_extract_attribute_case_1_simple_attribute() -> None:
+def test_extract_attribute_simple_attribute() -> None:
     """
     Test case 1: Extract simple attribute from element.
     """
@@ -19,7 +19,7 @@ def test_extract_attribute_case_1_simple_attribute() -> None:
     assert result == "/page"
 
 
-def test_extract_attribute_case_2_class_attribute() -> None:
+def test_extract_attribute_class_attribute() -> None:
     """
     Test case 2: Extract class attribute.
     """
@@ -35,7 +35,7 @@ def test_extract_attribute_case_2_class_attribute() -> None:
     assert result == ["main", "content"]
 
 
-def test_extract_attribute_case_3_missing_attribute() -> None:
+def test_extract_attribute_missing_attribute() -> None:
     """
     Test case 3: Return None when attribute doesn't exist.
     """
@@ -51,7 +51,7 @@ def test_extract_attribute_case_3_missing_attribute() -> None:
     assert result is None
 
 
-def test_extract_attribute_case_4_default_value() -> None:
+def test_extract_attribute_default_value() -> None:
     """
     Test case 4: Return default value when attribute missing.
     """
@@ -67,7 +67,7 @@ def test_extract_attribute_case_4_default_value() -> None:
     assert result == "default_value"
 
 
-def test_extract_attribute_case_5_id_attribute() -> None:
+def test_extract_attribute_id_attribute() -> None:
     """
     Test case 5: Extract id attribute.
     """
@@ -83,7 +83,7 @@ def test_extract_attribute_case_5_id_attribute() -> None:
     assert result == "main"
 
 
-def test_extract_attribute_case_6_data_attribute() -> None:
+def test_extract_attribute_data_attribute() -> None:
     """
     Test case 6: Extract data-* attribute.
     """
@@ -99,7 +99,7 @@ def test_extract_attribute_case_6_data_attribute() -> None:
     assert result == "123"
 
 
-def test_extract_attribute_case_7_type_error_element() -> None:
+def test_extract_attribute_type_error_element() -> None:
     """
     Test case 7: TypeError for invalid element type.
     """
@@ -108,7 +108,7 @@ def test_extract_attribute_case_7_type_error_element() -> None:
         extract_attribute("not a tag", "href")
 
 
-def test_extract_attribute_case_8_type_error_attribute() -> None:
+def test_extract_attribute_type_error_attribute() -> None:
     """
     Test case 8: TypeError for invalid attribute type.
     """
@@ -122,7 +122,7 @@ def test_extract_attribute_case_8_type_error_attribute() -> None:
         extract_attribute(element, 123)  # type: ignore
 
 
-def test_extract_attribute_case_9_value_error_empty_attribute() -> None:
+def test_extract_attribute_value_error_empty_attribute() -> None:
     """
     Test case 9: ValueError for empty attribute.
     """
@@ -136,7 +136,7 @@ def test_extract_attribute_case_9_value_error_empty_attribute() -> None:
         extract_attribute(element, "")
 
 
-def test_extract_attribute_case_10_whitespace_attribute() -> None:
+def test_extract_attribute_whitespace_attribute() -> None:
     """
     Test case 10: ValueError for whitespace-only attribute.
     """

--- a/pytest/unit/web_scraping_functions/selectors/test_select_by_css.py
+++ b/pytest/unit/web_scraping_functions/selectors/test_select_by_css.py
@@ -3,7 +3,7 @@ from bs4 import BeautifulSoup
 from web_scraping_functions.selectors.select_by_css import select_by_css
 
 
-def test_select_by_css_case_1_simple_selector() -> None:
+def test_select_by_css_simple_selector() -> None:
     """
     Test case 1: Select elements with simple CSS selector.
     """
@@ -20,7 +20,7 @@ def test_select_by_css_case_1_simple_selector() -> None:
     assert result[1].text == "B"
 
 
-def test_select_by_css_case_2_with_limit() -> None:
+def test_select_by_css_with_limit() -> None:
     """
     Test case 2: Select elements with limit.
     """
@@ -35,7 +35,7 @@ def test_select_by_css_case_2_with_limit() -> None:
     assert len(result) == 2
 
 
-def test_select_by_css_case_3_complex_selector() -> None:
+def test_select_by_css_complex_selector() -> None:
     """
     Test case 3: Use complex CSS selector.
     """
@@ -51,7 +51,7 @@ def test_select_by_css_case_3_complex_selector() -> None:
     assert result[0].text == "Text"
 
 
-def test_select_by_css_case_4_attribute_selector() -> None:
+def test_select_by_css_attribute_selector() -> None:
     """
     Test case 4: Use attribute selector.
     """
@@ -67,7 +67,7 @@ def test_select_by_css_case_4_attribute_selector() -> None:
     assert result[0].text == "Link1"
 
 
-def test_select_by_css_case_5_no_matches() -> None:
+def test_select_by_css_no_matches() -> None:
     """
     Test case 5: Return empty list when no matches found.
     """
@@ -82,7 +82,7 @@ def test_select_by_css_case_5_no_matches() -> None:
     assert result == []
 
 
-def test_select_by_css_case_6_type_error_element() -> None:
+def test_select_by_css_type_error_element() -> None:
     """
     Test case 6: TypeError for invalid element type.
     """
@@ -91,7 +91,7 @@ def test_select_by_css_case_6_type_error_element() -> None:
         select_by_css("not a soup", ".item")
 
 
-def test_select_by_css_case_7_type_error_selector() -> None:
+def test_select_by_css_type_error_selector() -> None:
     """
     Test case 7: TypeError for invalid selector type.
     """
@@ -104,7 +104,7 @@ def test_select_by_css_case_7_type_error_selector() -> None:
         select_by_css(soup, 123)
 
 
-def test_select_by_css_case_8_type_error_limit() -> None:
+def test_select_by_css_type_error_limit() -> None:
     """
     Test case 8: TypeError for invalid limit type.
     """
@@ -117,7 +117,7 @@ def test_select_by_css_case_8_type_error_limit() -> None:
         select_by_css(soup, ".item", limit="5")
 
 
-def test_select_by_css_case_9_value_error_empty_selector() -> None:
+def test_select_by_css_value_error_empty_selector() -> None:
     """
     Test case 9: ValueError for empty selector.
     """
@@ -130,7 +130,7 @@ def test_select_by_css_case_9_value_error_empty_selector() -> None:
         select_by_css(soup, "")
 
 
-def test_select_by_css_case_10_value_error_non_positive_limit() -> None:
+def test_select_by_css_value_error_non_positive_limit() -> None:
     """
     Test case 10: ValueError for non-positive limit.
     """

--- a/pytest/unit/web_scraping_functions/selectors/test_select_by_xpath.py
+++ b/pytest/unit/web_scraping_functions/selectors/test_select_by_xpath.py
@@ -3,7 +3,7 @@ from lxml import etree
 from web_scraping_functions.selectors.select_by_xpath import select_by_xpath
 
 
-def test_select_by_xpath_case_1_simple_xpath() -> None:
+def test_select_by_xpath_simple_xpath() -> None:
     """
     Test case 1: Select elements with simple XPath.
     """
@@ -18,7 +18,7 @@ def test_select_by_xpath_case_1_simple_xpath() -> None:
     assert all(isinstance(elem, etree._Element) for elem in result)
 
 
-def test_select_by_xpath_case_2_single_element() -> None:
+def test_select_by_xpath_single_element() -> None:
     """
     Test case 2: Select single element.
     """
@@ -32,7 +32,7 @@ def test_select_by_xpath_case_2_single_element() -> None:
     assert len(result) == 1
 
 
-def test_select_by_xpath_case_3_text_selection() -> None:
+def test_select_by_xpath_text_selection() -> None:
     """
     Test case 3: Select elements by text content.
     """
@@ -46,7 +46,7 @@ def test_select_by_xpath_case_3_text_selection() -> None:
     assert len(result) == 1
 
 
-def test_select_by_xpath_case_4_nested_selection() -> None:
+def test_select_by_xpath_nested_selection() -> None:
     """
     Test case 4: Select nested elements.
     """
@@ -60,7 +60,7 @@ def test_select_by_xpath_case_4_nested_selection() -> None:
     assert len(result) == 1
 
 
-def test_select_by_xpath_case_5_no_matches() -> None:
+def test_select_by_xpath_no_matches() -> None:
     """
     Test case 5: Return empty list when no matches found.
     """
@@ -74,7 +74,7 @@ def test_select_by_xpath_case_5_no_matches() -> None:
     assert result == []
 
 
-def test_select_by_xpath_case_6_type_error_html() -> None:
+def test_select_by_xpath_type_error_html() -> None:
     """
     Test case 6: TypeError for invalid html type.
     """
@@ -83,7 +83,7 @@ def test_select_by_xpath_case_6_type_error_html() -> None:
         select_by_xpath(123, "//div")  # type: ignore
 
 
-def test_select_by_xpath_case_7_type_error_xpath() -> None:
+def test_select_by_xpath_type_error_xpath() -> None:
     """
     Test case 7: TypeError for invalid xpath type.
     """
@@ -95,7 +95,7 @@ def test_select_by_xpath_case_7_type_error_xpath() -> None:
         select_by_xpath(html, 123)  # type: ignore
 
 
-def test_select_by_xpath_case_8_value_error_empty_html() -> None:
+def test_select_by_xpath_value_error_empty_html() -> None:
     """
     Test case 8: ValueError for empty html.
     """
@@ -104,7 +104,7 @@ def test_select_by_xpath_case_8_value_error_empty_html() -> None:
         select_by_xpath("", "//div")
 
 
-def test_select_by_xpath_case_9_value_error_empty_xpath() -> None:
+def test_select_by_xpath_value_error_empty_xpath() -> None:
     """
     Test case 9: ValueError for empty xpath.
     """


### PR DESCRIPTION
### Motivation
- Clean up and simplify pytest function names by removing redundant numeric `_case_<n>` suffixes.
- Improve readability of test names and make them more succinct and descriptive.
- Apply change consistently across the entire `pytest` test suite.

### Description
- Renamed test functions by removing the `_case_<n>` suffix across the `pytest` tree using a regex-based update (pattern targeted test defs with `_case_<number>` and removed that segment).
- Changes applied to many test modules under `pytest/unit/*` (91 test files modified).
- The refactor only renames test functions and preserves all test bodies, assertions and docstrings; there are no behavioral changes to the tests themselves.
- Bulk update was performed programmatically (script used the regex replacement over `pytest` files).

### Testing
- No automated test runs were executed as part of this change (did not run `pytest`).
- Recommend running `pytest` to validate the updated test names: execute `pytest -q` at repo root.
- Manual grep verification was used to confirm the `_case_<n>` pattern no longer appears in `pytest` files.
- If desired, CI should run the full test suite to ensure there are no collisions or name conflicts introduced by the renames.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69452f3726dc8325ad606b1c0a64c0b2)